### PR TITLE
Load ODBC extras

### DIFF
--- a/tableau-databricks/connection-builder.js
+++ b/tableau-databricks/connection-builder.js
@@ -40,7 +40,20 @@ limitations under the License.
 	// Minimum interval between consecutive polls for query execution status (1ms)
 	params["AsyncExecPollInterval"] = "1";
 
-	var formattedParams = [];
+  // Load ODBC connection string extras
+  var odbcConnectStringExtrasMap = {};
+	const attributeODBCConnectStringExtras = "odbc-connect-string-extras";
+
+	if (attributeODBCConnectStringExtras in attr) {
+		odbcConnectStringExtrasMap = connectionHelper
+			.ParseODBCConnectString(attr[attributeODBCConnectStringExtras]);
+	}
+
+  for (var key in odbcConnectStringExtrasMap) {
+		params[key] = odbcConnectStringExtrasMap[key];
+	}
+
+  var formattedParams = [];
   formattedParams.push(
 		connectionHelper.formatKeyValuePair(
 			driverLocator.keywordDriver, driverLocator.locateDriver(attr)));

--- a/tableau-databricks/connection-builder.js
+++ b/tableau-databricks/connection-builder.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 (function dsbuilder(attr) {
-  var params = {};
+	var params = {};
 
 	// The Databricks cluster ODBC endpoint
 	params["HOST"] = attr["server"];

--- a/tableau-databricks/connection-builder.js
+++ b/tableau-databricks/connection-builder.js
@@ -40,8 +40,8 @@ limitations under the License.
 	// Minimum interval between consecutive polls for query execution status (1ms)
 	params["AsyncExecPollInterval"] = "1";
 
-  // Load ODBC connection string extras
-  var odbcConnectStringExtrasMap = {};
+	// Load ODBC connection string extras
+	var odbcConnectStringExtrasMap = {};
 	const attributeODBCConnectStringExtras = "odbc-connect-string-extras";
 
 	if (attributeODBCConnectStringExtras in attr) {
@@ -49,18 +49,18 @@ limitations under the License.
 			.ParseODBCConnectString(attr[attributeODBCConnectStringExtras]);
 	}
 
-  for (var key in odbcConnectStringExtrasMap) {
+	for (var key in odbcConnectStringExtrasMap) {
 		params[key] = odbcConnectStringExtrasMap[key];
 	}
 
-  var formattedParams = [];
-  formattedParams.push(
+	var formattedParams = [];
+	formattedParams.push(
 		connectionHelper.formatKeyValuePair(
 			driverLocator.keywordDriver, driverLocator.locateDriver(attr)));
 
-  for (var key in params) {
-    formattedParams.push(connectionHelper.formatKeyValuePair(key, params[key]));
-  }
-
-  return formattedParams;
+	for (var key in params) {
+		formattedParams.push(connectionHelper.formatKeyValuePair(key, params[key]));
+	}
+	
+	return formattedParams;
 })

--- a/tableau-databricks/connection-builder.js
+++ b/tableau-databricks/connection-builder.js
@@ -45,7 +45,7 @@ limitations under the License.
 
 	// Load ODBC connection string extras
 	var odbcConnectStringExtrasMap = {};
-	const attributeODBCConnectStringExtras = "odbc-connect-string-extras";
+	const attributeODBCConnectStringExtras = connectionHelper.attributeODBCConnectStringExtras;
 
 	if (attributeODBCConnectStringExtras in attr) {
 		odbcConnectStringExtrasMap = connectionHelper


### PR DESCRIPTION
This PR uses the SDK to load ODBC connection string extras. ODBC string extras can be configured using instructions from https://community.tableau.com/docs/DOC-23121?_ga=2.220843096.118786453.1581585492-1923689120.1581585492&_fsi=RVazguZ3.

For example, to set proxy settings the `ProxyHost`, `ProxyPort`, `ProxyUID` and `ProxyPWD` extras you need to create a `.tdc` file inside the `My Tableau Repository\Datasources` folder with the content below:
`<connection-customization class='databricks' enabled='true' version='19.1'>
<vendor name='databricks' />
<driver name='databricks' />
  <customizations>
    <customization name='odbc-connect-string-extras' value='ProxyHost=myproxy.com;ProxyPort=8080;ProxyUID=myuser;ProxyPWD=foo' />
  </customizations>
</connection-customization>`

Alternatively, it can be put into the workbook `.twb` file: TODO