### PR TITLE
Pass UserAgentEntry client info to ODBC driver

### DIFF
--- a/tableau-databricks/connection-builder.js
+++ b/tableau-databricks/connection-builder.js
@@ -40,6 +40,9 @@ limitations under the License.
 	// Minimum interval between consecutive polls for query execution status (1ms)
 	params["AsyncExecPollInterval"] = "1";
 
+	// Tell the ODBC driver that it is Tableau connecting.
+	params["UserAgentEntry"] = "Tableau";
+
 	var formattedParams = [];
   formattedParams.push(
 		connectionHelper.formatKeyValuePair(


### PR DESCRIPTION
We add a special parameter to let the ODBC driver and Databricks workspace know that it is a connection coming from Tableau.