### PR TITLE
Tableau Changes Handback

### DIFF
--- a/tableau-databricks/connection-dialog.tcd
+++ b/tableau-databricks/connection-dialog.tcd
@@ -20,10 +20,10 @@ limitations under the License. -->
     <authentication-options>
         <option name="UsernameAndPassword" default="true" value="Username and Password" />
     </authentication-options>
-    <db-name-prompt value="HTTP Path: " />
+    <db-name-prompt value="@string/db_name_prompt/" />
     <has-databases value='false' />
     <has-schemas value='true' />
-    <server-prompt value="Server Hostname: " />
+    <server-prompt value="@string/server_prompt/" />
     <show-service-prompt value="true" />
   </connection-config>
 </connection-dialog>

--- a/tableau-databricks/connection-resolver.tdr
+++ b/tableau-databricks/connection-resolver.tdr
@@ -23,7 +23,19 @@ limitations under the License.
         </connection-builder>
 	
         <connection-normalizer>
-            <script file='connection-required.js' />
+            <required-attributes>
+                <setImpersonateAttributes/>
+                <attribute-list>
+                    <attr>class</attr>
+                    <attr>server</attr>
+                    <attr>dbname</attr>
+                    <attr>one-time-sql</attr>
+                    <attr>authentication</attr>
+                    <attr>username</attr>
+                    <attr>password</attr>
+                    <attr>authentication-type</attr>
+                </attribute-list>
+            </required-attributes>
         </connection-normalizer>
     </connection-resolver>
 	

--- a/tableau-databricks/manifest.xml
+++ b/tableau-databricks/manifest.xml
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<connector-plugin class='databricks' superclass='spark' plugin-version='0.1' name='Databricks' version='18.1'>
+<connector-plugin class='databricks' superclass='spark' plugin-version='0.1' name='@string/databricks/' version='18.1'>
 <connection-customization class="databricks" enabled="true" version="0.1">
     <vendor name="databricks"/>
     <driver name="databricks"/>

--- a/tableau-databricks/resources-de_DE.xml
+++ b/tableau-databricks/resources-de_DE.xml
@@ -1,4 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<!--
+Databricks Tableau Connector
+Copyright 2019 Databricks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="databricks">Databricks</string>
   <string name="db_name_prompt">HTTP Path:</string>

--- a/tableau-databricks/resources-de_DE.xml
+++ b/tableau-databricks/resources-de_DE.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="databricks">Databricks</string>
+  <string name="db_name_prompt">HTTP Path:</string>
+  <string name="server_prompt">Server Hostname:</string>
+</resources>

--- a/tableau-databricks/resources-en_GB.xml
+++ b/tableau-databricks/resources-en_GB.xml
@@ -1,4 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<!--
+Databricks Tableau Connector
+Copyright 2019 Databricks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="databricks">Databricks</string>
   <string name="db_name_prompt">HTTP Path:</string>

--- a/tableau-databricks/resources-en_GB.xml
+++ b/tableau-databricks/resources-en_GB.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="databricks">Databricks</string>
+  <string name="db_name_prompt">HTTP Path:</string>
+  <string name="server_prompt">Server Hostname:</string>
+</resources>

--- a/tableau-databricks/resources-en_US.xml
+++ b/tableau-databricks/resources-en_US.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="databricks">Databricks</string>
+  <string name="db_name_prompt">HTTP Path:</string>
+  <string name="server_prompt">Server Hostname:</string>
+</resources>

--- a/tableau-databricks/resources-en_US.xml
+++ b/tableau-databricks/resources-en_US.xml
@@ -1,3 +1,19 @@
+<!--
+Databricks Tableau Connector
+Copyright 2019 Databricks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="databricks">Databricks</string>

--- a/tableau-databricks/resources-es_ES.xml
+++ b/tableau-databricks/resources-es_ES.xml
@@ -1,4 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<!--
+Databricks Tableau Connector
+Copyright 2019 Databricks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="databricks">Databricks</string>
   <string name="db_name_prompt">HTTP Path:</string>

--- a/tableau-databricks/resources-es_ES.xml
+++ b/tableau-databricks/resources-es_ES.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="databricks">Databricks</string>
+  <string name="db_name_prompt">HTTP Path:</string>
+  <string name="server_prompt">Server Hostname:</string>
+</resources>

