### PR TITLE
Set Simba SSP to passthrough cross join Spark property

### DIFF
--- a/tableau-databricks/connection-builder.js
+++ b/tableau-databricks/connection-builder.js
@@ -43,6 +43,15 @@ limitations under the License.
 	// Tell the ODBC driver that it is Tableau connecting.
 	params["UserAgentEntry"] = "Tableau";
 
+	// Prevent the driver from turning server-side properties to lower-case
+	params["LCaseSspKeyName"] = "0";
+
+	// Prevent the driver to set properties by executing statements
+	params["ApplySSPWithQueries"] = "1";
+
+	// Enable cross join as a server-side property 
+	params["SSP_spark.sql.crossJoin.enabled"] = "true"
+
 	// Load ODBC connection string extras
 	var odbcConnectStringExtrasMap = {};
 	const attributeODBCConnectStringExtras = connectionHelper.attributeODBCConnectStringExtras;

--- a/tableau-databricks/connection-builder.js
+++ b/tableau-databricks/connection-builder.js
@@ -47,7 +47,7 @@ limitations under the License.
 	params["LCaseSspKeyName"] = "0";
 
 	// Prevent the driver to set properties by executing statements
-	params["ApplySSPWithQueries"] = "1";
+	params["ApplySSPWithQueries"] = "0";
 
 	// Enable cross join as a server-side property 
 	params["SSP_spark.sql.crossJoin.enabled"] = "true"


### PR DESCRIPTION
This patch allows the connector to passthrough the Spark SQL `spark.sql.crossJoin.enabled` property to the `ThriftServer` which will allow users to create dashboards using EXCLUDE operators without manually setting it on the cluster.