--- a/tableau-databricks/resources-fr_FR.xml
+++ b/tableau-databricks/resources-fr_FR.xml
@@ -1,4 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<!--
+Databricks Tableau Connector
+Copyright 2019 Databricks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="databricks">Databricks</string>
   <string name="db_name_prompt">HTTP Path:</string>

--- a/tableau-databricks/resources-fr_FR.xml
+++ b/tableau-databricks/resources-fr_FR.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="databricks">Databricks</string>
+  <string name="db_name_prompt">HTTP Path:</string>
+  <string name="server_prompt">Server Hostname:</string>
+</resources>

--- a/tableau-databricks/resources-it_IT.xml
+++ b/tableau-databricks/resources-it_IT.xml
@@ -1,4 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<!--
+Databricks Tableau Connector
+Copyright 2019 Databricks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="databricks">Databricks</string>
   <string name="db_name_prompt">HTTP Path:</string>

--- a/tableau-databricks/resources-it_IT.xml
+++ b/tableau-databricks/resources-it_IT.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="databricks">Databricks</string>
+  <string name="db_name_prompt">HTTP Path:</string>
+  <string name="server_prompt">Server Hostname:</string>
+</resources>

--- a/tableau-databricks/resources-ja_JP.xml
+++ b/tableau-databricks/resources-ja_JP.xml
@@ -1,4 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<!--
+Databricks Tableau Connector
+Copyright 2019 Databricks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="databricks">Databricks</string>
   <string name="db_name_prompt">HTTP Path:</string>

--- a/tableau-databricks/resources-ja_JP.xml
+++ b/tableau-databricks/resources-ja_JP.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="databricks">Databricks</string>
+  <string name="db_name_prompt">HTTP Path:</string>
+  <string name="server_prompt">Server Hostname:</string>
+</resources>

--- a/tableau-databricks/resources-ko_KR.xml
+++ b/tableau-databricks/resources-ko_KR.xml
@@ -1,4 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<!--
+Databricks Tableau Connector
+Copyright 2019 Databricks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="databricks">Databricks</string>
   <string name="db_name_prompt">HTTP Path:</string>

--- a/tableau-databricks/resources-ko_KR.xml
+++ b/tableau-databricks/resources-ko_KR.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="databricks">Databricks</string>
+  <string name="db_name_prompt">HTTP Path:</string>
+  <string name="server_prompt">Server Hostname:</string>
+</resources>

--- a/tableau-databricks/resources-pt_BR.xml
+++ b/tableau-databricks/resources-pt_BR.xml
@@ -1,4 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<!--
+Databricks Tableau Connector
+Copyright 2019 Databricks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="databricks">Databricks</string>
   <string name="db_name_prompt">HTTP Path:</string>

--- a/tableau-databricks/resources-pt_BR.xml
+++ b/tableau-databricks/resources-pt_BR.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="databricks">Databricks</string>
+  <string name="db_name_prompt">HTTP Path:</string>
+  <string name="server_prompt">Server Hostname:</string>
+</resources>

--- a/tableau-databricks/resources-zh_CN.xml
+++ b/tableau-databricks/resources-zh_CN.xml
@@ -1,4 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<!--
+Databricks Tableau Connector
+Copyright 2019 Databricks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="databricks">Databricks</string>
   <string name="db_name_prompt">HTTP Path:</string>

--- a/tableau-databricks/resources-zh_CN.xml
+++ b/tableau-databricks/resources-zh_CN.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="databricks">Databricks</string>
+  <string name="db_name_prompt">HTTP Path:</string>
+  <string name="server_prompt">Server Hostname:</string>
+</resources>

--- a/tableau-databricks/resources-zh_TW.xml
+++ b/tableau-databricks/resources-zh_TW.xml
@@ -1,4 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<!--
+Databricks Tableau Connector
+Copyright 2019 Databricks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="databricks">Databricks</string>
   <string name="db_name_prompt">HTTP Path:</string>

--- a/tableau-databricks/resources-zh_TW.xml
+++ b/tableau-databricks/resources-zh_TW.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="databricks">Databricks</string>
+  <string name="db_name_prompt">HTTP Path:</string>
+  <string name="server_prompt">Server Hostname:</string>
+</resources>


### PR DESCRIPTION
When integrating the Databricks conector to Tableau, we made a few changes to the connector:

- We removed the connection-required script and implemented the logic in the xml of the .tdr file to be more performant
- We moved the strings to the resource files for localization. We're doing this for all our connector plugins, although int his case it doesn't look like our loc team felt changes were necessary.

Let me know if you have any questions about the changes.