### PR TITLE
Add Tableau 2020.3 test results

### DIFF
--- a/tdvt_workspace/results/Tableau_2020_3_test_results.csv
+++ b/tdvt_workspace/results/Tableau_2020_3_test_results.csv
@@ -1,0 +1,23862 @@
+Suite,Test Set,TDSName,TestName,TestPath,Passed,Closest Expected,Diff count,Test Case,Test Type,Process Output,Error Msg,Error Type,Query Time (ms),Generated SQL,Actual (100)tuples,Expected (100)tuples
+databricks,StaplesConnectionTestdatabricks,Staples.databricks,staples_connection_test,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/pretest/connection_tests/staples/setup.staples_connection_test.txt,True,0,0,Discount,expression,,None,None,568.0,"
+      SELECT `staples`.`Discount` AS `temp_test__1913174168__0_`
+FROM `tableau_tdvt`.`staples` `staples`
+GROUP BY 1
+    ","0.0
+0.01
+0.02
+0.03
+0.04
+0.05
+0.06
+0.07
+0.08
+0.09
+0.1
+0.11
+0.12
+0.13
+0.15
+0.21
+0.24
+0.27
+0.3
+0.36
+0.39","0.0
+0.01
+0.02
+0.03
+0.04
+0.05
+0.06
+0.07
+0.08
+0.09
+0.1
+0.11
+0.12
+0.13
+0.15
+0.21
+0.24
+0.27
+0.3
+0.36
+0.39"
+databricks,CastCalcsConnectionTestdatabricks,cast_calcs.databricks,calcs_connection_test,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/pretest/connection_tests/calcs/setup.calcs_connection_test.txt,True,0,0,key,expression,,None,None,558.0,"
+      SELECT `calcs`.`key` AS `temp_test__3382465274__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""key00""
+""key01""
+""key02""
+""key03""
+""key04""
+""key05""
+""key06""
+""key07""
+""key08""
+""key09""
+""key10""
+""key11""
+""key12""
+""key13""
+""key14""
+""key15""
+""key16""","""key00""
+""key01""
+""key02""
+""key03""
+""key04""
+""key05""
+""key06""
+""key07""
+""key08""
+""key09""
+""key10""
+""key11""
+""key12""
+""key13""
+""key14""
+""key15""
+""key16"""
+databricks,logical.calcs.databricks,cast_calcs.databricks,BUGS.B1713,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.BUGS.B1713.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.BUGS.B1713.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,5097.0,"
+      SELECT `Calcs`.`str0` AS `str0`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+  JOIN (
+  SELECT `Calcs`.`str0` AS `str0`,
+    SUM(`Calcs`.`int2`) AS `x__alias__0`
+  FROM `tableau_tdvt`.`calcs` `Calcs`
+  WHERE ((`Calcs`.`str0` >= 'FURNITURE') AND (`Calcs`.`str0` <= 'TECHNOLOGY'))
+  GROUP BY 1
+  ORDER BY `x__alias__0` DESC
+  LIMIT 2
+) `t0` ON (`Calcs`.`str0` = `t0`.`str0`)
+  JOIN (
+  SELECT `Calcs`.`str1` AS `str1`,
+    SUM(`Calcs`.`int1`) AS `x__alias__1`
+  FROM `tableau_tdvt`.`calcs` `Calcs`
+  WHERE (((`Calcs`.`str1` >= 'AIR PURIFIERS') AND (`Calcs`.`str1` <= 'CD-R MEDIA')) OR ((`Calcs`.`str1` >= 'CONFERENCE PHONES') AND (`Calcs`.`str1` <= 'ERICSSON')))
+  GROUP BY 1
+  ORDER BY `x__alias__1` DESC
+  LIMIT 5
+) `t1` ON (`Calcs`.`str1` = `t1`.`str1`)
+GROUP BY 1
+    ","""OFFICE SUPPLIES""","""OFFICE SUPPLIES"""
+databricks,logical.calcs.databricks,cast_calcs.databricks,BUGS.B26728,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.BUGS.B26728.tableau_tdvt.xml,True,1,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.BUGS.B26728.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1909.0,"
+      SELECT FLOOR(DATEDIFF(TO_DATE(`Calcs`.`date0`), TO_DATE(`Calcs`.`datetime0`)) / 2) AS `daydiffs1__bin_`,
+  FLOOR(DATEDIFF(TO_DATE(`Calcs`.`datetime0`), TO_DATE(`Calcs`.`date0`)) / 3) AS `daydiffs2__bin_`,
+  FLOOR(DATEDIFF(TO_DATE(`Calcs`.`date0`), TO_DATE(`Calcs`.`date1`)) / 4) AS `daydiffs3__bin_`,
+  FLOOR(CAST(YEAR(`Calcs`.`date0`) - YEAR(`Calcs`.`datetime0`) AS BIGINT) / 2) AS `yeardiffs1__bin_`,
+  FLOOR(CAST(YEAR(`Calcs`.`datetime0`) - YEAR(`Calcs`.`date0`) AS BIGINT) / 3) AS `yeardiffs2__bin_`,
+  FLOOR(CAST(YEAR(`Calcs`.`date0`) - YEAR(`Calcs`.`date1`) AS BIGINT) / 4) AS `yeardiffs3__bin_`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+GROUP BY 1,
+  2,
+  3,
+  4,
+  5,
+  6
+    ","%null%
+%null%
+%null%
+%null%
+%null%
+%null%
+-5855
+3903
+-2899
+-16
+10
+-8
+-5246
+3497
+-2593
+-15
+9
+-8
+-43
+28
+3
+0
+0
+0
+-20
+13
+18
+0
+0
+0
+-16
+10
+15
+0
+0
+0","%null%
+%null%
+%null%
+%null%
+%null%
+%null%
+-5855
+3903
+-2899
+-16
+10
+-8
+-5246
+3497
+-2593
+-15
+9
+-8
+-43
+28
+3
+0
+0
+0
+-20
+13
+18
+0
+0
+0
+-16
+10
+15
+0
+0
+0"
+databricks,logical.calcs.databricks,cast_calcs.databricks,BUGS.B27875-asc-nulls-first,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.BUGS.B27875-asc-nulls-first.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.BUGS.B27875-asc-nulls-first.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1845.0,"
+      SELECT `Calcs`.`key` AS `key`,
+  SUM(`Calcs`.`num2`) AS `sum_num2_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+GROUP BY 1
+ORDER BY `sum_num2_ok` ASC
+LIMIT 10
+    ","""key02""
+%null%
+""key03""
+8.51
+""key04""
+6.46
+""key05""
+8.98
+""key08""
+%null%
+""key10""
+6.8
+""key11""
+3.79
+""key12""
+%null%
+""key14""
+%null%
+""key16""
+7.87","""key02""
+%null%
+""key03""
+8.51
+""key04""
+6.46
+""key05""
+8.98
+""key08""
+%null%
+""key10""
+6.8
+""key11""
+3.79
+""key12""
+%null%
+""key14""
+%null%
+""key16""
+7.87"
+databricks,logical.calcs.databricks,cast_calcs.databricks,BUGS.B27875-desc-nulls-last,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.BUGS.B27875-desc-nulls-last.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.BUGS.B27875-desc-nulls-last.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1595.0,"
+      SELECT `Calcs`.`key` AS `key`,
+  SUM(`Calcs`.`num2`) AS `sum_num2_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+GROUP BY 1
+ORDER BY `sum_num2_ok` DESC
+LIMIT 10
+    ","""key00""
+17.86
+""key01""
+16.73
+""key03""
+8.51
+""key05""
+8.98
+""key06""
+11.69
+""key07""
+17.25
+""key09""
+11.5
+""key13""
+13.04
+""key15""
+10.98
+""key16""
+7.87","""key00""
+17.86
+""key01""
+16.73
+""key03""
+8.51
+""key05""
+8.98
+""key06""
+11.69
+""key07""
+17.25
+""key09""
+11.5
+""key13""
+13.04
+""key15""
+10.98
+""key16""
+7.87"
+databricks,logical.calcs.databricks,cast_calcs.databricks,BUGS.B59740,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.BUGS.B59740.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.BUGS.B59740.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,868.0,"
+      SELECT (CASE WHEN (`Calcs`.`str2` IN ('eleven', 'fifteen', 'five', 'fourteen', 'nine', 'one', 'six', 'sixteen', 'ten', 'three', 'twelve')) THEN 'eleven' ELSE `Calcs`.`str2` END) AS `str2__group_`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+GROUP BY 1
+    ","%null%
+""eight""
+""eleven""
+""two""","%null%
+""eight""
+""eleven""
+""two"""
+databricks,logical.calcs.databricks,cast_calcs.databricks,BUGS.B641638,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.BUGS.B641638.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.BUGS.B641638.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1073.0,"
+      SELECT `Calcs`.`str1` AS `str1`,
+  SUM(`Calcs`.`num1`) AS `sum_num1_ok`,
+  `Calcs`.`time0` AS `time0`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+WHERE (`Calcs`.`time0` IN (CAST('1899-12-30 21:07:32' AS TIMESTAMP), CAST('1899-12-30 22:42:43' AS TIMESTAMP), CAST('1900-01-01 04:57:51' AS TIMESTAMP), CAST('1900-01-01 18:51:48' AS TIMESTAMP)))
+GROUP BY 1,
+  3
+    ","""BINDER ACCESSORIES""
+7.43
+#1900-01-01 18:51:48#
+""CLAMP ON LAMPS""
+8.42
+#21:07:32#
+""CORDLESS KEYBOARDS""
+10.37
+#1900-01-01 04:57:51#
+""DOT MATRIX PRINTERS""
+7.1
+#22:42:43#","""BINDER ACCESSORIES""
+7.43
+#1900-01-01 18:51:48#
+""CLAMP ON LAMPS""
+8.42
+#21:07:32#
+""CORDLESS KEYBOARDS""
+10.37
+#1900-01-01 04:57:51#
+""DOT MATRIX PRINTERS""
+7.1
+#22:42:43#"
+databricks,logical.calcs.databricks,cast_calcs.databricks,BUGS.TFS660780,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.BUGS.TFS660780.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.BUGS.TFS660780.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1122.0,"
+      SELECT SUM(1) AS `sum_number_of_records_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+WHERE ('All' = 'All')
+GROUP BY 1.1000000000000001
+    ",17,17
+databricks,logical.calcs.databricks,cast_calcs.databricks,Filter.Date_In,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.Date_In.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.Date_In.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1102.0,"
+      SELECT `Calcs`.`key` AS `key`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+WHERE `Calcs`.`date0` IN (CAST('1972-07-04 00:00:00' AS TIMESTAMP), CAST('1975-11-12 00:00:00' AS TIMESTAMP), CAST('2004-06-19 00:00:00' AS TIMESTAMP))
+GROUP BY 1
+    ","""key01""
+""key02""
+""key04""","""key01""
+""key02""
+""key04"""
+databricks,logical.calcs.databricks,cast_calcs.databricks,Filter.Date_In_Time,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.Date_In_Time.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.Date_In_Time.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1201.0,"
+      SELECT CAST(TO_DATE(CAST(CAST(`Calcs`.`date0` AS TIMESTAMP) AS DATE)) AS DATE) AS `tdy_calculation_2683863928708153344_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+WHERE (CAST(TO_DATE(CAST(CAST(`Calcs`.`date0` AS TIMESTAMP) AS DATE)) AS DATE) IN (CAST('1972-07-04 00:00:00' AS TIMESTAMP), CAST('1975-11-12 00:00:00' AS TIMESTAMP)))
+GROUP BY 1
+    ","#1972-07-04 00:00:00#
+#1975-11-12 00:00:00#","#1972-07-04 00:00:00#
+#1975-11-12 00:00:00#"
+databricks,logical.calcs.databricks,cast_calcs.databricks,Filter.Exclude-list-not-null,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.Exclude-list-not-null.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.Exclude-list-not-null.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1017.0,"
+      SELECT `Calcs`.`str2` AS `str2`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+WHERE ((NOT (`Calcs`.`str2` IN ('eight', 'eleven', 'fifteen', 'five'))) OR (`Calcs`.`str2` IS NULL))
+GROUP BY 1
+    ","%null%
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two""","%null%
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two"""
+databricks,logical.calcs.databricks,cast_calcs.databricks,Filter.Exclude-range-not-null,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.Exclude-range-not-null.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.Exclude-range-not-null.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,902.0,"
+      SELECT `Calcs`.`str2` AS `str2`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+WHERE ((NOT ((`Calcs`.`str2` >= 'eight') AND (`Calcs`.`str2` <= 'six'))) OR (`Calcs`.`str2` IS NULL))
+GROUP BY 1
+    ","%null%
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two""","%null%
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two"""
+databricks,logical.calcs.databricks,cast_calcs.databricks,Filter.FilterBy-to-no-results,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.FilterBy-to-no-results.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.FilterBy-to-no-results.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1124.0,"
+      SELECT `Calcs`.`str2` AS `str2`,
+  SUM(`Calcs`.`int2`) AS `x_measure__0`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+GROUP BY 1
+HAVING (SUM(`Calcs`.`int2`) > 1000)
+    ",,
+databricks,logical.calcs.databricks,cast_calcs.databricks,Filter.QFilter-NotNull,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-NotNull.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-NotNull.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,880.0,"
+      SELECT `Calcs`.`key` AS `key`,
+  SUM(`Calcs`.`int1`) AS `sum_int1_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+GROUP BY 1
+HAVING (NOT (SUM(`Calcs`.`int1`) IS NULL))
+    ","""key00""
+-3
+""key01""
+-6
+""key03""
+-4
+""key07""
+2
+""key08""
+3
+""key09""
+3
+""key11""
+-8
+""key16""
+-9","""key00""
+-3
+""key01""
+-6
+""key03""
+-4
+""key07""
+2
+""key08""
+3
+""key09""
+3
+""key11""
+-8
+""key16""
+-9"
+databricks,logical.calcs.databricks,cast_calcs.databricks,Filter.QFilter-Null,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-Null.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-Null.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1097.0,"
+      SELECT `Calcs`.`key` AS `key`,
+  SUM(`Calcs`.`int1`) AS `sum_int1_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+GROUP BY 1
+HAVING (SUM(`Calcs`.`int1`) IS NULL)
+    ","""key02""
+%null%
+""key04""
+%null%
+""key05""
+%null%
+""key06""
+%null%
+""key10""
+%null%
+""key12""
+%null%
+""key13""
+%null%
+""key14""
+%null%
+""key15""
+%null%","""key02""
+%null%
+""key04""
+%null%
+""key05""
+%null%
+""key06""
+%null%
+""key10""
+%null%
+""key12""
+%null%
+""key13""
+%null%
+""key14""
+%null%
+""key15""
+%null%"
+databricks,logical.calcs.databricks,cast_calcs.databricks,Filter.QFilter-max-NotNull,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-max-NotNull.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-max-NotNull.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,723.0,"
+      SELECT `Calcs`.`key` AS `key`,
+  SUM(`Calcs`.`int1`) AS `sum_int1_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+GROUP BY 1
+HAVING (SUM(`Calcs`.`int1`) <= 2)
+    ","""key00""
+-3
+""key01""
+-6
+""key03""
+-4
+""key07""
+2
+""key11""
+-8
+""key16""
+-9","""key00""
+-3
+""key01""
+-6
+""key03""
+-4
+""key07""
+2
+""key11""
+-8
+""key16""
+-9"
+databricks,logical.calcs.databricks,cast_calcs.databricks,Filter.QFilter-max-Null,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-max-Null.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-max-Null.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1117.0,"
+      SELECT `Calcs`.`key` AS `key`,
+  SUM(`Calcs`.`int1`) AS `sum_int1_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+GROUP BY 1
+HAVING ((SUM(`Calcs`.`int1`) <= 2) OR (SUM(`Calcs`.`int1`) IS NULL))
+    ","""key00""
+-3
+""key01""
+-6
+""key02""
+%null%
+""key03""
+-4
+""key04""
+%null%
+""key05""
+%null%
+""key06""
+%null%
+""key07""
+2
+""key10""
+%null%
+""key11""
+-8
+""key12""
+%null%
+""key13""
+%null%
+""key14""
+%null%
+""key15""
+%null%
+""key16""
+-9","""key00""
+-3
+""key01""
+-6
+""key02""
+%null%
+""key03""
+-4
+""key04""
+%null%
+""key05""
+%null%
+""key06""
+%null%
+""key07""
+2
+""key10""
+%null%
+""key11""
+-8
+""key12""
+%null%
+""key13""
+%null%
+""key14""
+%null%
+""key15""
+%null%
+""key16""
+-9"
+databricks,logical.calcs.databricks,cast_calcs.databricks,Filter.QFilter-min-NotNull,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-min-NotNull.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-min-NotNull.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1370.0,"
+      SELECT `Calcs`.`key` AS `key`,
+  SUM(`Calcs`.`int1`) AS `sum_int1_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+GROUP BY 1
+HAVING (SUM(`Calcs`.`int1`) >= 0)
+    ","""key07""
+2
+""key08""
+3
+""key09""
+3","""key07""
+2
+""key08""
+3
+""key09""
+3"
+databricks,logical.calcs.databricks,cast_calcs.databricks,Filter.QFilter-min-Null,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-min-Null.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-min-Null.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1177.0,"
+      SELECT `Calcs`.`key` AS `key`,
+  SUM(`Calcs`.`int1`) AS `sum_int1_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+GROUP BY 1
+HAVING ((SUM(`Calcs`.`int1`) >= 0) OR (SUM(`Calcs`.`int1`) IS NULL))
+    ","""key02""
+%null%
+""key04""
+%null%
+""key05""
+%null%
+""key06""
+%null%
+""key07""
+2
+""key08""
+3
+""key09""
+3
+""key10""
+%null%
+""key12""
+%null%
+""key13""
+%null%
+""key14""
+%null%
+""key15""
+%null%","""key02""
+%null%
+""key04""
+%null%
+""key05""
+%null%
+""key06""
+%null%
+""key07""
+2
+""key08""
+3
+""key09""
+3
+""key10""
+%null%
+""key12""
+%null%
+""key13""
+%null%
+""key14""
+%null%
+""key15""
+%null%"
+databricks,logical.calcs.databricks,cast_calcs.databricks,Filter.QFilter-minmax-NotNull,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-minmax-NotNull.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-minmax-NotNull.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1183.0,"
+      SELECT `Calcs`.`key` AS `key`,
+  SUM(`Calcs`.`int1`) AS `sum_int1_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+GROUP BY 1
+HAVING ((SUM(`Calcs`.`int1`) >= 0) AND (SUM(`Calcs`.`int1`) <= 2))
+    ","""key07""
+2","""key07""
+2"
+databricks,logical.calcs.databricks,cast_calcs.databricks,Filter.QFilter-minmax-Null,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-minmax-Null.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.QFilter-minmax-Null.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1157.0,"
+      SELECT `Calcs`.`key` AS `key`,
+  SUM(`Calcs`.`int1`) AS `sum_int1_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+GROUP BY 1
+HAVING (((SUM(`Calcs`.`int1`) >= 0) AND (SUM(`Calcs`.`int1`) <= 2)) OR (SUM(`Calcs`.`int1`) IS NULL))
+    ","""key02""
+%null%
+""key04""
+%null%
+""key05""
+%null%
+""key06""
+%null%
+""key07""
+2
+""key10""
+%null%
+""key12""
+%null%
+""key13""
+%null%
+""key14""
+%null%
+""key15""
+%null%","""key02""
+%null%
+""key04""
+%null%
+""key05""
+%null%
+""key06""
+%null%
+""key07""
+2
+""key10""
+%null%
+""key12""
+%null%
+""key13""
+%null%
+""key14""
+%null%
+""key15""
+%null%"
+databricks,logical.calcs.databricks,cast_calcs.databricks,Filter.TopN-context,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.TopN-context.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.TopN-context.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2689.0,"
+      SELECT `Calcs`.`str0` AS `str0`,
+  SUM(`Calcs`.`int2`) AS `sum_int2_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+  JOIN (
+  SELECT `Calcs`.`str0` AS `str0`,
+    SUM(`Calcs`.`int2`) AS `x__alias__0`
+  FROM `tableau_tdvt`.`calcs` `Calcs`
+  GROUP BY 1
+  ORDER BY `x__alias__0` DESC
+  LIMIT 2
+) `t0` ON (`Calcs`.`str0` = `t0`.`str0`)
+WHERE (((`Calcs`.`str1` >= 'AIR PURIFIERS') AND (`Calcs`.`str1` <= 'CD-R MEDIA')) OR ((`Calcs`.`str1` >= 'CONFERENCE PHONES') AND (`Calcs`.`str1` <= 'ERICSSON')))
+GROUP BY 1
+    ","""OFFICE SUPPLIES""
+14","""OFFICE SUPPLIES""
+14"
+databricks,logical.calcs.databricks,cast_calcs.databricks,Filter.datetime_fractional,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.datetime_fractional.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Filter.datetime_fractional.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1163.0,"
+      SELECT CAST('2016-07-15 10:11:12.123' AS TIMESTAMP) AS `calculation_958703807427547136`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+WHERE (CAST('2016-07-15 10:11:12.123' AS TIMESTAMP) = CAST('2016-07-15 10:11:12.123' AS TIMESTAMP))
+GROUP BY 1.1000000000000001
+    ",#2016-07-15 10:11:12.123#,#2016-07-15 10:11:12.123#
+databricks,logical.calcs.databricks,cast_calcs.databricks,Query.Filter.IsNOTNULL,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Query.Filter.IsNOTNULL.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Query.Filter.IsNOTNULL.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1205.0,"
+      SELECT `Calcs`.`str2` AS `str2`,
+  SUM(`Calcs`.`num3`) AS `sum_num3_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+WHERE ((`Calcs`.`str2` >= 'eight') AND (`Calcs`.`str2` <= 'two'))
+GROUP BY 1
+    ","""eight""
+3.64
+""eleven""
+-4.79
+""fifteen""
+6.84
+""five""
+12.93
+""fourteen""
+-18.43
+""nine""
+-13.38
+""one""
+-11.52
+""six""
+-19.96
+""sixteen""
+-10.98
+""ten""
+-10.56
+""three""
+-12.17
+""twelve""
+-10.81
+""two""
+-9.31","""eight""
+3.64
+""eleven""
+-4.79
+""fifteen""
+6.84
+""five""
+12.93
+""fourteen""
+-18.43
+""nine""
+-13.38
+""one""
+-11.52
+""six""
+-19.96
+""sixteen""
+-10.98
+""ten""
+-10.56
+""three""
+-12.17
+""twelve""
+-10.81
+""two""
+-9.31"
+databricks,logical.calcs.databricks,cast_calcs.databricks,Query.Filter.IsNULL,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Query.Filter.IsNULL.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Query.Filter.IsNULL.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1188.0,"
+      SELECT `Calcs`.`str2` AS `str2`,
+  SUM(`Calcs`.`num3`) AS `sum_num3_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+WHERE (`Calcs`.`str2` IS NULL)
+GROUP BY 1
+    ","%null%
+-5.54","%null%
+-5.54"
+databricks,logical.calcs.databricks,cast_calcs.databricks,Query.Filter.NullAndOne,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Query.Filter.NullAndOne.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.Query.Filter.NullAndOne.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1186.0,"
+      SELECT `Calcs`.`str2` AS `str2`,
+  SUM(`Calcs`.`num3`) AS `sum_num3_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+WHERE ((`Calcs`.`str2` IN ('sixteen')) OR (`Calcs`.`str2` IS NULL))
+GROUP BY 1
+    ","%null%
+-5.54
+""sixteen""
+-10.98","%null%
+-5.54
+""sixteen""
+-10.98"
+databricks,logical.calcs.databricks,cast_calcs.databricks,join.null.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.join.null.bool.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.join.null.bool.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,3088.0,"
+      SELECT `t0`.`x_measure__0` AS `calculation_845269395859349504`,
+  `Calcs`.`bool1` AS `bool1`,
+  SUM(`Calcs`.`num1`) AS `sum_num1_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+  JOIN (
+  SELECT `Calcs`.`bool1` AS `bool1`,
+    `Calcs`.`key` AS `key`,
+    SUM(`Calcs`.`num1`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`calcs` `Calcs`
+  GROUP BY 1,
+    2
+) `t0` ON ((`Calcs`.`bool1` IS NOT DISTINCT FROM `t0`.`bool1`) AND (`Calcs`.`key` IS NOT DISTINCT FROM `t0`.`key`))
+GROUP BY 1,
+  2
+    ","2.47
+true
+2.47
+6.71
+true
+6.71
+7.1
+false
+7.1
+7.12
+%null%
+7.12
+7.43
+false
+7.43
+8.42
+true
+8.42
+9.05
+false
+9.05
+9.38
+false
+9.38
+9.47
+%null%
+9.47
+9.78
+true
+9.78
+10.32
+true
+10.32
+10.37
+false
+10.37
+11.38
+%null%
+11.38
+12.05
+false
+12.05
+12.4
+true
+12.4
+16.42
+%null%
+16.42
+16.81
+%null%
+16.81","2.47
+true
+2.47
+6.71
+true
+6.71
+7.1
+false
+7.1
+7.12
+%null%
+7.12
+7.43
+false
+7.43
+8.42
+true
+8.42
+9.05
+false
+9.05
+9.38
+false
+9.38
+9.47
+%null%
+9.47
+9.78
+true
+9.78
+10.32
+true
+10.32
+10.37
+false
+10.37
+11.38
+%null%
+11.38
+12.05
+false
+12.05
+12.4
+true
+12.4
+16.42
+%null%
+16.42
+16.81
+%null%
+16.81"
+databricks,logical.calcs.databricks,cast_calcs.databricks,join.null.date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.join.null.date.tableau_tdvt.xml,True,1,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.join.null.date.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2275.0,"
+      SELECT `t0`.`x_measure__0` AS `calculation_845269395859349504`,
+  `Calcs`.`date0` AS `date0`,
+  SUM(`Calcs`.`num1`) AS `sum_num1_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+  JOIN (
+  SELECT `Calcs`.`date0` AS `date0`,
+    `Calcs`.`key` AS `key`,
+    SUM(`Calcs`.`num1`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`calcs` `Calcs`
+  GROUP BY 1,
+    2
+) `t0` ON ((`Calcs`.`date0` IS NOT DISTINCT FROM `t0`.`date0`) AND (`Calcs`.`key` IS NOT DISTINCT FROM `t0`.`key`))
+GROUP BY 1,
+  2
+    ","2.47
+%null%
+2.47
+6.71
+#1972-07-04#
+6.71
+7.1
+%null%
+7.1
+7.12
+%null%
+7.12
+7.43
+#2004-06-04#
+7.43
+8.42
+#2004-04-15#
+8.42
+9.05
+#2004-06-19#
+9.05
+9.38
+%null%
+9.38
+9.47
+%null%
+9.47
+9.78
+#1975-11-12#
+9.78
+10.32
+%null%
+10.32
+10.37
+%null%
+10.37
+11.38
+%null%
+11.38
+12.05
+%null%
+12.05
+12.4
+%null%
+12.4
+16.42
+%null%
+16.42
+16.81
+%null%
+16.81","2.47
+%null%
+2.47
+6.71
+#1972-07-04#
+6.71
+7.1
+%null%
+7.1
+7.12
+%null%
+7.12
+7.43
+#2004-06-04#
+7.43
+8.42
+#2004-04-15#
+8.42
+9.05
+#2004-06-19#
+9.05
+9.38
+%null%
+9.38
+9.47
+%null%
+9.47
+9.78
+#1975-11-12#
+9.78
+10.32
+%null%
+10.32
+10.37
+%null%
+10.37
+11.38
+%null%
+11.38
+12.05
+%null%
+12.05
+12.4
+%null%
+12.4
+16.42
+%null%
+16.42
+16.81
+%null%
+16.81"
+databricks,logical.calcs.databricks,cast_calcs.databricks,join.null.datetime,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.join.null.datetime.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.join.null.datetime.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2718.0,"
+      SELECT CAST(`Calcs`.`date0` AS TIMESTAMP) AS `calculation_3278620569574133760`,
+  `t0`.`x_measure__1` AS `calculation_845269395859349504`,
+  SUM(`Calcs`.`num1`) AS `sum_num1_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+  JOIN (
+  SELECT CAST(`Calcs`.`date0` AS TIMESTAMP) AS `x_dimension__0`,
+    `Calcs`.`key` AS `key`,
+    SUM(`Calcs`.`num1`) AS `x_measure__1`
+  FROM `tableau_tdvt`.`calcs` `Calcs`
+  GROUP BY 1,
+    2
+) `t0` ON ((CAST(`Calcs`.`date0` AS TIMESTAMP) IS NOT DISTINCT FROM `t0`.`x_dimension__0`) AND (`Calcs`.`key` IS NOT DISTINCT FROM `t0`.`key`))
+GROUP BY 1,
+  2
+    ","%null%
+2.47
+2.47
+%null%
+7.1
+7.1
+%null%
+7.12
+7.12
+%null%
+9.38
+9.38
+%null%
+9.47
+9.47
+%null%
+10.32
+10.32
+%null%
+10.37
+10.37
+%null%
+11.38
+11.38
+%null%
+12.05
+12.05
+%null%
+12.4
+12.4
+%null%
+16.42
+16.42
+%null%
+16.81
+16.81
+#1972-07-04 00:00:00#
+6.71
+6.71
+#1975-11-12 00:00:00#
+9.78
+9.78
+#2004-04-15 00:00:00#
+8.42
+8.42
+#2004-06-04 00:00:00#
+7.43
+7.43
+#2004-06-19 00:00:00#
+9.05
+9.05","%null%
+2.47
+2.47
+%null%
+7.1
+7.1
+%null%
+7.12
+7.12
+%null%
+9.38
+9.38
+%null%
+9.47
+9.47
+%null%
+10.32
+10.32
+%null%
+10.37
+10.37
+%null%
+11.38
+11.38
+%null%
+12.05
+12.05
+%null%
+12.4
+12.4
+%null%
+16.42
+16.42
+%null%
+16.81
+16.81
+#1972-07-04 00:00:00#
+6.71
+6.71
+#1975-11-12 00:00:00#
+9.78
+9.78
+#2004-04-15 00:00:00#
+8.42
+8.42
+#2004-06-04 00:00:00#
+7.43
+7.43
+#2004-06-19 00:00:00#
+9.05
+9.05"
+databricks,logical.calcs.databricks,cast_calcs.databricks,join.null.int,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.join.null.int.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.join.null.int.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1730.0,"
+      SELECT `t0`.`x_measure__0` AS `calculation_845269395859349504`,
+  `Calcs`.`int1` AS `int1`,
+  SUM(`Calcs`.`num1`) AS `sum_num1_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+  JOIN (
+  SELECT `Calcs`.`int1` AS `int1`,
+    `Calcs`.`key` AS `key`,
+    SUM(`Calcs`.`num1`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`calcs` `Calcs`
+  GROUP BY 1,
+    2
+) `t0` ON ((`Calcs`.`int1` IS NOT DISTINCT FROM `t0`.`int1`) AND (`Calcs`.`key` IS NOT DISTINCT FROM `t0`.`key`))
+GROUP BY 1,
+  2
+    ","2.47
+-8
+2.47
+6.71
+-6
+6.71
+7.1
+%null%
+7.1
+7.12
+-9
+7.12
+7.43
+-4
+7.43
+8.42
+-3
+8.42
+9.05
+%null%
+9.05
+9.38
+%null%
+9.38
+9.47
+3
+9.47
+9.78
+%null%
+9.78
+10.32
+%null%
+10.32
+10.37
+%null%
+10.37
+11.38
+2
+11.38
+12.05
+%null%
+12.05
+12.4
+3
+12.4
+16.42
+%null%
+16.42
+16.81
+%null%
+16.81","2.47
+-8
+2.47
+6.71
+-6
+6.71
+7.1
+%null%
+7.1
+7.12
+-9
+7.12
+7.43
+-4
+7.43
+8.42
+-3
+8.42
+9.05
+%null%
+9.05
+9.38
+%null%
+9.38
+9.47
+3
+9.47
+9.78
+%null%
+9.78
+10.32
+%null%
+10.32
+10.37
+%null%
+10.37
+11.38
+2
+11.38
+12.05
+%null%
+12.05
+12.4
+3
+12.4
+16.42
+%null%
+16.42
+16.81
+%null%
+16.81"
+databricks,logical.calcs.databricks,cast_calcs.databricks,join.null.real,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.join.null.real.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.join.null.real.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2352.0,"
+      SELECT `t0`.`x_measure__0` AS `calculation_845269395859349504`,
+  `Calcs`.`num2` AS `num2`,
+  SUM(`Calcs`.`num1`) AS `sum_num1_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+  JOIN (
+  SELECT `Calcs`.`num2` AS `num2`,
+    `Calcs`.`key` AS `key`,
+    SUM(`Calcs`.`num1`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`calcs` `Calcs`
+  GROUP BY 2,
+    1
+) `t0` ON ((`Calcs`.`num2` IS NOT DISTINCT FROM `t0`.`num2`) AND (`Calcs`.`key` IS NOT DISTINCT FROM `t0`.`key`))
+GROUP BY 1,
+  2
+    ","2.47
+3.79
+2.47
+6.71
+16.73
+6.71
+7.1
+%null%
+7.1
+7.12
+7.87
+7.12
+7.43
+8.51
+7.43
+8.42
+17.86
+8.42
+9.05
+6.46
+9.05
+9.38
+8.98
+9.38
+9.47
+%null%
+9.47
+9.78
+%null%
+9.78
+10.32
+6.8
+10.32
+10.37
+13.04
+10.37
+11.38
+17.25
+11.38
+12.05
+%null%
+12.05
+12.4
+11.5
+12.4
+16.42
+11.69
+16.42
+16.81
+10.98
+16.81","2.47
+3.79
+2.47
+6.71
+16.73
+6.71
+7.1
+%null%
+7.1
+7.12
+7.87
+7.12
+7.43
+8.51
+7.43
+8.42
+17.86
+8.42
+9.05
+6.46
+9.05
+9.38
+8.98
+9.38
+9.47
+%null%
+9.47
+9.78
+%null%
+9.78
+10.32
+6.8
+10.32
+10.37
+13.04
+10.37
+11.38
+17.25
+11.38
+12.05
+%null%
+12.05
+12.4
+11.5
+12.4
+16.42
+11.69
+16.42
+16.81
+10.98
+16.81"
+databricks,logical.calcs.databricks,cast_calcs.databricks,join.null.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.join.null.str.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/calcs\setup.join.null.str.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2277.0,"
+      SELECT `t0`.`x_measure__0` AS `calculation_845269395859349504`,
+  `Calcs`.`str2` AS `str2`,
+  SUM(`Calcs`.`num1`) AS `sum_num1_ok`
+FROM `tableau_tdvt`.`calcs` `Calcs`
+  JOIN (
+  SELECT `Calcs`.`key` AS `key`,
+    `Calcs`.`str2` AS `str2`,
+    SUM(`Calcs`.`num1`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`calcs` `Calcs`
+  GROUP BY 1,
+    2
+) `t0` ON ((`Calcs`.`key` IS NOT DISTINCT FROM `t0`.`key`) AND (`Calcs`.`str2` IS NOT DISTINCT FROM `t0`.`str2`))
+GROUP BY 1,
+  2
+    ","2.47
+""twelve""
+2.47
+6.71
+""two""
+6.71
+7.1
+""fifteen""
+7.1
+7.12
+%null%
+7.12
+7.43
+%null%
+7.43
+8.42
+""one""
+8.42
+9.05
+""five""
+9.05
+9.38
+""six""
+9.38
+9.47
+""nine""
+9.47
+9.78
+""three""
+9.78
+10.32
+""eleven""
+10.32
+10.37
+""fourteen""
+10.37
+11.38
+""eight""
+11.38
+12.05
+%null%
+12.05
+12.4
+""ten""
+12.4
+16.42
+%null%
+16.42
+16.81
+""sixteen""
+16.81","2.47
+""twelve""
+2.47
+6.71
+""two""
+6.71
+7.1
+""fifteen""
+7.1
+7.12
+%null%
+7.12
+7.43
+%null%
+7.43
+8.42
+""one""
+8.42
+9.05
+""five""
+9.05
+9.38
+""six""
+9.38
+9.47
+""nine""
+9.47
+9.78
+""three""
+9.78
+10.32
+""eleven""
+10.32
+10.37
+""fourteen""
+10.37
+11.38
+""eight""
+11.38
+12.05
+%null%
+12.05
+12.4
+""ten""
+12.4
+16.42
+%null%
+16.42
+16.81
+""sixteen""
+16.81"
+databricks,logical.staples.databricks,Staples.databricks,BUGS.B14080,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.BUGS.B14080.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.BUGS.B14080.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1610.0,"
+      SELECT `Staples`.`Call_Center_Region` AS `call_center_region`,
+  `Staples`.`Customer_State` AS `customer_state`,
+  SUM(`Staples`.`Gross_Profit`) AS `sum_gross_profit_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((CAST((UNIX_TIMESTAMP(`Staples`.`Received_Date`) - UNIX_TIMESTAMP(`Staples`.`Order_Date`)) / 86400.0 AS DOUBLE) IN (121., 122., 123., 124., 125., 126., 127., 128., 129., 130., 131., 132., 133., 134., 135., 137., 138.)) AND (NOT (CAST((UNIX_TIMESTAMP(`Staples`.`Received_Date`) - UNIX_TIMESTAMP(`Staples`.`Order_Date`)) / 86400.0 AS DOUBLE) IS NULL)))
+GROUP BY 1,
+  2
+    ","""CENTRAL""
+""ILLINOIS""
+15114.3
+""CENTRAL""
+""MICHIGAN""
+5994.94
+""CENTRAL""
+""OHIO""
+28344.05
+""CENTRAL""
+""TEXAS""
+7215.68
+""CENTRAL""
+""WISCONSIN""
+-528.76
+""EAST""
+""ALABAMA""
+1979.59
+""EAST""
+""CONNECTICUT""
+7841.78
+""EAST""
+""DELAWARE""
+18332.2
+""EAST""
+""FLORIDA""
+6839.97
+""EAST""
+""MARYLAND""
+12582.29
+""EAST""
+""MASS""
+19463.75
+""EAST""
+""NEBRASKA""
+2271.0
+""EAST""
+""NEW JERSEY""
+11730.03
+""EAST""
+""NEW YORK""
+14019.43
+""EAST""
+""NORTH CAROLINA""
+20345.13
+""EAST""
+""SOUTH CAROLINA""
+2535.34
+""EAST""
+""VIRGINIA""
+8583.95
+""EAST""
+""WASH D.C.""
+13302.4
+""WEST""
+""ARIZONA""
+33135.29
+""WEST""
+""CALIFORNIA""
+13652.95
+""WEST""
+""COLORADO""
+3286.8
+""WEST""
+""IDAHO""
+6873.27
+""WEST""
+""NEW MEXICO""
+3132.38
+""WEST""
+""UTAH""
+16972.86
+""WEST""
+""WASHINGTON""
+17160.4","""CENTRAL""
+""ILLINOIS""
+15114.3
+""CENTRAL""
+""MICHIGAN""
+5994.94
+""CENTRAL""
+""OHIO""
+28344.05
+""CENTRAL""
+""TEXAS""
+7215.68
+""CENTRAL""
+""WISCONSIN""
+-528.76
+""EAST""
+""ALABAMA""
+1979.59
+""EAST""
+""CONNECTICUT""
+7841.78
+""EAST""
+""DELAWARE""
+18332.2
+""EAST""
+""FLORIDA""
+6839.97
+""EAST""
+""MARYLAND""
+12582.29
+""EAST""
+""MASS""
+19463.75
+""EAST""
+""NEBRASKA""
+2271.0
+""EAST""
+""NEW JERSEY""
+11730.03
+""EAST""
+""NEW YORK""
+14019.43
+""EAST""
+""NORTH CAROLINA""
+20345.13
+""EAST""
+""SOUTH CAROLINA""
+2535.34
+""EAST""
+""VIRGINIA""
+8583.95
+""EAST""
+""WASH D.C.""
+13302.4
+""WEST""
+""ARIZONA""
+33135.29
+""WEST""
+""CALIFORNIA""
+13652.95
+""WEST""
+""COLORADO""
+3286.8
+""WEST""
+""IDAHO""
+6873.27
+""WEST""
+""NEW MEXICO""
+3132.38
+""WEST""
+""UTAH""
+16972.86
+""WEST""
+""WASHINGTON""
+17160.4"
+databricks,logical.staples.databricks,Staples.databricks,BUGS.B24394,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.BUGS.B24394.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.BUGS.B24394.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1233.0,"
+      SELECT FLOOR((14 + DATEDIFF(`Staples`.`Ship_Date`, TRUNC(`Staples`.`Ship_Date`,'YY')) + DATEDIFF(TRUNC(`Staples`.`Ship_Date`,'YY'),NEXT_DAY(TRUNC(`Staples`.`Ship_Date`,'YY'),'SU')))/7) AS `datepart__week__ship_date_`,
+  CAST(DATE_ADD(NEXT_DAY(`Staples`.`Ship_Date`,'SU'),-7) AS DATE) AS `datetrunc__week__ship_date_`,
+  `Staples`.`Ship_Date` AS `ship_date`,
+  (8 + DATEDIFF(`Staples`.`Ship_Date`,NEXT_DAY(CAST(`Staples`.`Ship_Date` AS DATE),'SU'))) AS `wd_ship_date_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE (`Staples`.`Ship_Date` <= CAST('1997-02-01 00:00:00' AS TIMESTAMP))
+GROUP BY 3
+    ","1
+#1996-12-29 00:00:00#
+#1997-01-01 00:00:00#
+4
+1
+#1996-12-29 00:00:00#
+#1997-01-02 00:00:00#
+5
+1
+#1996-12-29 00:00:00#
+#1997-01-03 00:00:00#
+6
+1
+#1996-12-29 00:00:00#
+#1997-01-04 00:00:00#
+7
+2
+#1997-01-05 00:00:00#
+#1997-01-05 00:00:00#
+1
+2
+#1997-01-05 00:00:00#
+#1997-01-06 00:00:00#
+2
+2
+#1997-01-05 00:00:00#
+#1997-01-07 00:00:00#
+3
+2
+#1997-01-05 00:00:00#
+#1997-01-08 00:00:00#
+4
+2
+#1997-01-05 00:00:00#
+#1997-01-09 00:00:00#
+5
+2
+#1997-01-05 00:00:00#
+#1997-01-10 00:00:00#
+6
+2
+#1997-01-05 00:00:00#
+#1997-01-11 00:00:00#
+7
+3
+#1997-01-12 00:00:00#
+#1997-01-12 00:00:00#
+1
+3
+#1997-01-12 00:00:00#
+#1997-01-13 00:00:00#
+2
+3
+#1997-01-12 00:00:00#
+#1997-01-14 00:00:00#
+3
+3
+#1997-01-12 00:00:00#
+#1997-01-15 00:00:00#
+4
+3
+#1997-01-12 00:00:00#
+#1997-01-16 00:00:00#
+5
+3
+#1997-01-12 00:00:00#
+#1997-01-17 00:00:00#
+6
+3
+#1997-01-12 00:00:00#
+#1997-01-18 00:00:00#
+7
+4
+#1997-01-19 00:00:00#
+#1997-01-19 00:00:00#
+1
+4
+#1997-01-19 00:00:00#
+#1997-01-20 00:00:00#
+2
+4
+#1997-01-19 00:00:00#
+#1997-01-21 00:00:00#
+3
+4
+#1997-01-19 00:00:00#
+#1997-01-22 00:00:00#
+4
+4
+#1997-01-19 00:00:00#
+#1997-01-23 00:00:00#
+5
+4
+#1997-01-19 00:00:00#
+#1997-01-24 00:00:00#
+6
+4
+#1997-01-19 00:00:00#
+#1997-01-25 00:00:00#
+7","1
+#1996-12-29 00:00:00#
+#1997-01-01 00:00:00#
+4
+1
+#1996-12-29 00:00:00#
+#1997-01-02 00:00:00#
+5
+1
+#1996-12-29 00:00:00#
+#1997-01-03 00:00:00#
+6
+1
+#1996-12-29 00:00:00#
+#1997-01-04 00:00:00#
+7
+2
+#1997-01-05 00:00:00#
+#1997-01-05 00:00:00#
+1
+2
+#1997-01-05 00:00:00#
+#1997-01-06 00:00:00#
+2
+2
+#1997-01-05 00:00:00#
+#1997-01-07 00:00:00#
+3
+2
+#1997-01-05 00:00:00#
+#1997-01-08 00:00:00#
+4
+2
+#1997-01-05 00:00:00#
+#1997-01-09 00:00:00#
+5
+2
+#1997-01-05 00:00:00#
+#1997-01-10 00:00:00#
+6
+2
+#1997-01-05 00:00:00#
+#1997-01-11 00:00:00#
+7
+3
+#1997-01-12 00:00:00#
+#1997-01-12 00:00:00#
+1
+3
+#1997-01-12 00:00:00#
+#1997-01-13 00:00:00#
+2
+3
+#1997-01-12 00:00:00#
+#1997-01-14 00:00:00#
+3
+3
+#1997-01-12 00:00:00#
+#1997-01-15 00:00:00#
+4
+3
+#1997-01-12 00:00:00#
+#1997-01-16 00:00:00#
+5
+3
+#1997-01-12 00:00:00#
+#1997-01-17 00:00:00#
+6
+3
+#1997-01-12 00:00:00#
+#1997-01-18 00:00:00#
+7
+4
+#1997-01-19 00:00:00#
+#1997-01-19 00:00:00#
+1
+4
+#1997-01-19 00:00:00#
+#1997-01-20 00:00:00#
+2
+4
+#1997-01-19 00:00:00#
+#1997-01-21 00:00:00#
+3
+4
+#1997-01-19 00:00:00#
+#1997-01-22 00:00:00#
+4
+4
+#1997-01-19 00:00:00#
+#1997-01-23 00:00:00#
+5
+4
+#1997-01-19 00:00:00#
+#1997-01-24 00:00:00#
+6
+4
+#1997-01-19 00:00:00#
+#1997-01-25 00:00:00#
+7"
+databricks,logical.staples.databricks,Staples.databricks,BUGS.B340,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.BUGS.B340.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.BUGS.B340.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,3237.0,"
+      SELECT `Staples`.`Call_Center_Region` AS `call_center_region`,
+  `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(`Staples`.`Customer_Balance`) AS `sum_customer_balance_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+  JOIN (
+  SELECT `Staples`.`Customer_Name` AS `customer_name`,
+    SUM(`Staples`.`Customer_Balance`) AS `x__alias__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+  ORDER BY `x__alias__0` DESC
+  LIMIT 10
+) `t0` ON (`Staples`.`Customer_Name` = `t0`.`customer_name`)
+GROUP BY 1,
+  2
+HAVING ((SUM(`Staples`.`Customer_Balance`) >= 999999.99999998999) AND (SUM(`Staples`.`Customer_Balance`) <= 3186976.0000000317))
+    ","""CENTRAL""
+""Hilary Holden""
+1093948.0
+""CENTRAL""
+""Roy Skaria""
+1229581.0
+""CENTRAL""
+""Zyzzy Zzuyzyzyk""
+1132594.0
+""EAST""
+""Jasper Cacioppo""
+2049341.0
+""EAST""
+""Jesus Ocampo""
+3078497.0
+""EAST""
+""Karen Seio""
+3098324.0
+""EAST""
+""Lena Cacioppo""
+3028281.0
+""EAST""
+""Lynn Smith-Reed""
+2415802.0
+""EAST""
+""Naresj Patel""
+1892464.0
+""EAST""
+""Roy Skaria""
+2805333.0
+""EAST""
+""Thomas Seio""
+2848296.0
+""EAST""
+""Zyzzy Zzuyzyzyk""
+3186975.0
+""WEST""
+""Hilary Holden""
+2274940.0
+""WEST""
+""Karen Seio""
+1707447.0
+""WEST""
+""Lynn Smith-Reed""
+1534576.0
+""WEST""
+""Naresj Patel""
+2431303.0","""CENTRAL""
+""Hilary Holden""
+1093948.0
+""CENTRAL""
+""Roy Skaria""
+1229581.0
+""CENTRAL""
+""Zyzzy Zzuyzyzyk""
+1132594.0
+""EAST""
+""Jasper Cacioppo""
+2049341.0
+""EAST""
+""Jesus Ocampo""
+3078497.0
+""EAST""
+""Karen Seio""
+3098324.0
+""EAST""
+""Lena Cacioppo""
+3028281.0
+""EAST""
+""Lynn Smith-Reed""
+2415802.0
+""EAST""
+""Naresj Patel""
+1892464.0
+""EAST""
+""Roy Skaria""
+2805333.0
+""EAST""
+""Thomas Seio""
+2848296.0
+""EAST""
+""Zyzzy Zzuyzyzyk""
+3186975.0
+""WEST""
+""Hilary Holden""
+2274940.0
+""WEST""
+""Karen Seio""
+1707447.0
+""WEST""
+""Lynn Smith-Reed""
+1534576.0
+""WEST""
+""Naresj Patel""
+2431303.0"
+databricks,logical.staples.databricks,Staples.databricks,BUGS.B530764,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.BUGS.B530764.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.BUGS.B530764.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1358.0,"
+      SELECT SUM((CASE WHEN 1.1000000000000001 = 0 THEN NULL ELSE `Staples`.`Price` / 1.1000000000000001 END)) AS `sum_calculation_555068687593533440_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1.1000000000000001
+    ",4275856.2,4275856.2
+databricks,logical.staples.databricks,Staples.databricks,BUGS.B8888,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.BUGS.B8888.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.BUGS.B8888.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,4434.0,"
+      SELECT CAST((CASE WHEN 7 = 0 THEN NULL ELSE ((6 + (8 + DATEDIFF(CAST(CONCAT(ADD_MONTHS(CAST(TRUNC(`Staples`.`Order_Date`,'YY') AS DATE),(CASE WHEN (MONTH(`Staples`.`Order_Date`) < 3) THEN -10 ELSE 2 END)),SUBSTR(CAST(CAST(TRUNC(`Staples`.`Order_Date`,'YY') AS DATE) AS TIMESTAMP),11)) AS TIMESTAMP),NEXT_DAY(CAST(CAST(CONCAT(ADD_MONTHS(CAST(TRUNC(`Staples`.`Order_Date`,'YY') AS DATE),(CASE WHEN (MONTH(`Staples`.`Order_Date`) < 3) THEN -10 ELSE 2 END)),SUBSTR(CAST(CAST(TRUNC(`Staples`.`Order_Date`,'YY') AS DATE) AS TIMESTAMP),11)) AS TIMESTAMP) AS DATE),'SU')))) + (UNIX_TIMESTAMP(`Staples`.`Order_Date`) - UNIX_TIMESTAMP(CAST(CONCAT(ADD_MONTHS(CAST(TRUNC(`Staples`.`Order_Date`,'YY') AS DATE),(CASE WHEN (MONTH(`Staples`.`Order_Date`) < 3) THEN -10 ELSE 2 END)),SUBSTR(CAST(CAST(TRUNC(`Staples`.`Order_Date`,'YY') AS DATE) AS TIMESTAMP),11)) AS TIMESTAMP))) / 86400.0) / 7 END) AS BIGINT) AS `week__`,
+  COUNT(DISTINCT `Staples`.`Order_Date`) AS `ctd_order_date_ok`,
+  YEAR(CAST(CONCAT(ADD_MONTHS(`Staples`.`Order_Date`,10),SUBSTR(CAST(`Staples`.`Order_Date` AS TIMESTAMP),11)) AS TIMESTAMP)) AS `yr_order_date_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1,
+  3
+    ","1
+1
+1998
+1
+2
+2003
+1
+3
+2002
+1
+4
+2001
+1
+6
+2000
+1
+7
+1999
+2
+7
+1998
+2
+7
+1999
+2
+7
+2000
+2
+7
+2001
+2
+7
+2002
+2
+7
+2003
+3
+7
+1998
+3
+7
+1999
+3
+7
+2000
+3
+7
+2001
+3
+7
+2002
+3
+7
+2003
+4
+7
+1998
+4
+7
+1999
+4
+7
+2000
+4
+7
+2001
+4
+7
+2002
+4
+7
+2003
+5
+7
+1998
+5
+7
+1999
+5
+7
+2000
+5
+7
+2001
+5
+7
+2002
+5
+7
+2003
+6
+7
+1998
+6
+7
+1999
+6
+7
+2000
+6","1
+1
+1998
+1
+2
+2003
+1
+3
+2002
+1
+4
+2001
+1
+6
+2000
+1
+7
+1999
+2
+7
+1998
+2
+7
+1999
+2
+7
+2000
+2
+7
+2001
+2
+7
+2002
+2
+7
+2003
+3
+7
+1998
+3
+7
+1999
+3
+7
+2000
+3
+7
+2001
+3
+7
+2002
+3
+7
+2003
+4
+7
+1998
+4
+7
+1999
+4
+7
+2000
+4
+7
+2001
+4
+7
+2002
+4
+7
+2003
+5
+7
+1998
+5
+7
+1999
+5
+7
+2000
+5
+7
+2001
+5
+7
+2002
+5
+7
+2003
+6
+7
+1998
+6
+7
+1999
+6
+7
+2000
+6"
+databricks,logical.staples.databricks,Staples.databricks,Filter.Add_to_context,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Filter.Add_to_context.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Filter.Add_to_context.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1735.0,"
+      SELECT `Staples`.`Market_Segment` AS `market_segment`,
+  `Staples`.`Prod_Type1` AS `prod_type1`,
+  `Staples`.`Prod_Type2` AS `prod_type2`,
+  `Staples`.`Prod_Type3` AS `prod_type3`,
+  `Staples`.`Prod_Type4` AS `prod_type4`,
+  SUM(`Staples`.`Gross_Profit`) AS `sum_gross_profit_ok`,
+  SUM(`Staples`.`Sales_Total`) AS `sum_sales_total_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((NOT ((`Staples`.`Market_Segment` = 'CORPORATE') AND (`Staples`.`Prod_Type1` = 'TECHNOLOGY') AND (`Staples`.`Prod_Type2` = 'TELEPHONES AND COMMUNICATION') AND (`Staples`.`Prod_Type3` = 'WIRELESS AND CELLULAR') AND (`Staples`.`Prod_Type4` = 'NOKIA'))) AND (`Staples`.`Customer_State` = 'ALABAMA'))
+GROUP BY 1,
+  2,
+  3,
+  4,
+  5
+    ","""CONSUMER""
+""FURNITURE""
+""BOOKCASES""
+""METAL BOOKCASES""
+""METAL BOOKCASES""
+-194.33
+2376.45
+""CONSUMER""
+""FURNITURE""
+""BOOKCASES""
+""WOODEN BOOKCASES""
+""WOODEN BOOKCASES""
+870.8
+13940.6
+""CONSUMER""
+""FURNITURE""
+""CHAIRS & CHAIRMATS""
+""OFFICE CHAIRS""
+""EXECUTIVE CHAIRS""
+-1806.31
+13465.46
+""CONSUMER""
+""FURNITURE""
+""CHAIRS & CHAIRMATS""
+""OFFICE CHAIRS""
+""STACKING AND FOLDING CHAIRS""
+1051.31
+19022.98
+""CONSUMER""
+""FURNITURE""
+""CHAIRS & CHAIRMATS""
+""OFFICE CHAIRS""
+""TASK CHAIRS""
+189.03
+3937.72
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""CLOCKS""
+""CLOCKS""
+410.49
+6201.22
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""DESK LAMPS""
+""CLAMP ON LAMPS""
+402.98
+2844.76
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""DESK LAMPS""
+""MAGNIFIER LAMPS""
+23.53
+425.76
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""DOOR ACCESSORIES""
+""DOOR ACCESSORIES""
+18.11
+161.87
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""FLOOR LAMPS""
+""FLOOR LAMPS""
+-64.76
+203.96
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""FRAMES""
+""FRAMES""
+207.54
+7126.16
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""LIGHTING""
+""LIGHT BULBS""
+-29.08
+370.41
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""MATS""
+""MATS""
+1937.8
+13400.56
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""PLASTIC DESK SETS""
+""PLASTIC DESK SETS""
+-757.26
+1287.76
+""CONSUMER""
+""FURNITURE""","""CONSUMER""
+""FURNITURE""
+""BOOKCASES""
+""METAL BOOKCASES""
+""METAL BOOKCASES""
+-194.33
+2376.45
+""CONSUMER""
+""FURNITURE""
+""BOOKCASES""
+""WOODEN BOOKCASES""
+""WOODEN BOOKCASES""
+870.8
+13940.6
+""CONSUMER""
+""FURNITURE""
+""CHAIRS & CHAIRMATS""
+""OFFICE CHAIRS""
+""EXECUTIVE CHAIRS""
+-1806.31
+13465.46
+""CONSUMER""
+""FURNITURE""
+""CHAIRS & CHAIRMATS""
+""OFFICE CHAIRS""
+""STACKING AND FOLDING CHAIRS""
+1051.31
+19022.98
+""CONSUMER""
+""FURNITURE""
+""CHAIRS & CHAIRMATS""
+""OFFICE CHAIRS""
+""TASK CHAIRS""
+189.03
+3937.72
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""CLOCKS""
+""CLOCKS""
+410.49
+6201.22
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""DESK LAMPS""
+""CLAMP ON LAMPS""
+402.98
+2844.76
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""DESK LAMPS""
+""MAGNIFIER LAMPS""
+23.53
+425.76
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""DOOR ACCESSORIES""
+""DOOR ACCESSORIES""
+18.11
+161.87
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""FLOOR LAMPS""
+""FLOOR LAMPS""
+-64.76
+203.96
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""FRAMES""
+""FRAMES""
+207.54
+7126.16
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""LIGHTING""
+""LIGHT BULBS""
+-29.08
+370.41
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""MATS""
+""MATS""
+1937.8
+13400.56
+""CONSUMER""
+""FURNITURE""
+""OFFICE FURNISHINGS""
+""PLASTIC DESK SETS""
+""PLASTIC DESK SETS""
+-757.26
+1287.76
+""CONSUMER""
+""FURNITURE"""
+databricks,logical.staples.databricks,Staples.databricks,Filter.Q_date_instance_filter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Filter.Q_date_instance_filter.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Filter.Q_date_instance_filter.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1290.0,"
+      SELECT `Staples`.`Order_Date` AS `order_date`,
+  SUM(1) AS `cnt_number_of_records_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((`Staples`.`Order_Date` >= CAST('1998-02-09 00:00:00' AS TIMESTAMP)) AND (`Staples`.`Order_Date` <= CAST('1998-07-03 23:59:59' AS TIMESTAMP)))
+GROUP BY 1
+    ","#1998-02-09 00:00:00#
+21
+#1998-02-10 00:00:00#
+28
+#1998-02-11 00:00:00#
+35
+#1998-02-12 00:00:00#
+22
+#1998-02-13 00:00:00#
+41
+#1998-02-14 00:00:00#
+13
+#1998-02-15 00:00:00#
+15
+#1998-02-16 00:00:00#
+22
+#1998-02-17 00:00:00#
+15
+#1998-02-18 00:00:00#
+19
+#1998-02-19 00:00:00#
+13
+#1998-02-20 00:00:00#
+25
+#1998-02-21 00:00:00#
+49
+#1998-02-22 00:00:00#
+23
+#1998-02-23 00:00:00#
+41
+#1998-02-24 00:00:00#
+11
+#1998-02-25 00:00:00#
+28
+#1998-02-26 00:00:00#
+24
+#1998-02-27 00:00:00#
+41
+#1998-02-28 00:00:00#
+46
+#1998-03-01 00:00:00#
+18
+#1998-03-02 00:00:00#
+15
+#1998-03-03 00:00:00#
+39
+#1998-03-04 00:00:00#
+36
+#1998-03-05 00:00:00#
+17
+#1998-03-06 00:00:00#
+24
+#1998-03-07 00:00:00#
+6
+#1998-03-08 00:00:00#
+47
+#1998-03-09 00:00:00#
+28
+#1998-03-10 00:00:00#
+46
+#1998-03-11 00:00:00#
+6
+#1998-03-12 00:00:00#
+19
+#1998-03-13 00:00:00#
+28
+#1998-03-14 00:00:00#
+30
+#1998-03-15 00:00:00#
+22
+#1998-03-16 00:00:00#
+17
+#1998-03-17 00:00:00#
+20
+#1998-03-18 00:00:00#
+26
+#1998-03-19 00:00:00#
+9
+#1998-03-20 00:00:00#
+12
+#1998-03-21 00:00:00#
+18
+#1998-03-22 00:00:00#
+26
+#1998-03-23 00:00:00#
+12
+#1998-03-24 00:00:00#
+13
+#1998-03-25 00:00:00#
+26
+#1998-03-26 00:00:00#
+22
+#1998-03-27 00:00:00#
+12
+#1998-03-28 00:00:00#
+13
+#1998-03-29 00:00:00#
+24
+#1998-03-30 00:00:00#
+23","#1998-02-09 00:00:00#
+21
+#1998-02-10 00:00:00#
+28
+#1998-02-11 00:00:00#
+35
+#1998-02-12 00:00:00#
+22
+#1998-02-13 00:00:00#
+41
+#1998-02-14 00:00:00#
+13
+#1998-02-15 00:00:00#
+15
+#1998-02-16 00:00:00#
+22
+#1998-02-17 00:00:00#
+15
+#1998-02-18 00:00:00#
+19
+#1998-02-19 00:00:00#
+13
+#1998-02-20 00:00:00#
+25
+#1998-02-21 00:00:00#
+49
+#1998-02-22 00:00:00#
+23
+#1998-02-23 00:00:00#
+41
+#1998-02-24 00:00:00#
+11
+#1998-02-25 00:00:00#
+28
+#1998-02-26 00:00:00#
+24
+#1998-02-27 00:00:00#
+41
+#1998-02-28 00:00:00#
+46
+#1998-03-01 00:00:00#
+18
+#1998-03-02 00:00:00#
+15
+#1998-03-03 00:00:00#
+39
+#1998-03-04 00:00:00#
+36
+#1998-03-05 00:00:00#
+17
+#1998-03-06 00:00:00#
+24
+#1998-03-07 00:00:00#
+6
+#1998-03-08 00:00:00#
+47
+#1998-03-09 00:00:00#
+28
+#1998-03-10 00:00:00#
+46
+#1998-03-11 00:00:00#
+6
+#1998-03-12 00:00:00#
+19
+#1998-03-13 00:00:00#
+28
+#1998-03-14 00:00:00#
+30
+#1998-03-15 00:00:00#
+22
+#1998-03-16 00:00:00#
+17
+#1998-03-17 00:00:00#
+20
+#1998-03-18 00:00:00#
+26
+#1998-03-19 00:00:00#
+9
+#1998-03-20 00:00:00#
+12
+#1998-03-21 00:00:00#
+18
+#1998-03-22 00:00:00#
+26
+#1998-03-23 00:00:00#
+12
+#1998-03-24 00:00:00#
+13
+#1998-03-25 00:00:00#
+26
+#1998-03-26 00:00:00#
+22
+#1998-03-27 00:00:00#
+12
+#1998-03-28 00:00:00#
+13
+#1998-03-29 00:00:00#
+24
+#1998-03-30 00:00:00#
+23"
+databricks,logical.staples.databricks,Staples.databricks,Filter.Q_date_month_instance_filter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Filter.Q_date_month_instance_filter.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Filter.Q_date_month_instance_filter.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1328.0,"
+      SELECT `Staples`.`Prod_Type2` AS `prod_type2`,
+  MONTH(`Staples`.`Order_Date`) AS `mn_order_date_ok`,
+  SUM(`Staples`.`Gross_Profit`) AS `sum_gross_profit_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE (MONTH(`Staples`.`Order_Date`) <= 8)
+GROUP BY 1,
+  2
+    ","""APPLIANCES""
+1
+144516.48
+""APPLIANCES""
+2
+97704.16
+""APPLIANCES""
+3
+87915.64
+""APPLIANCES""
+4
+93331.91
+""APPLIANCES""
+5
+121033.25
+""APPLIANCES""
+6
+133035.52
+""APPLIANCES""
+7
+76649.05
+""APPLIANCES""
+8
+107705.75
+""BINDERS AND BINDER ACCESSORIES""
+1
+160118.47
+""BINDERS AND BINDER ACCESSORIES""
+2
+138169.61
+""BINDERS AND BINDER ACCESSORIES""
+3
+183170.27
+""BINDERS AND BINDER ACCESSORIES""
+4
+210630.59
+""BINDERS AND BINDER ACCESSORIES""
+5
+249295.04
+""BINDERS AND BINDER ACCESSORIES""
+6
+227231.73
+""BINDERS AND BINDER ACCESSORIES""
+7
+224064.16
+""BINDERS AND BINDER ACCESSORIES""
+8
+213825.26
+""BOOKCASES""
+1
+30730.97
+""BOOKCASES""
+2
+4622.05
+""BOOKCASES""
+3
+28829.21
+""BOOKCASES""
+4
+-2331.62
+""BOOKCASES""
+5
+9870.95
+""BOOKCASES""
+6
+26657.7
+""BOOKCASES""
+7
+7681.92
+""BOOKCASES""
+8
+27868.12
+""CHAIRS & CHAIRMATS""
+1
+128133.36
+""CHAIRS & CHAIRMATS""
+2
+105074.06
+""CHAIRS & CHAIRMATS""
+3
+102070.23
+""CHAIRS & CHAIRMATS""
+4
+162000.01
+""CHAIRS & CHAIRMATS""
+5
+128434.92
+""CHAIRS & CHAIRMATS""
+6
+110570.63
+""CHAIRS & CHAIRMATS""
+7
+94758.41
+""CHAIRS & CHAIRMATS""
+8
+123841.71
+""COMPUTER PERIPHERALS""
+1
+142522.94
+""COMPUTER PERIPHERALS""","""APPLIANCES""
+1
+144516.48
+""APPLIANCES""
+2
+97704.16
+""APPLIANCES""
+3
+87915.64
+""APPLIANCES""
+4
+93331.91
+""APPLIANCES""
+5
+121033.25
+""APPLIANCES""
+6
+133035.52
+""APPLIANCES""
+7
+76649.05
+""APPLIANCES""
+8
+107705.75
+""BINDERS AND BINDER ACCESSORIES""
+1
+160118.47
+""BINDERS AND BINDER ACCESSORIES""
+2
+138169.61
+""BINDERS AND BINDER ACCESSORIES""
+3
+183170.27
+""BINDERS AND BINDER ACCESSORIES""
+4
+210630.59
+""BINDERS AND BINDER ACCESSORIES""
+5
+249295.04
+""BINDERS AND BINDER ACCESSORIES""
+6
+227231.73
+""BINDERS AND BINDER ACCESSORIES""
+7
+224064.16
+""BINDERS AND BINDER ACCESSORIES""
+8
+213825.26
+""BOOKCASES""
+1
+30730.97
+""BOOKCASES""
+2
+4622.05
+""BOOKCASES""
+3
+28829.21
+""BOOKCASES""
+4
+-2331.62
+""BOOKCASES""
+5
+9870.95
+""BOOKCASES""
+6
+26657.7
+""BOOKCASES""
+7
+7681.92
+""BOOKCASES""
+8
+27868.12
+""CHAIRS & CHAIRMATS""
+1
+128133.36
+""CHAIRS & CHAIRMATS""
+2
+105074.06
+""CHAIRS & CHAIRMATS""
+3
+102070.23
+""CHAIRS & CHAIRMATS""
+4
+162000.01
+""CHAIRS & CHAIRMATS""
+5
+128434.92
+""CHAIRS & CHAIRMATS""
+6
+110570.63
+""CHAIRS & CHAIRMATS""
+7
+94758.41
+""CHAIRS & CHAIRMATS""
+8
+123841.71
+""COMPUTER PERIPHERALS""
+1
+142522.94
+""COMPUTER PERIPHERALS"""
+databricks,logical.staples.databricks,Staples.databricks,Filter.Trademark,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Filter.Trademark.tableau_tdvt.xml,True,1,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Filter.Trademark.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1202.0,"
+      SELECT `Staples`.`Product_Name` AS `product_name`,
+  SUM(`Staples`.`Gross_Profit`) AS `sum_gross_profit_ok`,
+  SUM(`Staples`.`Sales_Total`) AS `sum_sales_total_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((`Staples`.`Product_Name` IN ('Acco Clips to Go™ Binder Clips, 24 Clips in Two Sizes', 'Acco Smartsocket™ Table Surge Protector, 6 Color-Coded Adapter Outlets', 'Acco® Hot Clips™ Clips to Go', 'Acme® Tagit™ Stainless Steel Antibacterial Scissors', 'Advantus SlideClip™ Paper Clips', 'Avery Binding System Hidden Tab™ Executive Style Index Sets', 'Avery Heavy-Duty EZD ™ Binder With Locking Rings', 'Avery Heavy-Duty EZD™ View Binder with Locking Rings', 'Avery Hi-Liter® EverBold™ Pen Style Fluorescent Highlighters, 4/Pack', 'Avery Personal Creations™ Heavyweight Cards', 'Avery® Hidden Tab™ Dividers for Binding Systems', 'Belkin 5 Outlet SurgeMaster™ Power Centers', 'Belkin ErgoBoard™ Keyboard', 'BIC® Brite Liner Grip™ Highlighters', 'BIC® Brite Liner Grip™ Highlighters, Assorted, 5/Pack', 'Boston 16801 Nautilus™ Battery Pencil Sharpener', 'Boston 1799 Powerhouse™ Electric Pencil Sharpener', 'Bravo II™ Megaboss® 12-Amp Hard Body Upright, Replacement Belts, 2 Belts per Pack', 'Clear Mylar™ Reinforcing Strips', 'Commercial WindTunnel™ Clean Air Upright Vacuum, Replacement Belts, Filtration Bags', 'Conquest™ 14 Commercial Heavy-Duty Upright Vacuum, Collection System, Accessory Kit', 'Crate-A-Files™', 'Deflect-o SuperTray™ Unbreakable Stackable Tray, Letter, Black', 'Deflect-O® Glasstique™ Clear Desk Accessories', 'DXL™ Angle-View Binders with Locking Rings by Samsill', 'DXL™ Angle-View Binders with Locking Rings, Black', 'Eldon Cleatmat Plus™ Chair Mats for High Pile Carpets', 'Eldon Jumbo ProFile™ Portable File Boxes Graphite/Black', 'Eldon Pizzaz™ Desk Accessories', 'Eldon ProFile™ File \'N Store™ Portable File Tub Letter/Legal Size Black', 'Eldon Shelf Savers™ Cubes and Bins', 'Eldon® Expressions™ Wood and Plastic Desk Accessories, Oak', 'Eldon® Expressions™ Wood Desk Accessories, Oak', 'Fellowes Officeware™ Wire Shelving', 'Fellowes Stor/Drawer® Steel Plus™ Storage Drawers', 'GBC Instant Index™ System for Binding Systems', 'GBC ProClick™ 150 Presentation Binding System', 'GBC Twin Loop™ Wire Binding Elements', 'GBC Twin Loop™ Wire Binding Elements, 9/16"" Spine, Black', 'GBC VeloBinder™ Manual Binding System', 'Global Adaptabilities™ Conference Tables', 'Global Enterprise™ Series Seating Low-Back Swivel/Tilt Chairs', 'Global Troy™ Executive Leather Low-Back Tilter', 'Hon 2111 Invitation™ Series Corner Table', 'Hon 2111 Invitation™ Series Straight Table', 'Hon iLevel™ Computer Training Table', 'Hon Mobius™ Operator\'s Chair', 'Hon Pagoda™ Stacking Chairs', 'Hon Valutask™ Swivel Chairs', 'Hoover Commercial Lightweight Upright Vacuum with E-Z Empty™ Dirt Cup', 'Hoover Portapower™ Portable Vacuum', 'Hoover Replacement Belts For Soft Guard™ & Commercial Ltweight Upright Vacs, 2/Pk', 'Hoover Shoulder Vac™ Commercial Portable Vacuum', 'Hoover WindTunnel™ Plus Canister Vacuum', 'Howard Miller 12-3/4 Diameter Accuwave DS ™ Wall Clock', 'Hunt PowerHouse™ Electric Pencil Sharpener, Blue', 'Jiffy™ Padded Mailers with Self-Seal Closure', 'Lifetime Advantage™ Folding Chairs, 4/Carton', 'Manco Dry-Lighter™ Erasable Highlighter', 'Park Ridge™ Embossed Executive Business Envelopes', 'Perma STOR-ALL™ Hanging File Box, 13 1/8""W x 12 1/4""D x 10 1/2""H', 'Personal Creations™ Ink Jet Cards and Labels', 'Pizazz® Global Quick File™', 'Redi-Strip™ #10 Envelopes, 4 1/8 x 9 1/2', 'SANFORD Liquid Accent™ Tank-Style Highlighters', 'SANFORD Major Accent™ Highlighters', 'Sanford Uni-Blazer™ View Highlighters, Chisel Tip, Yellow', 'SimpliFile™ Personal File, Black Granite, 15w x 6-15/16d x 11-1/4h', 'Sortfiler™ Multipurpose Personal File Organizer, Black', 'Southworth Structures Collection™', 'Space Solutions™ HD Industrial Steel Shelving.', 'Space Solutions™ Industrial Galvanized Steel Shelving.', 'Standard Line™ “While You Were Out” Hardbound Telephone Message Book', 'Storex Dura Pro™ Binders', 'Surelock™ Post Binders', 'Trimflex™ Flexible Post Binders', 'Tuf-Vin™ Binders', 'Tuff Stuff™ Recycled Round Ring Binders', 'U.S. Robotics V.90 56K Internal ISA Fax Modem with x2™ Technology, Fits Inside CPU', 'UniKeep™ View Case Binders', 'VariCap6™ Expandable Binder', 'Wilson Jones data.warehouse™ D-Ring Binders with DublLock®', 'Wilson Jones Easy Flow II™ Sheet Lifters', 'X-Rack™ File for Hanging Folders', 'XtraLife® ClearVue™ Slant-D Ring Binder, White, 3""', 'XtraLife® ClearVue™ Slant-D® Ring Binders by Cardinal')) OR ((`Staples`.`Product_Name` >= 'Binney & Smith inkTank™ Desk Highlighter, Chisel Tip, Yellow, 12/Box') AND (`Staples`.`Product_Name` <= 'Binney & Smith inkTank™ Erasable Pocket Highlighter, Chisel Tip, Yellow')) OR ((`Staples`.`Product_Name` >= 'Eldon Expressions™ Desk Accessory, Wood Pencil Holder, Oak') AND (`Staples`.`Product_Name` <= 'Eldon File Chest™ Portable File')) OR ((`Staples`.`Product_Name` >= 'Eldon® 100 Class™ Desk Accessories') AND (`Staples`.`Product_Name` <= 'Eldon® 500 Class™ Desk Accessories')) OR ((`Staples`.`Product_Name` >= 'Fellowes Bankers Box™ Recycled Super Stor/Drawer®') AND (`Staples`.`Product_Name` <= 'Fellowes Bankers Box™ Stor/Drawer® Steel Plus™')) OR ((`Staples`.`Product_Name` >= 'Global Comet™ Stacking Arm Chair') AND (`Staples`.`Product_Name` <= 'Global Commerce™ Series Low-Back Swivel/Tilt Chairs')) OR ((`Staples`.`Product_Name` >= 'Hon 4070 Series Pagoda™ Armless Upholstered Stacking Chairs') AND (`Staples`.`Product_Name` <= 'Hon 4700 Series Mobuis™ Mid-Back Task Chairs with Adjustable Arms')) OR ((`Staples`.`Product_Name` >= 'Polycom ViaVideo™ Desktop Video Communications Unit') AND (`Staples`.`Product_Name` <= 'Polycom ViewStation™ ISDN Videoconferencing Unit')))
+GROUP BY 1
+    ","""Acco Clips to Go™ Binder Clips, 24 Clips in Two Sizes""
+573.02
+2568.33
+""Acco Smartsocket™ Table Surge Protector, 6 Color-Coded Adapter Outlets""
+12958.36
+35295.15
+""Acco® Hot Clips™ Clips to Go""
+449.03
+2320.55
+""Acme® Tagit™ Stainless Steel Antibacterial Scissors""
+-1288.35
+7270.21
+""Advantus SlideClip™ Paper Clips""
+746.66
+1776.55
+""Avery Binding System Hidden Tab™ Executive Style Index Sets""
+-533.76
+3170.7
+""Avery Heavy-Duty EZD ™ Binder With Locking Rings""
+355.32
+3317.31
+""Avery Heavy-Duty EZD™ View Binder with Locking Rings""
+703.52
+4412.24
+""Avery Hi-Liter® EverBold™ Pen Style Fluorescent Highlighters, 4/Pack""
+1122.9
+6766.33
+""Avery Personal Creations™ Heavyweight Cards""
+1474.28
+8741.3
+""Avery® Hidden Tab™ Dividers for Binding Systems""
+-2068.91
+2223.14
+""BIC® Brite Liner Grip™ Highlighters""
+-98.59
+664.25
+""BIC® Brite Liner Grip™ Highlighters, Assorted, 5/Pack""
+794.28
+3874.11
+""Belkin 5 Outlet SurgeMaster™ Power Centers""
+14947.36
+37057.45
+""Belkin ErgoBoard™ Keyboard""
+6081.04
+51480.61
+""Binney & Smith inkTank™ Desk Highlighter, Chisel Tip, Yellow, 12/Box""
+-4774.92
+1542.83
+""Binney & Smith inkTank™ Erasable Desk Highlighter, Chisel Tip, Yellow, 12/Box""
+-2335.9
+2303.85
+""Binney & Smith inkTank™ Erasable Pocket Highlighter, Chisel Tip, Yellow""
+-2092.5
+1447.27
+""Boston 16801 Nautilus™ Battery Pencil Sharpener""
+2431.72
+15800.19
+""Boston 1799 Powerhouse™ Electric Pencil Sharpener""
+5853.87
+22532.51
+""Bravo II™ Megaboss® 12-Amp Hard Body Upright, Replacement Belts, 2 Belts per Pack""
+-21322.6
+2461.16
+""Clear Mylar™ Reinforcing Strips""
+1404.71
+11252.05
+""Commercial WindTunnel™ Clean Air Upright Vacuum, Replacement Belts, Filtration Bags""
+-3480.79
+3593.99
+""Conquest™ 14 Commercial Heavy-Duty Upright Vacuum, Collection System, Accessory Kit""
+11955.04
+54230.21
+""Crate-A-Files™""
+-1426.68
+5338.24
+""DXL™ Angle-View Binders with Locking Rings by Samsill""
+-607.39
+4266.51
+""DXL™ Angle-View Binders with Locking Rings, Black""
+-576.05
+3144.35
+""Deflect-O® Glasstique™ Clear Desk Accessories""
+-8.71
+5308.62
+""Deflect-o SuperTray™ Unbreakable Stackable Tray, Letter, Black""
+4702.49
+16977.79
+""Eldon Cleatmat Plus™ Chair Mats for High Pile Carpets""
+-16709.9
+50407.16
+""Eldon Expressions™ Desk Accessory, Wood Pencil Holder, Oak""
+-1632.6
+9987.16
+""Eldon Expressions™ Desk Accessory, Wood Photo Frame, Mahogany""
+733.42
+10123.78
+""Eldon Expressions™ Wood and Plastic Desk Accessories, Cherry Wood""
+-2699.76
+5223.68
+""Eldon File Chest™ Portable File""","""Acco Clips to Go™ Binder Clips, 24 Clips in Two Sizes""
+573.02
+2568.33
+""Acco Smartsocket™ Table Surge Protector, 6 Color-Coded Adapter Outlets""
+12958.36
+35295.15
+""Acco® Hot Clips™ Clips to Go""
+449.03
+2320.55
+""Acme® Tagit™ Stainless Steel Antibacterial Scissors""
+-1288.35
+7270.21
+""Advantus SlideClip™ Paper Clips""
+746.66
+1776.55
+""Avery Binding System Hidden Tab™ Executive Style Index Sets""
+-533.76
+3170.7
+""Avery Heavy-Duty EZD ™ Binder With Locking Rings""
+355.32
+3317.31
+""Avery Heavy-Duty EZD™ View Binder with Locking Rings""
+703.52
+4412.24
+""Avery Hi-Liter® EverBold™ Pen Style Fluorescent Highlighters, 4/Pack""
+1122.9
+6766.33
+""Avery Personal Creations™ Heavyweight Cards""
+1474.28
+8741.3
+""Avery® Hidden Tab™ Dividers for Binding Systems""
+-2068.91
+2223.14
+""BIC® Brite Liner Grip™ Highlighters""
+-98.59
+664.25
+""BIC® Brite Liner Grip™ Highlighters, Assorted, 5/Pack""
+794.28
+3874.11
+""Belkin 5 Outlet SurgeMaster™ Power Centers""
+14947.36
+37057.45
+""Belkin ErgoBoard™ Keyboard""
+6081.04
+51480.61
+""Binney & Smith inkTank™ Desk Highlighter, Chisel Tip, Yellow, 12/Box""
+-4774.92
+1542.83
+""Binney & Smith inkTank™ Erasable Desk Highlighter, Chisel Tip, Yellow, 12/Box""
+-2335.9
+2303.85
+""Binney & Smith inkTank™ Erasable Pocket Highlighter, Chisel Tip, Yellow""
+-2092.5
+1447.27
+""Boston 16801 Nautilus™ Battery Pencil Sharpener""
+2431.72
+15800.19
+""Boston 1799 Powerhouse™ Electric Pencil Sharpener""
+5853.87
+22532.51
+""Bravo II™ Megaboss® 12-Amp Hard Body Upright, Replacement Belts, 2 Belts per Pack""
+-21322.6
+2461.16
+""Clear Mylar™ Reinforcing Strips""
+1404.71
+11252.05
+""Commercial WindTunnel™ Clean Air Upright Vacuum, Replacement Belts, Filtration Bags""
+-3480.79
+3593.99
+""Conquest™ 14 Commercial Heavy-Duty Upright Vacuum, Collection System, Accessory Kit""
+11955.04
+54230.21
+""Crate-A-Files™""
+-1426.68
+5338.24
+""DXL™ Angle-View Binders with Locking Rings by Samsill""
+-607.39
+4266.51
+""DXL™ Angle-View Binders with Locking Rings, Black""
+-576.05
+3144.35
+""Deflect-O® Glasstique™ Clear Desk Accessories""
+-8.71
+5308.62
+""Deflect-o SuperTray™ Unbreakable Stackable Tray, Letter, Black""
+4702.49
+16977.79
+""Eldon Cleatmat Plus™ Chair Mats for High Pile Carpets""
+-16709.9
+50407.16
+""Eldon Expressions™ Desk Accessory, Wood Pencil Holder, Oak""
+-1632.6
+9987.16
+""Eldon Expressions™ Desk Accessory, Wood Photo Frame, Mahogany""
+733.42
+10123.78
+""Eldon Expressions™ Wood and Plastic Desk Accessories, Cherry Wood""
+-2699.76
+5223.68
+""Eldon File Chest™ Portable File"""
+databricks,logical.staples.databricks,Staples.databricks,Filter.slicing_Q_date_instance_filter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Filter.slicing_Q_date_instance_filter.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Filter.slicing_Q_date_instance_filter.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,988.0,"
+      SELECT `Staples`.`Prod_Type2` AS `prod_type2`,
+  SUM(`Staples`.`Gross_Profit`) AS `sum_gross_profit_ok`,
+  SUM(`Staples`.`Price`) AS `sum_price_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((`Staples`.`Order_Date` >= CAST('1998-02-09 00:00:00' AS TIMESTAMP)) AND (`Staples`.`Order_Date` <= CAST('1998-07-03 23:59:59' AS TIMESTAMP)))
+GROUP BY 1
+    ","""APPLIANCES""
+89646.98
+14618.77
+""BINDERS AND BINDER ACCESSORIES""
+195798.95
+23852.13
+""BOOKCASES""
+10347.42
+12060.54
+""CHAIRS & CHAIRMATS""
+89616.57
+22611.61
+""COMPUTER PERIPHERALS""
+87496.97
+12823.76
+""COPIERS AND FAX""
+260062.25
+21699.58
+""ENVELOPES""
+12829.57
+1900.77
+""LABELS""
+7387.64
+845.04
+""OFFICE FURNISHINGS""
+27257.91
+10577.27
+""OFFICE MACHINES""
+515148.07
+72578.74
+""PAPER""
+32705.85
+7338.51
+""PENS & ART SUPPLIES""
+11466.15
+2755.51
+""RUBBER BANDS""
+391.42
+221.37
+""SCISSORS, RULERS AND TRIMMERS""
+5224.7
+5373.83
+""STORAGE & ORGANIZATION""
+30037.19
+17851.4
+""TABLES""
+48328.06
+37087.27
+""TELEPHONES AND COMMUNICATION""
+319945.65
+35566.43","""APPLIANCES""
+89646.98
+14618.77
+""BINDERS AND BINDER ACCESSORIES""
+195798.95
+23852.13
+""BOOKCASES""
+10347.42
+12060.54
+""CHAIRS & CHAIRMATS""
+89616.57
+22611.61
+""COMPUTER PERIPHERALS""
+87496.97
+12823.76
+""COPIERS AND FAX""
+260062.25
+21699.58
+""ENVELOPES""
+12829.57
+1900.77
+""LABELS""
+7387.64
+845.04
+""OFFICE FURNISHINGS""
+27257.91
+10577.27
+""OFFICE MACHINES""
+515148.07
+72578.74
+""PAPER""
+32705.85
+7338.51
+""PENS & ART SUPPLIES""
+11466.15
+2755.51
+""RUBBER BANDS""
+391.42
+221.37
+""SCISSORS, RULERS AND TRIMMERS""
+5224.7
+5373.83
+""STORAGE & ORGANIZATION""
+30037.19
+17851.4
+""TABLES""
+48328.06
+37087.27
+""TELEPHONES AND COMMUNICATION""
+319945.65
+35566.43"
+databricks,logical.staples.databricks,Staples.databricks,Filter.slicing_Q_date_month_instance_filter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Filter.slicing_Q_date_month_instance_filter.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Filter.slicing_Q_date_month_instance_filter.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,474.0,"
+      SELECT MONTH(`Staples`.`Order_Date`) AS `mn_order_date_qk`
+FROM `tableau_tdvt`.`staples` `Staples`
+    ","1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1","1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1"
+databricks,logical.staples.databricks,Staples.databricks,Query.Dates_MDY,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Dates_MDY.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Dates_MDY.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1005.0,"
+      SELECT (((YEAR(`Staples`.`Order_Date`) * 10000) + (MONTH(`Staples`.`Order_Date`) * 100)) + DAY(`Staples`.`Order_Date`)) AS `md_order_date_ok`,
+  SUM(`Staples`.`Gross_Profit`) AS `sum_gross_profit_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1
+    ","19970101
+23274.61
+19970102
+12205.73
+19970103
+11166.91
+19970104
+14346.97
+19970105
+5389.37
+19970106
+14545.59
+19970107
+15464.29
+19970108
+21726.68
+19970109
+22153.92
+19970110
+4048.43
+19970111
+18067.98
+19970112
+14314.07
+19970113
+35059.5
+19970114
+14793.48
+19970115
+12543.13
+19970116
+2758.59
+19970117
+20905.54
+19970118
+5560.55
+19970119
+13112.72
+19970120
+27937.1
+19970121
+12901.73
+19970122
+2477.71
+19970123
+16693.27
+19970124
+9260.75
+19970125
+12311.8
+19970126
+17658.47
+19970127
+10462.44
+19970128
+7994.27
+19970129
+4360.12
+19970130
+3702.09
+19970131
+6465.5
+19970201
+4156.76
+19970202
+16542.77
+19970203
+7658.36
+19970204
+-184.19
+19970205
+7968.14
+19970206
+26095.46
+19970207
+10063.32
+19970208
+14774.39
+19970209
+14135.8
+19970210
+25366.86
+19970211
+3795.46
+19970212
+6070.55
+19970213
+15574.21
+19970214
+6853.58
+19970215
+9811.71
+19970216
+8965.65
+19970217
+6702.13
+19970218
+24396.84
+19970219
+16187.35","19970101
+23274.61
+19970102
+12205.73
+19970103
+11166.91
+19970104
+14346.97
+19970105
+5389.37
+19970106
+14545.59
+19970107
+15464.29
+19970108
+21726.68
+19970109
+22153.92
+19970110
+4048.43
+19970111
+18067.98
+19970112
+14314.07
+19970113
+35059.5
+19970114
+14793.48
+19970115
+12543.13
+19970116
+2758.59
+19970117
+20905.54
+19970118
+5560.55
+19970119
+13112.72
+19970120
+27937.1
+19970121
+12901.73
+19970122
+2477.71
+19970123
+16693.27
+19970124
+9260.75
+19970125
+12311.8
+19970126
+17658.47
+19970127
+10462.44
+19970128
+7994.27
+19970129
+4360.12
+19970130
+3702.09
+19970131
+6465.5
+19970201
+4156.76
+19970202
+16542.77
+19970203
+7658.36
+19970204
+-184.19
+19970205
+7968.14
+19970206
+26095.46
+19970207
+10063.32
+19970208
+14774.39
+19970209
+14135.8
+19970210
+25366.86
+19970211
+3795.46
+19970212
+6070.55
+19970213
+15574.21
+19970214
+6853.58
+19970215
+9811.71
+19970216
+8965.65
+19970217
+6702.13
+19970218
+24396.84
+19970219
+16187.35"
+databricks,logical.staples.databricks,Staples.databricks,Query.Dates_MDY_Filtered,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Dates_MDY_Filtered.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Dates_MDY_Filtered.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1443.0,"
+      SELECT (((YEAR(`Staples`.`Order_Date`) * 10000) + (MONTH(`Staples`.`Order_Date`) * 100)) + DAY(`Staples`.`Order_Date`)) AS `md_order_date_ok`,
+  SUM(`Staples`.`Gross_Profit`) AS `sum_gross_profit_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((((((YEAR(`Staples`.`Order_Date`) * 10000) + (MONTH(`Staples`.`Order_Date`) * 100)) + DAY(`Staples`.`Order_Date`)) >= 19970102) AND ((((YEAR(`Staples`.`Order_Date`) * 10000) + (MONTH(`Staples`.`Order_Date`) * 100)) + DAY(`Staples`.`Order_Date`)) <= 19970107)) OR (((((YEAR(`Staples`.`Order_Date`) * 10000) + (MONTH(`Staples`.`Order_Date`) * 100)) + DAY(`Staples`.`Order_Date`)) >= 19970109) AND ((((YEAR(`Staples`.`Order_Date`) * 10000) + (MONTH(`Staples`.`Order_Date`) * 100)) + DAY(`Staples`.`Order_Date`)) <= 19970117)) OR (((((YEAR(`Staples`.`Order_Date`) * 10000) + (MONTH(`Staples`.`Order_Date`) * 100)) + DAY(`Staples`.`Order_Date`)) >= 19970119) AND ((((YEAR(`Staples`.`Order_Date`) * 10000) + (MONTH(`Staples`.`Order_Date`) * 100)) + DAY(`Staples`.`Order_Date`)) <= 20021231)))
+GROUP BY 1
+    ","19970102
+12205.73
+19970103
+11166.91
+19970104
+14346.97
+19970105
+5389.37
+19970106
+14545.59
+19970107
+15464.29
+19970109
+22153.92
+19970110
+4048.43
+19970111
+18067.98
+19970112
+14314.07
+19970113
+35059.5
+19970114
+14793.48
+19970115
+12543.13
+19970116
+2758.59
+19970117
+20905.54
+19970119
+13112.72
+19970120
+27937.1
+19970121
+12901.73
+19970122
+2477.71
+19970123
+16693.27
+19970124
+9260.75
+19970125
+12311.8
+19970126
+17658.47
+19970127
+10462.44
+19970128
+7994.27
+19970129
+4360.12
+19970130
+3702.09
+19970131
+6465.5
+19970201
+4156.76
+19970202
+16542.77
+19970203
+7658.36
+19970204
+-184.19
+19970205
+7968.14
+19970206
+26095.46
+19970207
+10063.32
+19970208
+14774.39
+19970209
+14135.8
+19970210
+25366.86
+19970211
+3795.46
+19970212
+6070.55
+19970213
+15574.21
+19970214
+6853.58
+19970215
+9811.71
+19970216
+8965.65
+19970217
+6702.13
+19970218
+24396.84
+19970219
+16187.35
+19970220
+19329.18
+19970221
+-321.31
+19970222
+4972.74","19970102
+12205.73
+19970103
+11166.91
+19970104
+14346.97
+19970105
+5389.37
+19970106
+14545.59
+19970107
+15464.29
+19970109
+22153.92
+19970110
+4048.43
+19970111
+18067.98
+19970112
+14314.07
+19970113
+35059.5
+19970114
+14793.48
+19970115
+12543.13
+19970116
+2758.59
+19970117
+20905.54
+19970119
+13112.72
+19970120
+27937.1
+19970121
+12901.73
+19970122
+2477.71
+19970123
+16693.27
+19970124
+9260.75
+19970125
+12311.8
+19970126
+17658.47
+19970127
+10462.44
+19970128
+7994.27
+19970129
+4360.12
+19970130
+3702.09
+19970131
+6465.5
+19970201
+4156.76
+19970202
+16542.77
+19970203
+7658.36
+19970204
+-184.19
+19970205
+7968.14
+19970206
+26095.46
+19970207
+10063.32
+19970208
+14774.39
+19970209
+14135.8
+19970210
+25366.86
+19970211
+3795.46
+19970212
+6070.55
+19970213
+15574.21
+19970214
+6853.58
+19970215
+9811.71
+19970216
+8965.65
+19970217
+6702.13
+19970218
+24396.84
+19970219
+16187.35
+19970220
+19329.18
+19970221
+-321.31
+19970222
+4972.74"
+databricks,logical.staples.databricks,Staples.databricks,Query.FilterBy_DateTime_Slices,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.FilterBy_DateTime_Slices.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.FilterBy_DateTime_Slices.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2911.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(`Staples`.`Customer_Balance`) AS `sum_customer_balance_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+  JOIN (
+  SELECT `Staples`.`Customer_Name` AS `customer_name`,
+    SUM(1) AS `x_measure__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+  HAVING (SUM(1) < 1000)
+) `t0` ON (`Staples`.`Customer_Name` = `t0`.`customer_name`)
+WHERE ((`Staples`.`Order_Date` >= CAST('1997-01-01 00:00:00' AS TIMESTAMP)) AND (`Staples`.`Order_Date` <= CAST('1999-12-22 13:26:54' AS TIMESTAMP)) AND (`Staples`.`Ship_Mode` NOT IN ('DELIVERY TRUCK')) AND ((YEAR(`Staples`.`Order_Date`) IN (2002)) OR ((YEAR(`Staples`.`Order_Date`) >= 1998) AND (YEAR(`Staples`.`Order_Date`) <= 2000))))
+GROUP BY 1
+    ","""Barbara Fisher""
+810852.0
+""Dario Medina""
+665294.0
+""Dave Hallsten""
+464823.0
+""David Flashing""
+784989.0
+""David Wiener""
+1112437.0
+""Deanra Eno""
+831445.0
+""Debra Catini-Entman""
+800564.0
+""Elizabeth Moffitt""
+919596.0
+""Ellis Ballard""
+900220.0
+""Frank Olsen""
+646440.0
+""Grace Kelly""
+1094864.0
+""Hallie Redmond""
+986910.0
+""Harold Pawlan""
+923244.0
+""Heather Jas-Hannaway""
+680507.0
+""Henia Zydlo""
+722652.0
+""Herbert Flentye""
+700813.0
+""Hilary Holden""
+1176665.0
+""Jack O'Briant""
+702633.0
+""Jane Waco""
+650527.0
+""Jas O'Carroll""
+567067.0
+""Jason Gross""
+1047955.0
+""Jasper Cacioppo""
+1213588.0
+""Jennifer Patt""
+750007.0
+""Jesus Ocampo""
+1059996.0
+""Jim Sink""
+1137689.0
+""Joseph Airdo""
+292587.0
+""Karen Seio""
+1270616.0
+""Laura Armstrong""
+830032.0
+""Lela Donovan""
+1003977.0
+""Lena Cacioppo""
+1339421.0
+""Lynn Smith-Reed""
+1315451.0
+""Mary O'Rourke""
+804203.0
+""Mary Zewe""
+825312.0
+""MaryBeth Skach""
+1235557.0
+""Mathew Reese""
+508608.0
+""Maurice Satty""
+1003324.0
+""Maxwell Schwartz""
+725218.0
+""Meg O'Connel""
+492716.0
+""Meg Tillman-Sachs""
+1241470.0
+""Michael Moore""
+789461.0
+""Michael Oakman""
+921162.0
+""Naresj Patel""
+1039748.0
+""Nathan Mautz""
+1363244.0
+""Noel Staavos""
+980430.0
+""Nona Balk""
+995128.0
+""Olvera Toch""
+1251383.0
+""Patrick O'Brill""
+769898.0
+""Paul Prost""
+680254.0
+""Peter McVee""
+789660.0
+""Pierre Wener""
+1078418.0","""Barbara Fisher""
+810852.0
+""Dario Medina""
+665294.0
+""Dave Hallsten""
+464823.0
+""David Flashing""
+784989.0
+""David Wiener""
+1112437.0
+""Deanra Eno""
+831445.0
+""Debra Catini-Entman""
+800564.0
+""Elizabeth Moffitt""
+919596.0
+""Ellis Ballard""
+900220.0
+""Frank Olsen""
+646440.0
+""Grace Kelly""
+1094864.0
+""Hallie Redmond""
+986910.0
+""Harold Pawlan""
+923244.0
+""Heather Jas-Hannaway""
+680507.0
+""Henia Zydlo""
+722652.0
+""Herbert Flentye""
+700813.0
+""Hilary Holden""
+1176665.0
+""Jack O'Briant""
+702633.0
+""Jane Waco""
+650527.0
+""Jas O'Carroll""
+567067.0
+""Jason Gross""
+1047955.0
+""Jasper Cacioppo""
+1213588.0
+""Jennifer Patt""
+750007.0
+""Jesus Ocampo""
+1059996.0
+""Jim Sink""
+1137689.0
+""Joseph Airdo""
+292587.0
+""Karen Seio""
+1270616.0
+""Laura Armstrong""
+830032.0
+""Lela Donovan""
+1003977.0
+""Lena Cacioppo""
+1339421.0
+""Lynn Smith-Reed""
+1315451.0
+""Mary O'Rourke""
+804203.0
+""Mary Zewe""
+825312.0
+""MaryBeth Skach""
+1235557.0
+""Mathew Reese""
+508608.0
+""Maurice Satty""
+1003324.0
+""Maxwell Schwartz""
+725218.0
+""Meg O'Connel""
+492716.0
+""Meg Tillman-Sachs""
+1241470.0
+""Michael Moore""
+789461.0
+""Michael Oakman""
+921162.0
+""Naresj Patel""
+1039748.0
+""Nathan Mautz""
+1363244.0
+""Noel Staavos""
+980430.0
+""Nona Balk""
+995128.0
+""Olvera Toch""
+1251383.0
+""Patrick O'Brill""
+769898.0
+""Paul Prost""
+680254.0
+""Peter McVee""
+789660.0
+""Pierre Wener""
+1078418.0"
+databricks,logical.staples.databricks,Staples.databricks,Query.FilterBy_Q,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.FilterBy_Q.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.FilterBy_Q.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1345.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(`Staples`.`Customer_Balance`) AS `sum_customer_balance_ok`,
+  AVG(`Staples`.`Discount`) AS `x_measure__0`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1
+HAVING (AVG(`Staples`.`Discount`) < 0.070000000000000007)
+    ","""Barbara Fisher""
+2903943.0
+""Dario Medina""
+2061846.0
+""Dave Hallsten""
+1648480.0
+""David Flashing""
+3446006.0
+""David Wiener""
+3885765.0
+""Deanra Eno""
+2867586.0
+""Debra Catini-Entman""
+2264258.0
+""Elizabeth Moffitt""
+3230009.0
+""Ellis Ballard""
+3524373.0
+""Frank Olsen""
+3196838.0
+""Grace Kelly""
+3554045.0
+""Hallie Redmond""
+3400961.0
+""Harold Pawlan""
+2983868.0
+""Heather Jas-Hannaway""
+2594333.0
+""Henia Zydlo""
+2676295.0
+""Herbert Flentye""
+2507450.0
+""Hilary Holden""
+4314073.0
+""Jack O'Briant""
+1836645.0
+""Jane Waco""
+2529969.0
+""Jas O'Carroll""
+2230480.0
+""Jason Gross""
+3850271.0
+""Jasper Cacioppo""
+4013536.0
+""Jennifer Patt""
+2904238.0
+""Jesus Ocampo""
+4318228.0
+""Jim Sink""
+3176250.0
+""Joseph Airdo""
+1306316.0
+""Karen Seio""
+5074689.0
+""Laura Armstrong""
+2865910.0
+""Lela Donovan""
+3819713.0
+""Lena Cacioppo""
+4387205.0
+""Lynn Smith-Reed""
+4585698.0
+""Mary O'Rourke""
+3447191.0
+""Mary Zewe""
+3296799.0
+""MaryBeth Skach""
+3861193.0
+""Mathew Reese""
+2308376.0
+""Maurice Satty""
+3420618.0
+""Maxwell Schwartz""
+2430604.0
+""Meg O'Connel""
+2135079.0
+""Meg Tillman-Sachs""
+3831344.0
+""Michael Moore""
+2196434.0
+""Michael Oakman""
+3229418.0
+""Naresj Patel""
+4323767.0
+""Nathan Mautz""
+3703508.0
+""Noel Staavos""
+2854162.0
+""Nona Balk""
+2967836.0
+""Olvera Toch""
+3898824.0
+""Patrick O'Brill""
+3353491.0
+""Paul Prost""
+2460426.0
+""Peter McVee""
+1849223.0
+""Pierre Wener""
+3907566.0","""Barbara Fisher""
+2903943.0
+""Dario Medina""
+2061846.0
+""Dave Hallsten""
+1648480.0
+""David Flashing""
+3446006.0
+""David Wiener""
+3885765.0
+""Deanra Eno""
+2867586.0
+""Debra Catini-Entman""
+2264258.0
+""Elizabeth Moffitt""
+3230009.0
+""Ellis Ballard""
+3524373.0
+""Frank Olsen""
+3196838.0
+""Grace Kelly""
+3554045.0
+""Hallie Redmond""
+3400961.0
+""Harold Pawlan""
+2983868.0
+""Heather Jas-Hannaway""
+2594333.0
+""Henia Zydlo""
+2676295.0
+""Herbert Flentye""
+2507450.0
+""Hilary Holden""
+4314073.0
+""Jack O'Briant""
+1836645.0
+""Jane Waco""
+2529969.0
+""Jas O'Carroll""
+2230480.0
+""Jason Gross""
+3850271.0
+""Jasper Cacioppo""
+4013536.0
+""Jennifer Patt""
+2904238.0
+""Jesus Ocampo""
+4318228.0
+""Jim Sink""
+3176250.0
+""Joseph Airdo""
+1306316.0
+""Karen Seio""
+5074689.0
+""Laura Armstrong""
+2865910.0
+""Lela Donovan""
+3819713.0
+""Lena Cacioppo""
+4387205.0
+""Lynn Smith-Reed""
+4585698.0
+""Mary O'Rourke""
+3447191.0
+""Mary Zewe""
+3296799.0
+""MaryBeth Skach""
+3861193.0
+""Mathew Reese""
+2308376.0
+""Maurice Satty""
+3420618.0
+""Maxwell Schwartz""
+2430604.0
+""Meg O'Connel""
+2135079.0
+""Meg Tillman-Sachs""
+3831344.0
+""Michael Moore""
+2196434.0
+""Michael Oakman""
+3229418.0
+""Naresj Patel""
+4323767.0
+""Nathan Mautz""
+3703508.0
+""Noel Staavos""
+2854162.0
+""Nona Balk""
+2967836.0
+""Olvera Toch""
+3898824.0
+""Patrick O'Brill""
+3353491.0
+""Paul Prost""
+2460426.0
+""Peter McVee""
+1849223.0
+""Pierre Wener""
+3907566.0"
+databricks,logical.staples.databricks,Staples.databricks,Query.Filter_AVG,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_AVG.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_AVG.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1149.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  AVG(`Staples`.`Customer_Balance`) AS `avg_customer_balance_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1
+HAVING ((AVG(`Staples`.`Customer_Balance`) >= 252.99999999999747) AND (AVG(`Staples`.`Customer_Balance`) <= 3702.7330280000369))
+    ","""Dario Medina""
+2340.3473
+""Dave Hallsten""
+3448.7029
+""Debra Catini-Entman""
+3483.4738
+""Harold Pawlan""
+3308.0576
+""Heather Jas-Hannaway""
+3623.3701
+""Jack O'Briant""
+3452.3402
+""Jas O'Carroll""
+3256.1752
+""Joseph Airdo""
+3095.5355
+""Laura Armstrong""
+3516.454
+""Mary Zewe""
+3626.8416
+""Mathew Reese""
+2990.1244
+""Maxwell Schwartz""
+2819.7262
+""Meg O'Connel""
+3421.601
+""Michael Moore""
+3160.3367
+""Noel Staavos""
+3150.2892
+""Peter McVee""
+2619.296
+""Rick Reed""
+3533.5667
+""Rose O'Brian-Murray""
+3402.6851
+""Sheri Gordon""
+3340.444
+""Skye Norling-Christen""
+3681.3615
+""Steven Roelle""
+2838.6091
+""Sue Ann Reed-Freeman""
+3296.0575
+""Thomas Boland""
+3117.3761
+""Tonja Turnell""
+3569.099","""Dario Medina""
+2340.3473
+""Dave Hallsten""
+3448.7029
+""Debra Catini-Entman""
+3483.4738
+""Harold Pawlan""
+3308.0576
+""Heather Jas-Hannaway""
+3623.3701
+""Jack O'Briant""
+3452.3402
+""Jas O'Carroll""
+3256.1752
+""Joseph Airdo""
+3095.5355
+""Laura Armstrong""
+3516.454
+""Mary Zewe""
+3626.8416
+""Mathew Reese""
+2990.1244
+""Maxwell Schwartz""
+2819.7262
+""Meg O'Connel""
+3421.601
+""Michael Moore""
+3160.3367
+""Noel Staavos""
+3150.2892
+""Peter McVee""
+2619.296
+""Rick Reed""
+3533.5667
+""Rose O'Brian-Murray""
+3402.6851
+""Sheri Gordon""
+3340.444
+""Skye Norling-Christen""
+3681.3615
+""Steven Roelle""
+2838.6091
+""Sue Ann Reed-Freeman""
+3296.0575
+""Thomas Boland""
+3117.3761
+""Tonja Turnell""
+3569.099"
+databricks,logical.staples.databricks,Staples.databricks,Query.Filter_CNT,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_CNT.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_CNT.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1194.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(1) AS `cnt_customer_balance_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1
+HAVING (SUM(1) <= 577)
+    ","""Dave Hallsten""
+478
+""Frank Olsen""
+535
+""Herbert Flentye""
+573
+""Jack O'Briant""
+532
+""Joseph Airdo""
+422
+""Paul Prost""
+546
+""Sheri Gordon""
+518
+""Stephanie Ulpright""
+474
+""Sue Ann Reed-Freeman""
+574
+""Tracy Zic""
+575
+""William Brown""
+555","""Dave Hallsten""
+478
+""Frank Olsen""
+535
+""Herbert Flentye""
+573
+""Jack O'Briant""
+532
+""Joseph Airdo""
+422
+""Paul Prost""
+546
+""Sheri Gordon""
+518
+""Stephanie Ulpright""
+474
+""Sue Ann Reed-Freeman""
+574
+""Tracy Zic""
+575
+""William Brown""
+555"
+databricks,logical.staples.databricks,Staples.databricks,Query.Filter_Exclude1,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_Exclude1.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_Exclude1.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1370.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(`Staples`.`Customer_Balance`) AS `sum_customer_balance_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE (((`Staples`.`Customer_Name` >= 'Barbara Fisher') AND (`Staples`.`Customer_Name` <= 'Roy Skaria')) OR ((`Staples`.`Customer_Name` >= 'Sarah Jordon-Smith') AND (`Staples`.`Customer_Name` <= 'Zyzzy Zzuyzyzyk')))
+GROUP BY 1
+    ","""Barbara Fisher""
+2903943.0
+""Dario Medina""
+2061846.0
+""Dave Hallsten""
+1648480.0
+""David Flashing""
+3446006.0
+""David Wiener""
+3885765.0
+""Deanra Eno""
+2867586.0
+""Debra Catini-Entman""
+2264258.0
+""Elizabeth Moffitt""
+3230009.0
+""Ellis Ballard""
+3524373.0
+""Frank Olsen""
+3196838.0
+""Grace Kelly""
+3554045.0
+""Hallie Redmond""
+3400961.0
+""Harold Pawlan""
+2983868.0
+""Heather Jas-Hannaway""
+2594333.0
+""Henia Zydlo""
+2676295.0
+""Herbert Flentye""
+2507450.0
+""Hilary Holden""
+4314073.0
+""Jack O'Briant""
+1836645.0
+""Jane Waco""
+2529969.0
+""Jas O'Carroll""
+2230480.0
+""Jason Gross""
+3850271.0
+""Jasper Cacioppo""
+4013536.0
+""Jennifer Patt""
+2904238.0
+""Jesus Ocampo""
+4318228.0
+""Jim Sink""
+3176250.0
+""Joseph Airdo""
+1306316.0
+""Karen Seio""
+5074689.0
+""Laura Armstrong""
+2865910.0
+""Lela Donovan""
+3819713.0
+""Lena Cacioppo""
+4387205.0
+""Lynn Smith-Reed""
+4585698.0
+""Mary O'Rourke""
+3447191.0
+""Mary Zewe""
+3296799.0
+""MaryBeth Skach""
+3861193.0
+""Mathew Reese""
+2308376.0
+""Maurice Satty""
+3420618.0
+""Maxwell Schwartz""
+2430604.0
+""Meg O'Connel""
+2135079.0
+""Meg Tillman-Sachs""
+3831344.0
+""Michael Moore""
+2196434.0
+""Michael Oakman""
+3229418.0
+""Naresj Patel""
+4323767.0
+""Nathan Mautz""
+3703508.0
+""Noel Staavos""
+2854162.0
+""Nona Balk""
+2967836.0
+""Olvera Toch""
+3898824.0
+""Patrick O'Brill""
+3353491.0
+""Paul Prost""
+2460426.0
+""Peter McVee""
+1849223.0
+""Pierre Wener""
+3907566.0","""Barbara Fisher""
+2903943.0
+""Dario Medina""
+2061846.0
+""Dave Hallsten""
+1648480.0
+""David Flashing""
+3446006.0
+""David Wiener""
+3885765.0
+""Deanra Eno""
+2867586.0
+""Debra Catini-Entman""
+2264258.0
+""Elizabeth Moffitt""
+3230009.0
+""Ellis Ballard""
+3524373.0
+""Frank Olsen""
+3196838.0
+""Grace Kelly""
+3554045.0
+""Hallie Redmond""
+3400961.0
+""Harold Pawlan""
+2983868.0
+""Heather Jas-Hannaway""
+2594333.0
+""Henia Zydlo""
+2676295.0
+""Herbert Flentye""
+2507450.0
+""Hilary Holden""
+4314073.0
+""Jack O'Briant""
+1836645.0
+""Jane Waco""
+2529969.0
+""Jas O'Carroll""
+2230480.0
+""Jason Gross""
+3850271.0
+""Jasper Cacioppo""
+4013536.0
+""Jennifer Patt""
+2904238.0
+""Jesus Ocampo""
+4318228.0
+""Jim Sink""
+3176250.0
+""Joseph Airdo""
+1306316.0
+""Karen Seio""
+5074689.0
+""Laura Armstrong""
+2865910.0
+""Lela Donovan""
+3819713.0
+""Lena Cacioppo""
+4387205.0
+""Lynn Smith-Reed""
+4585698.0
+""Mary O'Rourke""
+3447191.0
+""Mary Zewe""
+3296799.0
+""MaryBeth Skach""
+3861193.0
+""Mathew Reese""
+2308376.0
+""Maurice Satty""
+3420618.0
+""Maxwell Schwartz""
+2430604.0
+""Meg O'Connel""
+2135079.0
+""Meg Tillman-Sachs""
+3831344.0
+""Michael Moore""
+2196434.0
+""Michael Oakman""
+3229418.0
+""Naresj Patel""
+4323767.0
+""Nathan Mautz""
+3703508.0
+""Noel Staavos""
+2854162.0
+""Nona Balk""
+2967836.0
+""Olvera Toch""
+3898824.0
+""Patrick O'Brill""
+3353491.0
+""Paul Prost""
+2460426.0
+""Peter McVee""
+1849223.0
+""Pierre Wener""
+3907566.0"
+databricks,logical.staples.databricks,Staples.databricks,Query.Filter_Include1,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_Include1.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_Include1.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1101.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(`Staples`.`Customer_Balance`) AS `sum_customer_balance_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE (`Staples`.`Customer_Name` = 'Hallie Redmond')
+GROUP BY 1
+    ","""Hallie Redmond""
+3400961.0","""Hallie Redmond""
+3400961.0"
+databricks,logical.staples.databricks,Staples.databricks,Query.Filter_MAX,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_MAX.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_MAX.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1052.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  MAX(`Staples`.`Customer_Balance`) AS `max_customer_balance_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1
+HAVING ((MAX(`Staples`.`Customer_Balance`) >= 7008.9899999999298) AND (MAX(`Staples`.`Customer_Balance`) <= 9000.0000000000891))
+    ","""Barbara Fisher""
+8082.0
+""Ellis Ballard""
+8878.0
+""Grace Kelly""
+8999.0
+""Hallie Redmond""
+7915.0
+""Herbert Flentye""
+8157.0
+""Jane Waco""
+8922.0
+""Jennifer Patt""
+8606.0
+""Maxwell Schwartz""
+8227.0
+""Meg Tillman-Sachs""
+8915.0
+""Noel Staavos""
+7055.0
+""Peter McVee""
+8438.0
+""Pierre Wener""
+8483.0
+""Quincy Jones""
+8396.0
+""Rose O'Brian-Murray""
+7618.0
+""Seth Vernon""
+8031.0
+""Shui Tom""
+8177.0
+""Steven Roelle""
+7557.0
+""Suzanne McNair""
+8667.0
+""Tracy Zic""
+7009.0","""Barbara Fisher""
+8082.0
+""Ellis Ballard""
+8878.0
+""Grace Kelly""
+8999.0
+""Hallie Redmond""
+7915.0
+""Herbert Flentye""
+8157.0
+""Jane Waco""
+8922.0
+""Jennifer Patt""
+8606.0
+""Maxwell Schwartz""
+8227.0
+""Meg Tillman-Sachs""
+8915.0
+""Noel Staavos""
+7055.0
+""Peter McVee""
+8438.0
+""Pierre Wener""
+8483.0
+""Quincy Jones""
+8396.0
+""Rose O'Brian-Murray""
+7618.0
+""Seth Vernon""
+8031.0
+""Shui Tom""
+8177.0
+""Steven Roelle""
+7557.0
+""Suzanne McNair""
+8667.0
+""Tracy Zic""
+7009.0"
+databricks,logical.staples.databricks,Staples.databricks,Query.Filter_MIN,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_MIN.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_MIN.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1415.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  MIN(`Staples`.`Customer_Balance`) AS `min_customer_balance_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1
+HAVING ((MIN(`Staples`.`Customer_Balance`) >= -988.00000000000989) AND (MIN(`Staples`.`Customer_Balance`) <= -99.999999999999005))
+    ","""Barbara Fisher""
+-396.0
+""Dario Medina""
+-574.0
+""Dave Hallsten""
+-902.0
+""David Flashing""
+-234.0
+""Deanra Eno""
+-875.0
+""Debra Catini-Entman""
+-377.0
+""Elizabeth Moffitt""
+-982.0
+""Ellis Ballard""
+-611.0
+""Frank Olsen""
+-949.0
+""Grace Kelly""
+-308.0
+""Hallie Redmond""
+-112.0
+""Harold Pawlan""
+-932.0
+""Heather Jas-Hannaway""
+-859.0
+""Henia Zydlo""
+-920.0
+""Hilary Holden""
+-556.0
+""Jack O'Briant""
+-614.0
+""Jane Waco""
+-526.0
+""Jas O'Carroll""
+-982.0
+""Jasper Cacioppo""
+-271.0
+""Jennifer Patt""
+-259.0
+""Jim Sink""
+-647.0
+""Joseph Airdo""
+-849.0
+""Laura Armstrong""
+-808.0
+""Lela Donovan""
+-110.0
+""Mary O'Rourke""
+-716.0
+""Mary Zewe""
+-550.0
+""MaryBeth Skach""
+-952.0
+""Mathew Reese""
+-987.0
+""Maxwell Schwartz""
+-655.0
+""Meg O'Connel""
+-545.0
+""Meg Tillman-Sachs""
+-567.0
+""Noel Staavos""
+-304.0
+""Nona Balk""
+-425.0
+""Peter McVee""
+-842.0
+""Rick Reed""
+-943.0
+""Robert Marley""
+-729.0
+""Rose O'Brian-Murray""
+-652.0
+""Roy Skaria""
+-302.0
+""Sandra Glassco""
+-588.0
+""Sarah Jordon-Smith""
+-868.0
+""Sharelle Roach-McGee""
+-326.0
+""Sheri Gordon""
+-501.0
+""Shui Tom""
+-920.0
+""Speros Goranitis""
+-762.0
+""Steven Roelle""
+-933.0
+""Sue Ann Reed-Freeman""
+-565.0
+""Suzanne McNair""
+-593.0
+""Tanja Norvell""
+-488.0
+""Thomas Boland""
+-897.0
+""Tonja Turnell""
+-923.0","""Barbara Fisher""
+-396.0
+""Dario Medina""
+-574.0
+""Dave Hallsten""
+-902.0
+""David Flashing""
+-234.0
+""Deanra Eno""
+-875.0
+""Debra Catini-Entman""
+-377.0
+""Elizabeth Moffitt""
+-982.0
+""Ellis Ballard""
+-611.0
+""Frank Olsen""
+-949.0
+""Grace Kelly""
+-308.0
+""Hallie Redmond""
+-112.0
+""Harold Pawlan""
+-932.0
+""Heather Jas-Hannaway""
+-859.0
+""Henia Zydlo""
+-920.0
+""Hilary Holden""
+-556.0
+""Jack O'Briant""
+-614.0
+""Jane Waco""
+-526.0
+""Jas O'Carroll""
+-982.0
+""Jasper Cacioppo""
+-271.0
+""Jennifer Patt""
+-259.0
+""Jim Sink""
+-647.0
+""Joseph Airdo""
+-849.0
+""Laura Armstrong""
+-808.0
+""Lela Donovan""
+-110.0
+""Mary O'Rourke""
+-716.0
+""Mary Zewe""
+-550.0
+""MaryBeth Skach""
+-952.0
+""Mathew Reese""
+-987.0
+""Maxwell Schwartz""
+-655.0
+""Meg O'Connel""
+-545.0
+""Meg Tillman-Sachs""
+-567.0
+""Noel Staavos""
+-304.0
+""Nona Balk""
+-425.0
+""Peter McVee""
+-842.0
+""Rick Reed""
+-943.0
+""Robert Marley""
+-729.0
+""Rose O'Brian-Murray""
+-652.0
+""Roy Skaria""
+-302.0
+""Sandra Glassco""
+-588.0
+""Sarah Jordon-Smith""
+-868.0
+""Sharelle Roach-McGee""
+-326.0
+""Sheri Gordon""
+-501.0
+""Shui Tom""
+-920.0
+""Speros Goranitis""
+-762.0
+""Steven Roelle""
+-933.0
+""Sue Ann Reed-Freeman""
+-565.0
+""Suzanne McNair""
+-593.0
+""Tanja Norvell""
+-488.0
+""Thomas Boland""
+-897.0
+""Tonja Turnell""
+-923.0"
+databricks,logical.staples.databricks,Staples.databricks,Query.Filter_SUM,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_SUM.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_SUM.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1232.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(`Staples`.`Customer_Balance`) AS `sum_customer_balance_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1
+HAVING ((SUM(`Staples`.`Customer_Balance`) >= -746.0000000000075) AND (SUM(`Staples`.`Customer_Balance`) <= 2384363.5474140239))
+    ","""Dario Medina""
+2061846.0
+""Dave Hallsten""
+1648480.0
+""Debra Catini-Entman""
+2264258.0
+""Jack O'Briant""
+1836645.0
+""Jas O'Carroll""
+2230480.0
+""Joseph Airdo""
+1306316.0
+""Mathew Reese""
+2308376.0
+""Meg O'Connel""
+2135079.0
+""Michael Moore""
+2196434.0
+""Peter McVee""
+1849223.0
+""Rose O'Brian-Murray""
+2096054.0
+""Sheri Gordon""
+1730350.0
+""Steven Roelle""
+1677618.0
+""Sue Ann Reed-Freeman""
+1891937.0
+""Tonja Turnell""
+2380589.0
+""Tracy Zic""
+2143477.0","""Dario Medina""
+2061846.0
+""Dave Hallsten""
+1648480.0
+""Debra Catini-Entman""
+2264258.0
+""Jack O'Briant""
+1836645.0
+""Jas O'Carroll""
+2230480.0
+""Joseph Airdo""
+1306316.0
+""Mathew Reese""
+2308376.0
+""Meg O'Connel""
+2135079.0
+""Michael Moore""
+2196434.0
+""Peter McVee""
+1849223.0
+""Rose O'Brian-Murray""
+2096054.0
+""Sheri Gordon""
+1730350.0
+""Steven Roelle""
+1677618.0
+""Sue Ann Reed-Freeman""
+1891937.0
+""Tonja Turnell""
+2380589.0
+""Tracy Zic""
+2143477.0"
+databricks,logical.staples.databricks,Staples.databricks,Query.Filter_SliceAggQ,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_SliceAggQ.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_SliceAggQ.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1256.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(`Staples`.`Customer_Balance`) AS `sum_customer_balance_ok`,
+  SUM(`Staples`.`Order_Quantity`) AS `sum_order_quantity_ok`,
+  AVG(`Staples`.`Discount`) AS `x_measure__0`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1
+HAVING ((AVG(`Staples`.`Discount`) >= 0.049244999999999504) AND (AVG(`Staples`.`Discount`) <= 0.060000000000000595))
+    ","""Barbara Fisher""
+2903943.0
+17229.0
+""Dario Medina""
+2061846.0
+22762.0
+""Dave Hallsten""
+1648480.0
+11238.0
+""David Flashing""
+3446006.0
+20240.0
+""David Wiener""
+3885765.0
+19995.0
+""Deanra Eno""
+2867586.0
+18924.0
+""Debra Catini-Entman""
+2264258.0
+16416.0
+""Elizabeth Moffitt""
+3230009.0
+17529.0
+""Ellis Ballard""
+3524373.0
+21248.0
+""Frank Olsen""
+3196838.0
+13689.0
+""Grace Kelly""
+3554045.0
+19140.0
+""Hallie Redmond""
+3400961.0
+20334.0
+""Harold Pawlan""
+2983868.0
+22765.0
+""Heather Jas-Hannaway""
+2594333.0
+17972.0
+""Henia Zydlo""
+2676295.0
+18380.0
+""Herbert Flentye""
+2507450.0
+14031.0
+""Hilary Holden""
+4314073.0
+21569.0
+""Jack O'Briant""
+1836645.0
+13932.0
+""Jane Waco""
+2529969.0
+16154.0
+""Jas O'Carroll""
+2230480.0
+17133.0
+""Jason Gross""
+3850271.0
+17415.0
+""Jasper Cacioppo""
+4013536.0
+22236.0
+""Jennifer Patt""
+2904238.0
+16461.0
+""Jesus Ocampo""
+4318228.0
+23948.0
+""Jim Sink""
+3176250.0
+16974.0
+""Joseph Airdo""
+1306316.0
+11175.0
+""Karen Seio""
+5074689.0
+21734.0
+""Laura Armstrong""
+2865910.0
+20975.0
+""Lela Donovan""
+3819713.0
+16383.0
+""Lena Cacioppo""
+4387205.0
+23158.0
+""Lynn Smith-Reed""
+4585698.0
+20871.0
+""Mary O'Rourke""
+3447191.0
+18749.0
+""MaryBeth Skach""
+3861193.0
+21836.0
+""Mathew Reese""","""Barbara Fisher""
+2903943.0
+17229.0
+""Dario Medina""
+2061846.0
+22762.0
+""Dave Hallsten""
+1648480.0
+11238.0
+""David Flashing""
+3446006.0
+20240.0
+""David Wiener""
+3885765.0
+19995.0
+""Deanra Eno""
+2867586.0
+18924.0
+""Debra Catini-Entman""
+2264258.0
+16416.0
+""Elizabeth Moffitt""
+3230009.0
+17529.0
+""Ellis Ballard""
+3524373.0
+21248.0
+""Frank Olsen""
+3196838.0
+13689.0
+""Grace Kelly""
+3554045.0
+19140.0
+""Hallie Redmond""
+3400961.0
+20334.0
+""Harold Pawlan""
+2983868.0
+22765.0
+""Heather Jas-Hannaway""
+2594333.0
+17972.0
+""Henia Zydlo""
+2676295.0
+18380.0
+""Herbert Flentye""
+2507450.0
+14031.0
+""Hilary Holden""
+4314073.0
+21569.0
+""Jack O'Briant""
+1836645.0
+13932.0
+""Jane Waco""
+2529969.0
+16154.0
+""Jas O'Carroll""
+2230480.0
+17133.0
+""Jason Gross""
+3850271.0
+17415.0
+""Jasper Cacioppo""
+4013536.0
+22236.0
+""Jennifer Patt""
+2904238.0
+16461.0
+""Jesus Ocampo""
+4318228.0
+23948.0
+""Jim Sink""
+3176250.0
+16974.0
+""Joseph Airdo""
+1306316.0
+11175.0
+""Karen Seio""
+5074689.0
+21734.0
+""Laura Armstrong""
+2865910.0
+20975.0
+""Lela Donovan""
+3819713.0
+16383.0
+""Lena Cacioppo""
+4387205.0
+23158.0
+""Lynn Smith-Reed""
+4585698.0
+20871.0
+""Mary O'Rourke""
+3447191.0
+18749.0
+""MaryBeth Skach""
+3861193.0
+21836.0
+""Mathew Reese"""
+databricks,logical.staples.databricks,Staples.databricks,Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_SliceAggQUnaggQUnaggDT_AxisQOYear.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1649.0,"
+      SELECT `Staples`.`Call_Center_Region` AS `call_center_region`,
+  `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(`Staples`.`Customer_Balance`) AS `sum_customer_balance_ok`,
+  SUM(`Staples`.`Order_Quantity`) AS `sum_order_quantity_ok`,
+  YEAR(`Staples`.`Order_Date`) AS `yr_order_date_ok`,
+  SUM(1) AS `x_measure__0`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((`Staples`.`Call_Center_Region` NOT IN ('CENTRAL')) AND (YEAR(`Staples`.`Order_Date`) IN (2001, 2002)) AND (`Staples`.`Discount` >= -0.001) AND (`Staples`.`Discount` <= 0.215172) AND (`Staples`.`Order_Date` >= CAST('1997-01-01 00:00:00' AS TIMESTAMP)) AND (`Staples`.`Order_Date` <= CAST('2002-06-01 00:00:00' AS TIMESTAMP)))
+GROUP BY 1,
+  2,
+  5
+HAVING ((SUM(1) <= 822) AND (SUM(`Staples`.`Customer_Balance`) >= -746.0000000000075) AND (SUM(`Staples`.`Customer_Balance`) <= 4074689.000000041))
+    ","""EAST""
+""Barbara Fisher""
+62180.0
+491.0
+2002
+""EAST""
+""Barbara Fisher""
+257629.0
+1135.0
+2001
+""EAST""
+""Dario Medina""
+88698.0
+680.0
+2002
+""EAST""
+""Dario Medina""
+108758.0
+1755.0
+2001
+""EAST""
+""Dave Hallsten""
+112045.0
+431.0
+2002
+""EAST""
+""Dave Hallsten""
+216261.0
+1239.0
+2001
+""EAST""
+""David Flashing""
+129300.0
+903.0
+2002
+""EAST""
+""David Flashing""
+290536.0
+1991.0
+2001
+""EAST""
+""David Wiener""
+88361.0
+401.0
+2002
+""EAST""
+""David Wiener""
+466789.0
+2453.0
+2001
+""EAST""
+""Deanra Eno""
+187930.0
+680.0
+2002
+""EAST""
+""Deanra Eno""
+309042.0
+2019.0
+2001
+""EAST""
+""Debra Catini-Entman""
+49439.0
+500.0
+2002
+""EAST""
+""Debra Catini-Entman""
+248659.0
+1576.0
+2001
+""EAST""
+""Elizabeth Moffitt""
+50749.0
+512.0
+2002
+""EAST""
+""Elizabeth Moffitt""
+315255.0
+2303.0
+2001
+""EAST""
+""Ellis Ballard""
+105488.0
+564.0
+2002
+""EAST""
+""Ellis Ballard""
+389843.0
+2186.0
+2001
+""EAST""
+""Frank Olsen""
+263523.0
+779.0
+2002
+""EAST""
+""Frank Olsen""
+347670.0
+1408.0
+2001","""EAST""
+""Barbara Fisher""
+62180.0
+491.0
+2002
+""EAST""
+""Barbara Fisher""
+257629.0
+1135.0
+2001
+""EAST""
+""Dario Medina""
+88698.0
+680.0
+2002
+""EAST""
+""Dario Medina""
+108758.0
+1755.0
+2001
+""EAST""
+""Dave Hallsten""
+112045.0
+431.0
+2002
+""EAST""
+""Dave Hallsten""
+216261.0
+1239.0
+2001
+""EAST""
+""David Flashing""
+129300.0
+903.0
+2002
+""EAST""
+""David Flashing""
+290536.0
+1991.0
+2001
+""EAST""
+""David Wiener""
+88361.0
+401.0
+2002
+""EAST""
+""David Wiener""
+466789.0
+2453.0
+2001
+""EAST""
+""Deanra Eno""
+187930.0
+680.0
+2002
+""EAST""
+""Deanra Eno""
+309042.0
+2019.0
+2001
+""EAST""
+""Debra Catini-Entman""
+49439.0
+500.0
+2002
+""EAST""
+""Debra Catini-Entman""
+248659.0
+1576.0
+2001
+""EAST""
+""Elizabeth Moffitt""
+50749.0
+512.0
+2002
+""EAST""
+""Elizabeth Moffitt""
+315255.0
+2303.0
+2001
+""EAST""
+""Ellis Ballard""
+105488.0
+564.0
+2002
+""EAST""
+""Ellis Ballard""
+389843.0
+2186.0
+2001
+""EAST""
+""Frank Olsen""
+263523.0
+779.0
+2002
+""EAST""
+""Frank Olsen""
+347670.0
+1408.0
+2001"
+databricks,logical.staples.databricks,Staples.databricks,Query.Filter_SliceAggQUnaggQ_AxisQ,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_SliceAggQUnaggQ_AxisQ.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_SliceAggQUnaggQ_AxisQ.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1247.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(`Staples`.`Customer_Balance`) AS `sum_customer_balance_ok`,
+  SUM(`Staples`.`Order_Quantity`) AS `sum_order_quantity_ok`,
+  SUM(1) AS `x_measure__0`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((`Staples`.`Discount` >= -0.001) AND (`Staples`.`Discount` <= 0.215172))
+GROUP BY 1
+HAVING ((SUM(1) <= 822) AND (SUM(`Staples`.`Customer_Balance`) >= -746.0000000000075) AND (SUM(`Staples`.`Customer_Balance`) <= 4074689.000000041))
+    ","""Barbara Fisher""
+2866777.0
+17044.0
+""Dave Hallsten""
+1639295.0
+11225.0
+""David Flashing""
+3428767.0
+20197.0
+""David Wiener""
+3850228.0
+19809.0
+""Deanra Eno""
+2818965.0
+18732.0
+""Debra Catini-Entman""
+2237137.0
+16314.0
+""Elizabeth Moffitt""
+3218378.0
+17476.0
+""Frank Olsen""
+3162315.0
+13549.0
+""Grace Kelly""
+3533810.0
+19028.0
+""Hallie Redmond""
+3379826.0
+20165.0
+""Heather Jas-Hannaway""
+2594709.0
+17929.0
+""Henia Zydlo""
+2656060.0
+18266.0
+""Herbert Flentye""
+2505716.0
+14005.0
+""Jack O'Briant""
+1834163.0
+13920.0
+""Jane Waco""
+2492567.0
+16049.0
+""Jas O'Carroll""
+2215329.0
+16935.0
+""Jason Gross""
+3817851.0
+17267.0
+""Jennifer Patt""
+2893104.0
+16399.0
+""Jim Sink""
+3159762.0
+16907.0
+""Joseph Airdo""
+1292405.0
+11128.0
+""Laura Armstrong""
+2853807.0
+20829.0
+""Lela Donovan""
+3788266.0
+16267.0
+""Mary O'Rourke""
+3445461.0
+18675.0
+""Mathew Reese""
+2267174.0
+19702.0
+""Maurice Satty""
+3416329.0
+16927.0
+""Meg O'Connel""
+2122087.0
+15686.0
+""Meg Tillman-Sachs""
+3824845.0
+20869.0
+""Michael Moore""
+2188904.0
+17145.0
+""Michael Oakman""
+3212028.0
+15997.0
+""Nathan Mautz""
+3676274.0
+21640.0
+""Nona Balk""
+2962869.0
+15143.0
+""Olvera Toch""
+3888092.0
+16522.0
+""Patrick O'Brill""
+3343468.0
+16663.0
+""Paul Prost""","""Barbara Fisher""
+2866777.0
+17044.0
+""Dave Hallsten""
+1639295.0
+11225.0
+""David Flashing""
+3428767.0
+20197.0
+""David Wiener""
+3850228.0
+19809.0
+""Deanra Eno""
+2818965.0
+18732.0
+""Debra Catini-Entman""
+2237137.0
+16314.0
+""Elizabeth Moffitt""
+3218378.0
+17476.0
+""Frank Olsen""
+3162315.0
+13549.0
+""Grace Kelly""
+3533810.0
+19028.0
+""Hallie Redmond""
+3379826.0
+20165.0
+""Heather Jas-Hannaway""
+2594709.0
+17929.0
+""Henia Zydlo""
+2656060.0
+18266.0
+""Herbert Flentye""
+2505716.0
+14005.0
+""Jack O'Briant""
+1834163.0
+13920.0
+""Jane Waco""
+2492567.0
+16049.0
+""Jas O'Carroll""
+2215329.0
+16935.0
+""Jason Gross""
+3817851.0
+17267.0
+""Jennifer Patt""
+2893104.0
+16399.0
+""Jim Sink""
+3159762.0
+16907.0
+""Joseph Airdo""
+1292405.0
+11128.0
+""Laura Armstrong""
+2853807.0
+20829.0
+""Lela Donovan""
+3788266.0
+16267.0
+""Mary O'Rourke""
+3445461.0
+18675.0
+""Mathew Reese""
+2267174.0
+19702.0
+""Maurice Satty""
+3416329.0
+16927.0
+""Meg O'Connel""
+2122087.0
+15686.0
+""Meg Tillman-Sachs""
+3824845.0
+20869.0
+""Michael Moore""
+2188904.0
+17145.0
+""Michael Oakman""
+3212028.0
+15997.0
+""Nathan Mautz""
+3676274.0
+21640.0
+""Nona Balk""
+2962869.0
+15143.0
+""Olvera Toch""
+3888092.0
+16522.0
+""Patrick O'Brill""
+3343468.0
+16663.0
+""Paul Prost"""
+databricks,logical.staples.databricks,Staples.databricks,Query.Filter_SliceAggQUnaggQ_AxisQO,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_SliceAggQUnaggQ_AxisQO.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_SliceAggQUnaggQ_AxisQO.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1444.0,"
+      SELECT `Staples`.`Call_Center_Region` AS `call_center_region`,
+  `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(`Staples`.`Customer_Balance`) AS `sum_customer_balance_ok`,
+  SUM(`Staples`.`Order_Quantity`) AS `sum_order_quantity_ok`,
+  SUM(1) AS `x_measure__0`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((`Staples`.`Call_Center_Region` NOT IN ('CENTRAL')) AND (`Staples`.`Discount` >= -0.001) AND (`Staples`.`Discount` <= 0.215172))
+GROUP BY 1,
+  2
+HAVING ((SUM(1) <= 822) AND (SUM(`Staples`.`Customer_Balance`) >= -746.0000000000075) AND (SUM(`Staples`.`Customer_Balance`) <= 4074689.000000041))
+    ","""EAST""
+""Barbara Fisher""
+1228846.0
+7640.0
+""EAST""
+""Dario Medina""
+658694.0
+10676.0
+""EAST""
+""Dave Hallsten""
+1370351.0
+8173.0
+""EAST""
+""David Flashing""
+1393388.0
+9027.0
+""EAST""
+""David Wiener""
+2357240.0
+11974.0
+""EAST""
+""Deanra Eno""
+2744638.0
+13063.0
+""EAST""
+""Debra Catini-Entman""
+1250845.0
+10103.0
+""EAST""
+""Elizabeth Moffitt""
+1764910.0
+11274.0
+""EAST""
+""Ellis Ballard""
+2183955.0
+11162.0
+""EAST""
+""Frank Olsen""
+2575651.0
+8950.0
+""EAST""
+""Grace Kelly""
+2516455.0
+15743.0
+""EAST""
+""Hallie Redmond""
+1893378.0
+10939.0
+""EAST""
+""Harold Pawlan""
+752998.0
+9137.0
+""EAST""
+""Heather Jas-Hannaway""
+1504614.0
+6075.0
+""EAST""
+""Henia Zydlo""
+1074767.0
+6813.0
+""EAST""
+""Herbert Flentye""
+1313383.0
+6852.0
+""EAST""
+""Hilary Holden""
+927733.0
+7737.0
+""EAST""
+""Jack O'Briant""
+359692.0
+2583.0
+""EAST""
+""Jane Waco""
+1716319.0
+8491.0
+""EAST""
+""Jas O'Carroll""
+1336609.0
+12062.0
+""EAST""
+""Jason Gross""
+2009184.0
+8824.0
+""EAST""
+""Jasper Cacioppo""
+2038249.0
+11138.0
+""EAST""
+""Jennifer Patt""
+1531539.0
+9436.0
+""EAST""
+""Jesus Ocampo""
+3049334.0
+15068.0
+""EAST""
+""Jim Sink""
+1549547.0
+6433.0","""EAST""
+""Barbara Fisher""
+1228846.0
+7640.0
+""EAST""
+""Dario Medina""
+658694.0
+10676.0
+""EAST""
+""Dave Hallsten""
+1370351.0
+8173.0
+""EAST""
+""David Flashing""
+1393388.0
+9027.0
+""EAST""
+""David Wiener""
+2357240.0
+11974.0
+""EAST""
+""Deanra Eno""
+2744638.0
+13063.0
+""EAST""
+""Debra Catini-Entman""
+1250845.0
+10103.0
+""EAST""
+""Elizabeth Moffitt""
+1764910.0
+11274.0
+""EAST""
+""Ellis Ballard""
+2183955.0
+11162.0
+""EAST""
+""Frank Olsen""
+2575651.0
+8950.0
+""EAST""
+""Grace Kelly""
+2516455.0
+15743.0
+""EAST""
+""Hallie Redmond""
+1893378.0
+10939.0
+""EAST""
+""Harold Pawlan""
+752998.0
+9137.0
+""EAST""
+""Heather Jas-Hannaway""
+1504614.0
+6075.0
+""EAST""
+""Henia Zydlo""
+1074767.0
+6813.0
+""EAST""
+""Herbert Flentye""
+1313383.0
+6852.0
+""EAST""
+""Hilary Holden""
+927733.0
+7737.0
+""EAST""
+""Jack O'Briant""
+359692.0
+2583.0
+""EAST""
+""Jane Waco""
+1716319.0
+8491.0
+""EAST""
+""Jas O'Carroll""
+1336609.0
+12062.0
+""EAST""
+""Jason Gross""
+2009184.0
+8824.0
+""EAST""
+""Jasper Cacioppo""
+2038249.0
+11138.0
+""EAST""
+""Jennifer Patt""
+1531539.0
+9436.0
+""EAST""
+""Jesus Ocampo""
+3049334.0
+15068.0
+""EAST""
+""Jim Sink""
+1549547.0
+6433.0"
+databricks,logical.staples.databricks,Staples.databricks,Query.Filter_SliceAggQUnaggQ_AxisQOYear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_SliceAggQUnaggQ_AxisQOYear.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_SliceAggQUnaggQ_AxisQOYear.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1620.0,"
+      SELECT `Staples`.`Call_Center_Region` AS `call_center_region`,
+  `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(`Staples`.`Customer_Balance`) AS `sum_customer_balance_ok`,
+  SUM(`Staples`.`Order_Quantity`) AS `sum_order_quantity_ok`,
+  YEAR(`Staples`.`Order_Date`) AS `yr_order_date_ok`,
+  SUM(1) AS `x_measure__0`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((`Staples`.`Call_Center_Region` NOT IN ('CENTRAL')) AND (YEAR(`Staples`.`Order_Date`) IN (2001, 2002)) AND (`Staples`.`Discount` >= -0.001) AND (`Staples`.`Discount` <= 0.215172))
+GROUP BY 1,
+  2,
+  5
+HAVING ((SUM(1) <= 822) AND (SUM(`Staples`.`Customer_Balance`) >= -746.0000000000075) AND (SUM(`Staples`.`Customer_Balance`) <= 4074689.000000041))
+    ","""EAST""
+""Barbara Fisher""
+214098.0
+1527.0
+2002
+""EAST""
+""Barbara Fisher""
+257629.0
+1135.0
+2001
+""EAST""
+""Dario Medina""
+108758.0
+1755.0
+2001
+""EAST""
+""Dario Medina""
+207436.0
+2564.0
+2002
+""EAST""
+""Dave Hallsten""
+216261.0
+1239.0
+2001
+""EAST""
+""Dave Hallsten""
+274830.0
+1055.0
+2002
+""EAST""
+""David Flashing""
+234870.0
+1578.0
+2002
+""EAST""
+""David Flashing""
+290536.0
+1991.0
+2001
+""EAST""
+""David Wiener""
+329515.0
+1557.0
+2002
+""EAST""
+""David Wiener""
+466789.0
+2453.0
+2001
+""EAST""
+""Deanra Eno""
+309042.0
+2019.0
+2001
+""EAST""
+""Deanra Eno""
+565297.0
+2173.0
+2002
+""EAST""
+""Debra Catini-Entman""
+132032.0
+1719.0
+2002
+""EAST""
+""Debra Catini-Entman""
+248659.0
+1576.0
+2001
+""EAST""
+""Elizabeth Moffitt""
+260630.0
+1437.0
+2002
+""EAST""
+""Elizabeth Moffitt""
+315255.0
+2303.0
+2001
+""EAST""
+""Ellis Ballard""
+389843.0
+2186.0
+2001
+""EAST""
+""Ellis Ballard""
+402917.0
+1744.0
+2002
+""EAST""
+""Frank Olsen""
+347670.0
+1408.0
+2001
+""EAST""
+""Frank Olsen""
+647661.0
+2062.0
+2002","""EAST""
+""Barbara Fisher""
+214098.0
+1527.0
+2002
+""EAST""
+""Barbara Fisher""
+257629.0
+1135.0
+2001
+""EAST""
+""Dario Medina""
+108758.0
+1755.0
+2001
+""EAST""
+""Dario Medina""
+207436.0
+2564.0
+2002
+""EAST""
+""Dave Hallsten""
+216261.0
+1239.0
+2001
+""EAST""
+""Dave Hallsten""
+274830.0
+1055.0
+2002
+""EAST""
+""David Flashing""
+234870.0
+1578.0
+2002
+""EAST""
+""David Flashing""
+290536.0
+1991.0
+2001
+""EAST""
+""David Wiener""
+329515.0
+1557.0
+2002
+""EAST""
+""David Wiener""
+466789.0
+2453.0
+2001
+""EAST""
+""Deanra Eno""
+309042.0
+2019.0
+2001
+""EAST""
+""Deanra Eno""
+565297.0
+2173.0
+2002
+""EAST""
+""Debra Catini-Entman""
+132032.0
+1719.0
+2002
+""EAST""
+""Debra Catini-Entman""
+248659.0
+1576.0
+2001
+""EAST""
+""Elizabeth Moffitt""
+260630.0
+1437.0
+2002
+""EAST""
+""Elizabeth Moffitt""
+315255.0
+2303.0
+2001
+""EAST""
+""Ellis Ballard""
+389843.0
+2186.0
+2001
+""EAST""
+""Ellis Ballard""
+402917.0
+1744.0
+2002
+""EAST""
+""Frank Olsen""
+347670.0
+1408.0
+2001
+""EAST""
+""Frank Olsen""
+647661.0
+2062.0
+2002"
+databricks,logical.staples.databricks,Staples.databricks,Query.Filter_SliceAggQ_AxisQ,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_SliceAggQ_AxisQ.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Filter_SliceAggQ_AxisQ.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1147.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(`Staples`.`Customer_Balance`) AS `sum_customer_balance_ok`,
+  SUM(`Staples`.`Order_Quantity`) AS `sum_order_quantity_ok`,
+  SUM(1) AS `x_measure__0`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1
+HAVING ((SUM(1) <= 822) AND (SUM(`Staples`.`Customer_Balance`) >= -746.0000000000075) AND (SUM(`Staples`.`Customer_Balance`) <= 4074689.000000041))
+    ","""Barbara Fisher""
+2903943.0
+17229.0
+""Dave Hallsten""
+1648480.0
+11238.0
+""David Flashing""
+3446006.0
+20240.0
+""David Wiener""
+3885765.0
+19995.0
+""Deanra Eno""
+2867586.0
+18924.0
+""Debra Catini-Entman""
+2264258.0
+16416.0
+""Elizabeth Moffitt""
+3230009.0
+17529.0
+""Frank Olsen""
+3196838.0
+13689.0
+""Grace Kelly""
+3554045.0
+19140.0
+""Hallie Redmond""
+3400961.0
+20334.0
+""Heather Jas-Hannaway""
+2594333.0
+17972.0
+""Henia Zydlo""
+2676295.0
+18380.0
+""Herbert Flentye""
+2507450.0
+14031.0
+""Jack O'Briant""
+1836645.0
+13932.0
+""Jane Waco""
+2529969.0
+16154.0
+""Jas O'Carroll""
+2230480.0
+17133.0
+""Jason Gross""
+3850271.0
+17415.0
+""Jennifer Patt""
+2904238.0
+16461.0
+""Jim Sink""
+3176250.0
+16974.0
+""Joseph Airdo""
+1306316.0
+11175.0
+""Laura Armstrong""
+2865910.0
+20975.0
+""Lela Donovan""
+3819713.0
+16383.0
+""Mary O'Rourke""
+3447191.0
+18749.0
+""Mathew Reese""
+2308376.0
+20040.0
+""Maurice Satty""
+3420618.0
+16947.0
+""Meg O'Connel""
+2135079.0
+15842.0
+""Meg Tillman-Sachs""
+3831344.0
+20906.0
+""Michael Moore""
+2196434.0
+17219.0
+""Michael Oakman""
+3229418.0
+16090.0
+""Nona Balk""
+2967836.0
+15145.0
+""Olvera Toch""
+3898824.0
+16579.0
+""Patrick O'Brill""
+3353491.0
+16736.0
+""Paul Prost""
+2460426.0
+13497.0
+""Peter McVee""","""Barbara Fisher""
+2903943.0
+17229.0
+""Dave Hallsten""
+1648480.0
+11238.0
+""David Flashing""
+3446006.0
+20240.0
+""David Wiener""
+3885765.0
+19995.0
+""Deanra Eno""
+2867586.0
+18924.0
+""Debra Catini-Entman""
+2264258.0
+16416.0
+""Elizabeth Moffitt""
+3230009.0
+17529.0
+""Frank Olsen""
+3196838.0
+13689.0
+""Grace Kelly""
+3554045.0
+19140.0
+""Hallie Redmond""
+3400961.0
+20334.0
+""Heather Jas-Hannaway""
+2594333.0
+17972.0
+""Henia Zydlo""
+2676295.0
+18380.0
+""Herbert Flentye""
+2507450.0
+14031.0
+""Jack O'Briant""
+1836645.0
+13932.0
+""Jane Waco""
+2529969.0
+16154.0
+""Jas O'Carroll""
+2230480.0
+17133.0
+""Jason Gross""
+3850271.0
+17415.0
+""Jennifer Patt""
+2904238.0
+16461.0
+""Jim Sink""
+3176250.0
+16974.0
+""Joseph Airdo""
+1306316.0
+11175.0
+""Laura Armstrong""
+2865910.0
+20975.0
+""Lela Donovan""
+3819713.0
+16383.0
+""Mary O'Rourke""
+3447191.0
+18749.0
+""Mathew Reese""
+2308376.0
+20040.0
+""Maurice Satty""
+3420618.0
+16947.0
+""Meg O'Connel""
+2135079.0
+15842.0
+""Meg Tillman-Sachs""
+3831344.0
+20906.0
+""Michael Moore""
+2196434.0
+17219.0
+""Michael Oakman""
+3229418.0
+16090.0
+""Nona Balk""
+2967836.0
+15145.0
+""Olvera Toch""
+3898824.0
+16579.0
+""Patrick O'Brill""
+3353491.0
+16736.0
+""Paul Prost""
+2460426.0
+13497.0
+""Peter McVee"""
+databricks,logical.staples.databricks,Staples.databricks,Query.HideEmptyRows,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.HideEmptyRows.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.HideEmptyRows.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2327.0,"
+      SELECT `Staples`.`Employee_Name` AS `employee_name`,
+  AVG(`Staples`.`Employee_Salary`) AS `avg_employee_salary_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+  JOIN (
+  SELECT `Staples`.`Call_Center_Region` AS `call_center_region`,
+    `Staples`.`Employee_Name` AS `employee_name`,
+    AVG(`Staples`.`Employee_Salary`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1,
+    2
+  HAVING ((AVG(`Staples`.`Employee_Salary`) >= 102499.99999999898) AND (AVG(`Staples`.`Employee_Salary`) <= 110000.00000000111))
+) `t0` ON ((`Staples`.`Call_Center_Region` = `t0`.`call_center_region`) AND (`Staples`.`Employee_Name` = `t0`.`employee_name`))
+GROUP BY 1
+    ","""Adam Haberlach""
+104406.0
+""Alok Kapoor""
+102923.0
+""Baton Rouge Alumnae""
+102540.0
+""Bob Pennefather""
+103617.0
+""Carpenter, Jill""
+104224.0
+""Charles A.W. Adams""
+102605.0
+""Clayton, Nancy""
+103864.0
+""Colleen Hurwitz""
+103907.0
+""Collins, Babs""
+102752.0
+""Daniel Champ""
+104913.0
+""Ellis, Elaine""
+104452.0
+""Eric Jones""
+103790.0
+""Eric Landry""
+102914.0
+""Faris, Marilyn""
+103882.0
+""G.P Pandey""
+102542.0
+""Galen Kountz""
+103561.0
+""Gerardo Colmenar""
+104186.0
+""Jones, Melody""
+104832.0
+""Kathryn Blackmer-Reyes""
+104591.0
+""Linda Arce""
+102623.0
+""MacCallum, Joan""
+103324.0
+""Matthew Ruzicka""
+104509.0
+""Michael J. Jacobs""
+103600.0
+""Peacock, Margaret""
+102973.0
+""Philippe Sauvageau""
+102835.0
+""Pradeep S Mehta""
+104569.0
+""Purkey, Jan""
+104677.0
+""Ransbury, Wendy""
+104897.0
+""Rosenzweig, Loren""
+104362.0
+""Rudisill, Martha""
+103619.0
+""Sharp, Mary Jane""
+103281.0
+""Stevenson, Carol""
+104287.0
+""Suzanne Lafrenière""
+103442.0","""Adam Haberlach""
+104406.0
+""Alok Kapoor""
+102923.0
+""Baton Rouge Alumnae""
+102540.0
+""Bob Pennefather""
+103617.0
+""Carpenter, Jill""
+104224.0
+""Charles A.W. Adams""
+102605.0
+""Clayton, Nancy""
+103864.0
+""Colleen Hurwitz""
+103907.0
+""Collins, Babs""
+102752.0
+""Daniel Champ""
+104913.0
+""Ellis, Elaine""
+104452.0
+""Eric Jones""
+103790.0
+""Eric Landry""
+102914.0
+""Faris, Marilyn""
+103882.0
+""G.P Pandey""
+102542.0
+""Galen Kountz""
+103561.0
+""Gerardo Colmenar""
+104186.0
+""Jones, Melody""
+104832.0
+""Kathryn Blackmer-Reyes""
+104591.0
+""Linda Arce""
+102623.0
+""MacCallum, Joan""
+103324.0
+""Matthew Ruzicka""
+104509.0
+""Michael J. Jacobs""
+103600.0
+""Peacock, Margaret""
+102973.0
+""Philippe Sauvageau""
+102835.0
+""Pradeep S Mehta""
+104569.0
+""Purkey, Jan""
+104677.0
+""Ransbury, Wendy""
+104897.0
+""Rosenzweig, Loren""
+104362.0
+""Rudisill, Martha""
+103619.0
+""Sharp, Mary Jane""
+103281.0
+""Stevenson, Carol""
+104287.0
+""Suzanne Lafrenière""
+103442.0"
+databricks,logical.staples.databricks,Staples.databricks,Query.MultipleFilters,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.MultipleFilters.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.MultipleFilters.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1418.0,"
+      SELECT `Staples`.`Call_Center_Region` AS `call_center_region`,
+  `Staples`.`Order_ID` AS `order_id`,
+  `Staples`.`Product_Container` AS `product_container`,
+  AVG(`Staples`.`Gross_Profit`) AS `avg_gross_profit_ok`,
+  MONTH(`Staples`.`Order_Date`) AS `mn_order_date_ok`,
+  SUM(`Staples`.`Price`) AS `sum_price_ok`,
+  YEAR(`Staples`.`Order_Date`) AS `yr_order_date_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((`Staples`.`Call_Center_Region` = 'WEST') AND (((`Staples`.`Order_ID` >= '1') AND (`Staples`.`Order_ID` <= '35361')) OR ((`Staples`.`Order_ID` >= '35363') AND (`Staples`.`Order_ID` <= '9991'))) AND (`Staples`.`Product_Container` = 'MEDIUM BOX') AND (MONTH(`Staples`.`Order_Date`) IN (1, 4, 7, 10)) AND (`Staples`.`Discount` >= 0.27489599999999997) AND (`Staples`.`Discount` <= 0.39001000000000002))
+GROUP BY 1,
+  2,
+  3,
+  5,
+  7
+    ","""WEST""
+""23143""
+""MEDIUM BOX""
+-93.18
+10
+11.33
+2002
+""WEST""
+""30086""
+""MEDIUM BOX""
+4660.61
+7
+500.98
+2002
+""WEST""
+""47653""
+""MEDIUM BOX""
+-38.72
+7
+21.78
+2002
+""WEST""
+""7266""
+""MEDIUM BOX""
+-21.82
+7
+9.77
+2002","""WEST""
+""23143""
+""MEDIUM BOX""
+-93.18
+10
+11.33
+2002
+""WEST""
+""30086""
+""MEDIUM BOX""
+4660.61
+7
+500.98
+2002
+""WEST""
+""47653""
+""MEDIUM BOX""
+-38.72
+7
+21.78
+2002
+""WEST""
+""7266""
+""MEDIUM BOX""
+-21.82
+7
+9.77
+2002"
+databricks,logical.staples.databricks,Staples.databricks,Query.Nest_FilterO1O2_SliceOQ_SortByO1,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Nest_FilterO1O2_SliceOQ_SortByO1.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Nest_FilterO1O2_SliceOQ_SortByO1.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1190.0,"
+      SELECT `Staples`.`Prod_Type1` AS `prod_type1`,
+  `Staples`.`Prod_Type2` AS `prod_type2`,
+  SUM(`Staples`.`Gross_Profit`) AS `sum_gross_profit_ok`,
+  AVG(`Staples`.`Discount`) AS `x_measure__0`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((`Staples`.`Prod_Type1` NOT IN ('FURNITURE')) AND ((`Staples`.`Prod_Type2` IN ('APPLIANCES')) OR ((`Staples`.`Prod_Type2` >= 'BOOKCASES') AND (`Staples`.`Prod_Type2` <= 'COMPUTER PERIPHERALS')) OR ((`Staples`.`Prod_Type2` >= 'ENVELOPES') AND (`Staples`.`Prod_Type2` <= 'TELEPHONES AND COMMUNICATION'))) AND (`Staples`.`Call_Center_Region` NOT IN ('CENTRAL')))
+GROUP BY 1,
+  2
+HAVING ((AVG(`Staples`.`Discount`) >= 0.051399999999999488) AND (AVG(`Staples`.`Discount`) <= 0.059000000000000587))
+    ","""OFFICE SUPPLIES""
+""ENVELOPES""
+224628.16
+""OFFICE SUPPLIES""
+""LABELS""
+128811.9
+""OFFICE SUPPLIES""
+""PAPER""
+515438.67
+""OFFICE SUPPLIES""
+""PENS & ART SUPPLIES""
+135086.7
+""OFFICE SUPPLIES""
+""RUBBER BANDS""
+9112.59
+""OFFICE SUPPLIES""
+""SCISSORS, RULERS AND TRIMMERS""
+62884.71
+""OFFICE SUPPLIES""
+""STORAGE & ORGANIZATION""
+219465.8
+""TECHNOLOGY""
+""COMPUTER PERIPHERALS""
+1173533.7
+""TECHNOLOGY""
+""OFFICE MACHINES""
+5254647.7
+""TECHNOLOGY""
+""TELEPHONES AND COMMUNICATION""
+3873400.3","""OFFICE SUPPLIES""
+""ENVELOPES""
+224628.16
+""OFFICE SUPPLIES""
+""LABELS""
+128811.9
+""OFFICE SUPPLIES""
+""PAPER""
+515438.67
+""OFFICE SUPPLIES""
+""PENS & ART SUPPLIES""
+135086.7
+""OFFICE SUPPLIES""
+""RUBBER BANDS""
+9112.59
+""OFFICE SUPPLIES""
+""SCISSORS, RULERS AND TRIMMERS""
+62884.71
+""OFFICE SUPPLIES""
+""STORAGE & ORGANIZATION""
+219465.8
+""TECHNOLOGY""
+""COMPUTER PERIPHERALS""
+1173533.7
+""TECHNOLOGY""
+""OFFICE MACHINES""
+5254647.7
+""TECHNOLOGY""
+""TELEPHONES AND COMMUNICATION""
+3873400.3"
+databricks,logical.staples.databricks,Staples.databricks,Query.Nest_FilterO1O2_SliceOQ_SortByO1O2,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Nest_FilterO1O2_SliceOQ_SortByO1O2.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Nest_FilterO1O2_SliceOQ_SortByO1O2.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1104.0,"
+      SELECT `Staples`.`Prod_Type1` AS `prod_type1`,
+  `Staples`.`Prod_Type2` AS `prod_type2`,
+  SUM(`Staples`.`Gross_Profit`) AS `sum_gross_profit_ok`,
+  AVG(`Staples`.`Discount`) AS `x_measure__0`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((`Staples`.`Prod_Type1` NOT IN ('FURNITURE')) AND ((`Staples`.`Prod_Type2` IN ('APPLIANCES')) OR ((`Staples`.`Prod_Type2` >= 'BOOKCASES') AND (`Staples`.`Prod_Type2` <= 'COMPUTER PERIPHERALS')) OR ((`Staples`.`Prod_Type2` >= 'ENVELOPES') AND (`Staples`.`Prod_Type2` <= 'TELEPHONES AND COMMUNICATION'))) AND (`Staples`.`Call_Center_Region` NOT IN ('CENTRAL')))
+GROUP BY 1,
+  2
+HAVING ((AVG(`Staples`.`Discount`) >= 0.051399999999999488) AND (AVG(`Staples`.`Discount`) <= 0.059000000000000587))
+    ","""OFFICE SUPPLIES""
+""ENVELOPES""
+224628.16
+""OFFICE SUPPLIES""
+""LABELS""
+128811.9
+""OFFICE SUPPLIES""
+""PAPER""
+515438.67
+""OFFICE SUPPLIES""
+""PENS & ART SUPPLIES""
+135086.7
+""OFFICE SUPPLIES""
+""RUBBER BANDS""
+9112.59
+""OFFICE SUPPLIES""
+""SCISSORS, RULERS AND TRIMMERS""
+62884.71
+""OFFICE SUPPLIES""
+""STORAGE & ORGANIZATION""
+219465.8
+""TECHNOLOGY""
+""COMPUTER PERIPHERALS""
+1173533.7
+""TECHNOLOGY""
+""OFFICE MACHINES""
+5254647.7
+""TECHNOLOGY""
+""TELEPHONES AND COMMUNICATION""
+3873400.3","""OFFICE SUPPLIES""
+""ENVELOPES""
+224628.16
+""OFFICE SUPPLIES""
+""LABELS""
+128811.9
+""OFFICE SUPPLIES""
+""PAPER""
+515438.67
+""OFFICE SUPPLIES""
+""PENS & ART SUPPLIES""
+135086.7
+""OFFICE SUPPLIES""
+""RUBBER BANDS""
+9112.59
+""OFFICE SUPPLIES""
+""SCISSORS, RULERS AND TRIMMERS""
+62884.71
+""OFFICE SUPPLIES""
+""STORAGE & ORGANIZATION""
+219465.8
+""TECHNOLOGY""
+""COMPUTER PERIPHERALS""
+1173533.7
+""TECHNOLOGY""
+""OFFICE MACHINES""
+5254647.7
+""TECHNOLOGY""
+""TELEPHONES AND COMMUNICATION""
+3873400.3"
+databricks,logical.staples.databricks,Staples.databricks,Query.Nest_FilterO1_SliceOQ,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Nest_FilterO1_SliceOQ.tableau_tdvt.xml,True,1,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Nest_FilterO1_SliceOQ.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1407.0,"
+      SELECT `Staples`.`Prod_Type1` AS `prod_type1`,
+  `Staples`.`Prod_Type2` AS `prod_type2`,
+  SUM(`Staples`.`Gross_Profit`) AS `sum_gross_profit_ok`,
+  AVG(`Staples`.`Discount`) AS `x_measure__0`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((`Staples`.`Prod_Type1` NOT IN ('FURNITURE')) AND (`Staples`.`Call_Center_Region` NOT IN ('CENTRAL')))
+GROUP BY 1,
+  2
+HAVING ((AVG(`Staples`.`Discount`) >= 0.051399999999999488) AND (AVG(`Staples`.`Discount`) <= 0.059000000000000587))
+    ","""OFFICE SUPPLIES""
+""BINDERS AND BINDER ACCESSORIES""
+1853136.8
+""OFFICE SUPPLIES""
+""ENVELOPES""
+224628.16
+""OFFICE SUPPLIES""
+""LABELS""
+128811.9
+""OFFICE SUPPLIES""
+""PAPER""
+515438.67
+""OFFICE SUPPLIES""
+""PENS & ART SUPPLIES""
+135086.7
+""OFFICE SUPPLIES""
+""RUBBER BANDS""
+9112.59
+""OFFICE SUPPLIES""
+""SCISSORS, RULERS AND TRIMMERS""
+62884.71
+""OFFICE SUPPLIES""
+""STORAGE & ORGANIZATION""
+219465.8
+""TECHNOLOGY""
+""COMPUTER PERIPHERALS""
+1173533.7
+""TECHNOLOGY""
+""COPIERS AND FAX""
+2732619.0
+""TECHNOLOGY""
+""OFFICE MACHINES""
+5254647.7
+""TECHNOLOGY""
+""TELEPHONES AND COMMUNICATION""
+3873400.3","""OFFICE SUPPLIES""
+""BINDERS AND BINDER ACCESSORIES""
+1853136.8
+""OFFICE SUPPLIES""
+""ENVELOPES""
+224628.16
+""OFFICE SUPPLIES""
+""LABELS""
+128811.9
+""OFFICE SUPPLIES""
+""PAPER""
+515438.67
+""OFFICE SUPPLIES""
+""PENS & ART SUPPLIES""
+135086.7
+""OFFICE SUPPLIES""
+""RUBBER BANDS""
+9112.59
+""OFFICE SUPPLIES""
+""SCISSORS, RULERS AND TRIMMERS""
+62884.71
+""OFFICE SUPPLIES""
+""STORAGE & ORGANIZATION""
+219465.8
+""TECHNOLOGY""
+""COMPUTER PERIPHERALS""
+1173533.7
+""TECHNOLOGY""
+""COPIERS AND FAX""
+2732619.0
+""TECHNOLOGY""
+""OFFICE MACHINES""
+5254647.7
+""TECHNOLOGY""
+""TELEPHONES AND COMMUNICATION""
+3873400.3"
+databricks,logical.staples.databricks,Staples.databricks,Query.Nest_SliceQ,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Nest_SliceQ.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Nest_SliceQ.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1039.0,"
+      SELECT `Staples`.`Prod_Type1` AS `prod_type1`,
+  `Staples`.`Prod_Type2` AS `prod_type2`,
+  SUM(`Staples`.`Gross_Profit`) AS `sum_gross_profit_ok`,
+  AVG(`Staples`.`Discount`) AS `x_measure__0`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1,
+  2
+HAVING ((AVG(`Staples`.`Discount`) >= 0.051399999999999488) AND (AVG(`Staples`.`Discount`) <= 0.055001000000000549))
+    ","""FURNITURE""
+""BOOKCASES""
+206121.02
+""FURNITURE""
+""CHAIRS & CHAIRMATS""
+1475917.4
+""OFFICE SUPPLIES""
+""ENVELOPES""
+298279.65
+""OFFICE SUPPLIES""
+""LABELS""
+163803.11
+""OFFICE SUPPLIES""
+""PAPER""
+653940.66
+""OFFICE SUPPLIES""
+""PENS & ART SUPPLIES""
+169273.34
+""OFFICE SUPPLIES""
+""RUBBER BANDS""
+11577.16
+""OFFICE SUPPLIES""
+""SCISSORS, RULERS AND TRIMMERS""
+83934.3
+""OFFICE SUPPLIES""
+""STORAGE & ORGANIZATION""
+283818.12
+""TECHNOLOGY""
+""COPIERS AND FAX""
+3472108.1
+""TECHNOLOGY""
+""TELEPHONES AND COMMUNICATION""
+4830099.3","""FURNITURE""
+""BOOKCASES""
+206121.02
+""FURNITURE""
+""CHAIRS & CHAIRMATS""
+1475917.4
+""OFFICE SUPPLIES""
+""ENVELOPES""
+298279.65
+""OFFICE SUPPLIES""
+""LABELS""
+163803.11
+""OFFICE SUPPLIES""
+""PAPER""
+653940.66
+""OFFICE SUPPLIES""
+""PENS & ART SUPPLIES""
+169273.34
+""OFFICE SUPPLIES""
+""RUBBER BANDS""
+11577.16
+""OFFICE SUPPLIES""
+""SCISSORS, RULERS AND TRIMMERS""
+83934.3
+""OFFICE SUPPLIES""
+""STORAGE & ORGANIZATION""
+283818.12
+""TECHNOLOGY""
+""COPIERS AND FAX""
+3472108.1
+""TECHNOLOGY""
+""TELEPHONES AND COMMUNICATION""
+4830099.3"
+databricks,logical.staples.databricks,Staples.databricks,Query.Nest_SliceQO,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Nest_SliceQO.tableau_tdvt.xml,True,1,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Nest_SliceQO.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,798.0,"
+      SELECT `Staples`.`Prod_Type1` AS `prod_type1`,
+  `Staples`.`Prod_Type2` AS `prod_type2`,
+  SUM(`Staples`.`Gross_Profit`) AS `sum_gross_profit_ok`,
+  AVG(`Staples`.`Discount`) AS `x_measure__0`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE (`Staples`.`Call_Center_Region` NOT IN ('CENTRAL'))
+GROUP BY 1,
+  2
+HAVING ((AVG(`Staples`.`Discount`) >= 0.051399999999999488) AND (AVG(`Staples`.`Discount`) <= 0.059000000000000587))
+    ","""FURNITURE""
+""BOOKCASES""
+126861.19
+""FURNITURE""
+""CHAIRS & CHAIRMATS""
+1122820.1
+""FURNITURE""
+""TABLES""
+577674.43
+""OFFICE SUPPLIES""
+""BINDERS AND BINDER ACCESSORIES""
+1853136.8
+""OFFICE SUPPLIES""
+""ENVELOPES""
+224628.16
+""OFFICE SUPPLIES""
+""LABELS""
+128811.9
+""OFFICE SUPPLIES""
+""PAPER""
+515438.67
+""OFFICE SUPPLIES""
+""PENS & ART SUPPLIES""
+135086.7
+""OFFICE SUPPLIES""
+""RUBBER BANDS""
+9112.59
+""OFFICE SUPPLIES""
+""SCISSORS, RULERS AND TRIMMERS""
+62884.71
+""OFFICE SUPPLIES""
+""STORAGE & ORGANIZATION""
+219465.8
+""TECHNOLOGY""
+""COMPUTER PERIPHERALS""
+1173533.7
+""TECHNOLOGY""
+""COPIERS AND FAX""
+2732619.0
+""TECHNOLOGY""
+""OFFICE MACHINES""
+5254647.7
+""TECHNOLOGY""
+""TELEPHONES AND COMMUNICATION""
+3873400.3","""FURNITURE""
+""BOOKCASES""
+126861.19
+""FURNITURE""
+""CHAIRS & CHAIRMATS""
+1122820.1
+""FURNITURE""
+""TABLES""
+577674.43
+""OFFICE SUPPLIES""
+""BINDERS AND BINDER ACCESSORIES""
+1853136.8
+""OFFICE SUPPLIES""
+""ENVELOPES""
+224628.16
+""OFFICE SUPPLIES""
+""LABELS""
+128811.9
+""OFFICE SUPPLIES""
+""PAPER""
+515438.67
+""OFFICE SUPPLIES""
+""PENS & ART SUPPLIES""
+135086.7
+""OFFICE SUPPLIES""
+""RUBBER BANDS""
+9112.59
+""OFFICE SUPPLIES""
+""SCISSORS, RULERS AND TRIMMERS""
+62884.71
+""OFFICE SUPPLIES""
+""STORAGE & ORGANIZATION""
+219465.8
+""TECHNOLOGY""
+""COMPUTER PERIPHERALS""
+1173533.7
+""TECHNOLOGY""
+""COPIERS AND FAX""
+2732619.0
+""TECHNOLOGY""
+""OFFICE MACHINES""
+5254647.7
+""TECHNOLOGY""
+""TELEPHONES AND COMMUNICATION""
+3873400.3"
+databricks,logical.staples.databricks,Staples.databricks,Query.Sort_Alphabetic_DESC_Top1,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Sort_Alphabetic_DESC_Top1.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Sort_Alphabetic_DESC_Top1.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1606.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(`Staples`.`Customer_Balance`) AS `sum_customer_balance_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+  JOIN (
+  SELECT `Staples`.`Customer_Name` AS `customer_name`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+  ORDER BY `customer_name` DESC
+  LIMIT 1
+) `t0` ON (`Staples`.`Customer_Name` = `t0`.`customer_name`)
+GROUP BY 1
+    ","""Zyzzy Zzuyzyzyk""
+5052539.0","""Zyzzy Zzuyzyzyk""
+5052539.0"
+databricks,logical.staples.databricks,Staples.databricks,Query.Sort_Alphabetic_DESC_Top10,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Sort_Alphabetic_DESC_Top10.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Sort_Alphabetic_DESC_Top10.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,871.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(`Staples`.`Customer_Balance`) AS `sum_customer_balance_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1
+ORDER BY `customer_name` DESC
+LIMIT 10
+    ","""Suzanne McNair""
+3947695.0
+""Tanja Norvell""
+3095019.0
+""Thomas Boland""
+2503253.0
+""Thomas Seio""
+3990114.0
+""Tonja Turnell""
+2380589.0
+""Tracy Zic""
+2143477.0
+""Victor Price""
+2748451.0
+""William Brown""
+2981310.0
+""Yoseph Carroll-Englig""
+3231972.0
+""Zyzzy Zzuyzyzyk""
+5052539.0","""Suzanne McNair""
+3947695.0
+""Tanja Norvell""
+3095019.0
+""Thomas Boland""
+2503253.0
+""Thomas Seio""
+3990114.0
+""Tonja Turnell""
+2380589.0
+""Tracy Zic""
+2143477.0
+""Victor Price""
+2748451.0
+""William Brown""
+2981310.0
+""Yoseph Carroll-Englig""
+3231972.0
+""Zyzzy Zzuyzyzyk""
+5052539.0"
+databricks,logical.staples.databricks,Staples.databricks,Query.Sort_Natural_DESC,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Sort_Natural_DESC.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Sort_Natural_DESC.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,783.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  SUM(`Staples`.`Customer_Balance`) AS `sum_customer_balance_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1
+    ","""Barbara Fisher""
+2903943.0
+""Dario Medina""
+2061846.0
+""Dave Hallsten""
+1648480.0
+""David Flashing""
+3446006.0
+""David Wiener""
+3885765.0
+""Deanra Eno""
+2867586.0
+""Debra Catini-Entman""
+2264258.0
+""Elizabeth Moffitt""
+3230009.0
+""Ellis Ballard""
+3524373.0
+""Frank Olsen""
+3196838.0
+""Grace Kelly""
+3554045.0
+""Hallie Redmond""
+3400961.0
+""Harold Pawlan""
+2983868.0
+""Heather Jas-Hannaway""
+2594333.0
+""Henia Zydlo""
+2676295.0
+""Herbert Flentye""
+2507450.0
+""Hilary Holden""
+4314073.0
+""Jack O'Briant""
+1836645.0
+""Jane Waco""
+2529969.0
+""Jas O'Carroll""
+2230480.0
+""Jason Gross""
+3850271.0
+""Jasper Cacioppo""
+4013536.0
+""Jennifer Patt""
+2904238.0
+""Jesus Ocampo""
+4318228.0
+""Jim Sink""
+3176250.0
+""Joseph Airdo""
+1306316.0
+""Karen Seio""
+5074689.0
+""Laura Armstrong""
+2865910.0
+""Lela Donovan""
+3819713.0
+""Lena Cacioppo""
+4387205.0
+""Lynn Smith-Reed""
+4585698.0
+""Mary O'Rourke""
+3447191.0
+""Mary Zewe""
+3296799.0
+""MaryBeth Skach""
+3861193.0
+""Mathew Reese""
+2308376.0
+""Maurice Satty""
+3420618.0
+""Maxwell Schwartz""
+2430604.0
+""Meg O'Connel""
+2135079.0
+""Meg Tillman-Sachs""
+3831344.0
+""Michael Moore""
+2196434.0
+""Michael Oakman""
+3229418.0
+""Naresj Patel""
+4323767.0
+""Nathan Mautz""
+3703508.0
+""Noel Staavos""
+2854162.0
+""Nona Balk""
+2967836.0
+""Olvera Toch""
+3898824.0
+""Patrick O'Brill""
+3353491.0
+""Paul Prost""
+2460426.0
+""Peter McVee""
+1849223.0
+""Pierre Wener""
+3907566.0","""Barbara Fisher""
+2903943.0
+""Dario Medina""
+2061846.0
+""Dave Hallsten""
+1648480.0
+""David Flashing""
+3446006.0
+""David Wiener""
+3885765.0
+""Deanra Eno""
+2867586.0
+""Debra Catini-Entman""
+2264258.0
+""Elizabeth Moffitt""
+3230009.0
+""Ellis Ballard""
+3524373.0
+""Frank Olsen""
+3196838.0
+""Grace Kelly""
+3554045.0
+""Hallie Redmond""
+3400961.0
+""Harold Pawlan""
+2983868.0
+""Heather Jas-Hannaway""
+2594333.0
+""Henia Zydlo""
+2676295.0
+""Herbert Flentye""
+2507450.0
+""Hilary Holden""
+4314073.0
+""Jack O'Briant""
+1836645.0
+""Jane Waco""
+2529969.0
+""Jas O'Carroll""
+2230480.0
+""Jason Gross""
+3850271.0
+""Jasper Cacioppo""
+4013536.0
+""Jennifer Patt""
+2904238.0
+""Jesus Ocampo""
+4318228.0
+""Jim Sink""
+3176250.0
+""Joseph Airdo""
+1306316.0
+""Karen Seio""
+5074689.0
+""Laura Armstrong""
+2865910.0
+""Lela Donovan""
+3819713.0
+""Lena Cacioppo""
+4387205.0
+""Lynn Smith-Reed""
+4585698.0
+""Mary O'Rourke""
+3447191.0
+""Mary Zewe""
+3296799.0
+""MaryBeth Skach""
+3861193.0
+""Mathew Reese""
+2308376.0
+""Maurice Satty""
+3420618.0
+""Maxwell Schwartz""
+2430604.0
+""Meg O'Connel""
+2135079.0
+""Meg Tillman-Sachs""
+3831344.0
+""Michael Moore""
+2196434.0
+""Michael Oakman""
+3229418.0
+""Naresj Patel""
+4323767.0
+""Nathan Mautz""
+3703508.0
+""Noel Staavos""
+2854162.0
+""Nona Balk""
+2967836.0
+""Olvera Toch""
+3898824.0
+""Patrick O'Brill""
+3353491.0
+""Paul Prost""
+2460426.0
+""Peter McVee""
+1849223.0
+""Pierre Wener""
+3907566.0"
+databricks,logical.staples.databricks,Staples.databricks,Query.Top99_ByField,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Top99_ByField.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Top99_ByField.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1059.0,"
+      SELECT `Staples`.`Employee_Name` AS `employee_name`,
+  AVG(`Staples`.`Employee_Salary`) AS `avg_employee_salary_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1
+ORDER BY `avg_employee_salary_ok` DESC
+LIMIT 99
+    ","""Adalin Torres-Zayas""
+102081.0
+""Adam Haberlach""
+104406.0
+""Alok Kapoor""
+102923.0
+""Baton Rouge Alumnae""
+102540.0
+""Beatriz Pascual""
+100648.0
+""Ben Booth""
+102211.0
+""Blomquist, Laura""
+98221.0
+""Bob Pennefather""
+103617.0
+""Bonnie McCune""
+100059.0
+""Brue, Jill""
+99223.0
+""Bruner, Virginia""
+100346.0
+""Cale, Harriett""
+99616.0
+""Carey Beckstead""
+102021.0
+""Carpenter, Jan""
+101170.0
+""Carpenter, Jill""
+104224.0
+""Charles A.W. Adams""
+102605.0
+""Clark, Carol""
+99486.0
+""Clayton, Nancy""
+103864.0
+""Colleen Hurwitz""
+103907.0
+""Collins, Babs""
+102752.0
+""Craig A. Edwards""
+101970.0
+""Dallas Alumnae""
+101112.0
+""Daniel Champ""
+104913.0
+""Davis, Nancy""
+97952.0
+""Deepak D. Raj""
+100233.0
+""Dhruv Gupta""
+98729.0
+""Dodds, Christina""
+100405.0
+""Ellis, Elaine""
+104452.0
+""Eric Jones""
+103790.0
+""Eric Landry""
+102914.0
+""Familo, Amy""
+100570.0
+""Faris, Marilyn""
+103882.0
+""G.P Pandey""
+102542.0
+""Gail Anderson-Dargatz""
+99993.0
+""Galehan, Karen""
+100999.0
+""Galen Kountz""
+103561.0
+""Gary Ledbetter""
+98767.0
+""George Mattok""
+97971.0
+""Gerardo Colmenar""
+104186.0
+""Harish Kumar""
+102068.0
+""Harsh Manglik""
+102235.0
+""Hastrich, Mary Frances""
+102182.0
+""Hougaard, Patricia""
+98324.0
+""Hudgins, Carolyn""
+98565.0
+""J. L. Rastogi""
+100819.0
+""Jack Juni""
+101132.0
+""Jeet Bindra""
+99583.0
+""Joe Schmidt""
+99143.0
+""Jones, Melody""
+104832.0
+""K.K Dave""
+101589.0","""Adalin Torres-Zayas""
+102081.0
+""Adam Haberlach""
+104406.0
+""Alok Kapoor""
+102923.0
+""Baton Rouge Alumnae""
+102540.0
+""Beatriz Pascual""
+100648.0
+""Ben Booth""
+102211.0
+""Blomquist, Laura""
+98221.0
+""Bob Pennefather""
+103617.0
+""Bonnie McCune""
+100059.0
+""Brue, Jill""
+99223.0
+""Bruner, Virginia""
+100346.0
+""Cale, Harriett""
+99616.0
+""Carey Beckstead""
+102021.0
+""Carpenter, Jan""
+101170.0
+""Carpenter, Jill""
+104224.0
+""Charles A.W. Adams""
+102605.0
+""Clark, Carol""
+99486.0
+""Clayton, Nancy""
+103864.0
+""Colleen Hurwitz""
+103907.0
+""Collins, Babs""
+102752.0
+""Craig A. Edwards""
+101970.0
+""Dallas Alumnae""
+101112.0
+""Daniel Champ""
+104913.0
+""Davis, Nancy""
+97952.0
+""Deepak D. Raj""
+100233.0
+""Dhruv Gupta""
+98729.0
+""Dodds, Christina""
+100405.0
+""Ellis, Elaine""
+104452.0
+""Eric Jones""
+103790.0
+""Eric Landry""
+102914.0
+""Familo, Amy""
+100570.0
+""Faris, Marilyn""
+103882.0
+""G.P Pandey""
+102542.0
+""Gail Anderson-Dargatz""
+99993.0
+""Galehan, Karen""
+100999.0
+""Galen Kountz""
+103561.0
+""Gary Ledbetter""
+98767.0
+""George Mattok""
+97971.0
+""Gerardo Colmenar""
+104186.0
+""Harish Kumar""
+102068.0
+""Harsh Manglik""
+102235.0
+""Hastrich, Mary Frances""
+102182.0
+""Hougaard, Patricia""
+98324.0
+""Hudgins, Carolyn""
+98565.0
+""J. L. Rastogi""
+100819.0
+""Jack Juni""
+101132.0
+""Jeet Bindra""
+99583.0
+""Joe Schmidt""
+99143.0
+""Jones, Melody""
+104832.0
+""K.K Dave""
+101589.0"
+databricks,logical.staples.databricks,Staples.databricks,Query.Unaggregated_Filter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Unaggregated_Filter.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Unaggregated_Filter.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,349.0,"
+      SELECT `Staples`.`Call_Center_Region` AS `call_center_region`,
+  `Staples`.`PID` AS `pid`,
+  `Staples`.`Customer_Balance` AS `sum_customer_balance_ok`,
+  `Staples`.`Order_Quantity` AS `sum_order_quantity_ok`,
+  YEAR(`Staples`.`Order_Date`) AS `yr_order_date_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((`Staples`.`Call_Center_Region` NOT IN ('CENTRAL')) AND (`Staples`.`Discount` >= 0.091693999999999998) AND (`Staples`.`Discount` <= 0.214724) AND (`Staples`.`Order_Date` >= CAST('2001-06-01 00:00:00' AS TIMESTAMP)) AND (`Staples`.`Order_Date` <= CAST('2002-06-01 00:00:00' AS TIMESTAMP)) AND (YEAR(`Staples`.`Order_Date`) IN (2001, 2002)))
+    ","""EAST""
+40479
+3214.0
+30.0
+2001
+""EAST""
+40480
+3214.0
+1.0
+2001
+""EAST""
+40481
+3214.0
+26.0
+2001
+""EAST""
+40504
+2210.0
+34.0
+2001
+""EAST""
+40505
+2210.0
+49.0
+2001
+""EAST""
+40507
+2210.0
+29.0
+2001
+""EAST""
+40510
+2829.0
+38.0
+2001
+""EAST""
+40523
+910.0
+27.0
+2001
+""EAST""
+40524
+910.0
+37.0
+2001
+""EAST""
+40525
+910.0
+7.0
+2001
+""EAST""
+40545
+378.0
+4.0
+2001
+""EAST""
+40548
+378.0
+35.0
+2001
+""EAST""
+40564
+2975.0
+6.0
+2001
+""EAST""
+40566
+2975.0
+36.0
+2001
+""EAST""
+40567
+2975.0
+32.0
+2001
+""EAST""
+40572
+1194.0
+22.0
+2001
+""EAST""
+40582
+-882.0
+26.0
+2001
+""EAST""
+40584
+-882.0
+21.0
+2001
+""EAST""
+40586
+1438.0
+11.0
+2001
+""EAST""
+40587
+1438.0
+7.0
+2001","""EAST""
+40479
+3214.0
+30.0
+2001
+""EAST""
+40480
+3214.0
+1.0
+2001
+""EAST""
+40481
+3214.0
+26.0
+2001
+""EAST""
+40504
+2210.0
+34.0
+2001
+""EAST""
+40505
+2210.0
+49.0
+2001
+""EAST""
+40507
+2210.0
+29.0
+2001
+""EAST""
+40510
+2829.0
+38.0
+2001
+""EAST""
+40523
+910.0
+27.0
+2001
+""EAST""
+40524
+910.0
+37.0
+2001
+""EAST""
+40525
+910.0
+7.0
+2001
+""EAST""
+40545
+378.0
+4.0
+2001
+""EAST""
+40548
+378.0
+35.0
+2001
+""EAST""
+40564
+2975.0
+6.0
+2001
+""EAST""
+40566
+2975.0
+36.0
+2001
+""EAST""
+40567
+2975.0
+32.0
+2001
+""EAST""
+40572
+1194.0
+22.0
+2001
+""EAST""
+40582
+-882.0
+26.0
+2001
+""EAST""
+40584
+-882.0
+21.0
+2001
+""EAST""
+40586
+1438.0
+11.0
+2001
+""EAST""
+40587
+1438.0
+7.0
+2001"
+databricks,logical.staples.databricks,Staples.databricks,Query.Unaggregated_Filter_NoDateTime,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Unaggregated_Filter_NoDateTime.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.Query.Unaggregated_Filter_NoDateTime.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,377.0,"
+      SELECT `Staples`.`Call_Center_Region` AS `call_center_region`,
+  `Staples`.`PID` AS `pid`,
+  `Staples`.`Customer_Balance` AS `sum_customer_balance_ok`,
+  `Staples`.`Order_Quantity` AS `sum_order_quantity_ok`,
+  YEAR(`Staples`.`Order_Date`) AS `yr_order_date_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((`Staples`.`Call_Center_Region` NOT IN ('CENTRAL')) AND (`Staples`.`Discount` >= 0.091693999999999998) AND (`Staples`.`Discount` <= 0.214724) AND (YEAR(`Staples`.`Order_Date`) IN (2001, 2002)))
+    ","""EAST""
+36558
+-617.0
+30.0
+2001
+""EAST""
+36560
+8899.0
+13.0
+2001
+""EAST""
+36564
+8899.0
+47.0
+2001
+""EAST""
+36565
+9109.0
+15.0
+2001
+""EAST""
+36570
+9109.0
+13.0
+2001
+""EAST""
+36572
+2099.0
+6.0
+2001
+""EAST""
+36575
+2099.0
+19.0
+2001
+""EAST""
+36578
+8217.0
+34.0
+2001
+""EAST""
+36590
+8795.0
+34.0
+2001
+""EAST""
+36600
+3829.0
+16.0
+2001
+""EAST""
+36620
+958.0
+22.0
+2001
+""EAST""
+36624
+958.0
+9.0
+2001
+""EAST""
+36627
+-982.0
+40.0
+2001
+""EAST""
+36629
+-982.0
+39.0
+2001
+""EAST""
+36630
+-982.0
+8.0
+2001
+""EAST""
+36632
+7412.0
+8.0
+2001
+""EAST""
+36636
+-98.0
+12.0
+2001
+""EAST""
+36637
+-98.0
+21.0
+2001
+""EAST""
+36640
+4151.0
+32.0
+2001
+""EAST""
+36660
+-377.0
+21.0
+2001","""EAST""
+36558
+-617.0
+30.0
+2001
+""EAST""
+36560
+8899.0
+13.0
+2001
+""EAST""
+36564
+8899.0
+47.0
+2001
+""EAST""
+36565
+9109.0
+15.0
+2001
+""EAST""
+36570
+9109.0
+13.0
+2001
+""EAST""
+36572
+2099.0
+6.0
+2001
+""EAST""
+36575
+2099.0
+19.0
+2001
+""EAST""
+36578
+8217.0
+34.0
+2001
+""EAST""
+36590
+8795.0
+34.0
+2001
+""EAST""
+36600
+3829.0
+16.0
+2001
+""EAST""
+36620
+958.0
+22.0
+2001
+""EAST""
+36624
+958.0
+9.0
+2001
+""EAST""
+36627
+-982.0
+40.0
+2001
+""EAST""
+36629
+-982.0
+39.0
+2001
+""EAST""
+36630
+-982.0
+8.0
+2001
+""EAST""
+36632
+7412.0
+8.0
+2001
+""EAST""
+36636
+-98.0
+12.0
+2001
+""EAST""
+36637
+-98.0
+21.0
+2001
+""EAST""
+36640
+4151.0
+32.0
+2001
+""EAST""
+36660
+-377.0
+21.0
+2001"
+databricks,logical.staples.databricks,Staples.databricks,ZTesting.Staples9,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.ZTesting.Staples9.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/staples\setup.ZTesting.Staples9.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,297.0,"
+      SELECT `Staples`.`PID` AS `pid`,
+  `Staples`.`Gross_Profit` AS `sum_gross_profit_ok`,
+  `Staples`.`Sales_Total` AS `sum_sales_total_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+WHERE ((`Staples`.`Call_Center_Region` = 'EAST') AND (`Staples`.`Sales_Total` >= -3640.23) AND (`Staples`.`Sales_Total` <= 24622.400000000001) AND (YEAR(`Staples`.`Order_Date`) = 2002))
+    ","45686
+25.62
+207.59
+45687
+31.39
+108.91
+45688
+472.9
+1563.46
+45696
+-45.04
+74.34
+45697
+5.35
+28.09
+45701
+4.55
+28.25
+45708
+-18.96
+93.25
+45709
+163.19
+581.37
+45710
+114.75
+206.21
+45711
+-54.28
+986.34
+45719
+353.6
+1940.52
+45720
+-214.63
+116.89
+45727
+-443.93
+762.75
+45728
+2.14
+63.55
+45729
+20.81
+85.38
+45730
+-141.67
+179.64
+45731
+-291.61
+3275.58
+45732
+-17.28
+38.48
+45733
+505.99
+1128.11
+45734
+-133.49
+241.87
+45744
+636.91
+1854.85
+45745
+-108.85
+418.94
+45746
+313.28
+1204.16
+45747
+70.44
+215.32
+45748
+73.07
+1461.78
+45749
+-349.68
+699.5
+45750
+-24.0
+140.27
+45766
+100.01
+1492.74
+45767
+739.49
+1395.03
+45768
+266.19
+1779.23
+45769
+-71.13
+110.19
+45770
+947.36
+4040.84
+45771
+35.06
+77.0
+45786","45686
+25.62
+207.59
+45687
+31.39
+108.91
+45688
+472.9
+1563.46
+45696
+-45.04
+74.34
+45697
+5.35
+28.09
+45701
+4.55
+28.25
+45708
+-18.96
+93.25
+45709
+163.19
+581.37
+45710
+114.75
+206.21
+45711
+-54.28
+986.34
+45719
+353.6
+1940.52
+45720
+-214.63
+116.89
+45727
+-443.93
+762.75
+45728
+2.14
+63.55
+45729
+20.81
+85.38
+45730
+-141.67
+179.64
+45731
+-291.61
+3275.58
+45732
+-17.28
+38.48
+45733
+505.99
+1128.11
+45734
+-133.49
+241.87
+45744
+636.91
+1854.85
+45745
+-108.85
+418.94
+45746
+313.28
+1204.16
+45747
+70.44
+215.32
+45748
+73.07
+1461.78
+45749
+-349.68
+699.5
+45750
+-24.0
+140.27
+45766
+100.01
+1492.74
+45767
+739.49
+1395.03
+45768
+266.19
+1779.23
+45769
+-71.13
+110.19
+45770
+947.36
+4040.84
+45771
+35.06
+77.0
+45786"
+databricks,logical.lod.databricks,Staples.databricks,lod.10_As in-out Set,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.10_As in-out Set.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.10_As in-out Set.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,3294.0,"
+      SELECT `t0`.`lod___fixed___1__copy_2_` AS `lod___fixed___1__copy_2_`
+FROM (
+  SELECT MIN(`Staples`.`Order_Date`) AS `lod___fixed___1__copy_2_`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY `Staples`.`Customer_Name`
+) `t0`
+GROUP BY 1
+ORDER BY `lod___fixed___1__copy_2_` ASC
+    ","#1997-01-01 00:00:00#
+#1997-01-02 00:00:00#
+#1997-01-03 00:00:00#
+#1997-01-04 00:00:00#
+#1997-01-05 00:00:00#
+#1997-01-06 00:00:00#
+#1997-01-07 00:00:00#
+#1997-01-08 00:00:00#
+#1997-01-09 00:00:00#
+#1997-01-10 00:00:00#
+#1997-01-11 00:00:00#
+#1997-01-12 00:00:00#
+#1997-01-13 00:00:00#
+#1997-01-14 00:00:00#
+#1997-01-15 00:00:00#
+#1997-01-17 00:00:00#
+#1997-01-18 00:00:00#
+#1997-01-19 00:00:00#
+#1997-01-20 00:00:00#
+#1997-01-21 00:00:00#
+#1997-01-23 00:00:00#
+#1997-01-24 00:00:00#
+#1997-01-26 00:00:00#
+#1997-01-28 00:00:00#
+#1997-01-31 00:00:00#
+#1997-02-02 00:00:00#
+#1997-02-10 00:00:00#","#1997-01-01 00:00:00#
+#1997-01-02 00:00:00#
+#1997-01-03 00:00:00#
+#1997-01-04 00:00:00#
+#1997-01-05 00:00:00#
+#1997-01-06 00:00:00#
+#1997-01-07 00:00:00#
+#1997-01-08 00:00:00#
+#1997-01-09 00:00:00#
+#1997-01-10 00:00:00#
+#1997-01-11 00:00:00#
+#1997-01-12 00:00:00#
+#1997-01-13 00:00:00#
+#1997-01-14 00:00:00#
+#1997-01-15 00:00:00#
+#1997-01-17 00:00:00#
+#1997-01-18 00:00:00#
+#1997-01-19 00:00:00#
+#1997-01-20 00:00:00#
+#1997-01-21 00:00:00#
+#1997-01-23 00:00:00#
+#1997-01-24 00:00:00#
+#1997-01-26 00:00:00#
+#1997-01-28 00:00:00#
+#1997-01-31 00:00:00#
+#1997-02-02 00:00:00#
+#1997-02-10 00:00:00#"
+databricks,logical.lod.databricks,Staples.databricks,lod.11_As in-out Set,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.11_As in-out Set.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.11_As in-out Set.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2145.0,"
+      SELECT `t0`.`x_measure__0` AS `lod___fixed___1__copy_2_`
+FROM `tableau_tdvt`.`staples` `Staples`
+  JOIN (
+  SELECT `Staples`.`Customer_Name` AS `customer_name`,
+    MIN(`Staples`.`Order_Date`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+) `t0` ON (`Staples`.`Customer_Name` IS NOT DISTINCT FROM `t0`.`customer_name`)
+WHERE (`t0`.`x_measure__0` IS NULL)
+LIMIT 1
+    ",,
+databricks,logical.lod.databricks,Staples.databricks,lod.12_As in-out Set,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.12_As in-out Set.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.12_As in-out Set.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,3644.0,"
+      SELECT `t0`.`lod___fixed___1__copy_2_` AS `lod___fixed___1__copy_2_`
+FROM (
+  SELECT MIN(`Staples`.`Order_Date`) AS `lod___fixed___1__copy_2_`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY `Staples`.`Customer_Name`
+) `t0`
+GROUP BY 1
+ORDER BY `lod___fixed___1__copy_2_` ASC
+    ","#1997-01-01 00:00:00#
+#1997-01-02 00:00:00#
+#1997-01-03 00:00:00#
+#1997-01-04 00:00:00#
+#1997-01-05 00:00:00#
+#1997-01-06 00:00:00#
+#1997-01-07 00:00:00#
+#1997-01-08 00:00:00#
+#1997-01-09 00:00:00#
+#1997-01-10 00:00:00#
+#1997-01-11 00:00:00#
+#1997-01-12 00:00:00#
+#1997-01-13 00:00:00#
+#1997-01-14 00:00:00#
+#1997-01-15 00:00:00#
+#1997-01-17 00:00:00#
+#1997-01-18 00:00:00#
+#1997-01-19 00:00:00#
+#1997-01-20 00:00:00#
+#1997-01-21 00:00:00#
+#1997-01-23 00:00:00#
+#1997-01-24 00:00:00#
+#1997-01-26 00:00:00#
+#1997-01-28 00:00:00#
+#1997-01-31 00:00:00#
+#1997-02-02 00:00:00#
+#1997-02-10 00:00:00#","#1997-01-01 00:00:00#
+#1997-01-02 00:00:00#
+#1997-01-03 00:00:00#
+#1997-01-04 00:00:00#
+#1997-01-05 00:00:00#
+#1997-01-06 00:00:00#
+#1997-01-07 00:00:00#
+#1997-01-08 00:00:00#
+#1997-01-09 00:00:00#
+#1997-01-10 00:00:00#
+#1997-01-11 00:00:00#
+#1997-01-12 00:00:00#
+#1997-01-13 00:00:00#
+#1997-01-14 00:00:00#
+#1997-01-15 00:00:00#
+#1997-01-17 00:00:00#
+#1997-01-18 00:00:00#
+#1997-01-19 00:00:00#
+#1997-01-20 00:00:00#
+#1997-01-21 00:00:00#
+#1997-01-23 00:00:00#
+#1997-01-24 00:00:00#
+#1997-01-26 00:00:00#
+#1997-01-28 00:00:00#
+#1997-01-31 00:00:00#
+#1997-02-02 00:00:00#
+#1997-02-10 00:00:00#"
+databricks,logical.lod.databricks,Staples.databricks,lod.13_As in-out Set,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.13_As in-out Set.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.13_As in-out Set.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1721.0,"
+      SELECT `t0`.`x_measure__0` AS `lod___fixed___1__copy_2_`
+FROM `tableau_tdvt`.`staples` `Staples`
+  JOIN (
+  SELECT `Staples`.`Customer_Name` AS `customer_name`,
+    MIN(`Staples`.`Order_Date`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+) `t0` ON (`Staples`.`Customer_Name` IS NOT DISTINCT FROM `t0`.`customer_name`)
+WHERE (`t0`.`x_measure__0` IS NULL)
+LIMIT 1
+    ",,
+databricks,logical.lod.databricks,Staples.databricks,lod.14_As in-out Set,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.14_As in-out Set.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.14_As in-out Set.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,6089.0,"
+      SELECT `t8`.`x_measure__1` AS `avg_calculation_4621225004123988_ok`,
+  `t3`.`io_set_1_nk` AS `io_set_1_nk`,
+  `t3`.`sum_sales_total_ok` AS `sum_sales_total_ok`
+FROM (
+  SELECT (NOT (`t2`.`xtemp2_output` IS NULL)) AS `io_set_1_nk`,
+    SUM(`Staples`.`Sales_Total`) AS `sum_sales_total_ok`
+  FROM `tableau_tdvt`.`staples` `Staples`
+    JOIN (
+    SELECT `Staples`.`Customer_Name` AS `customer_name`,
+      MIN(`Staples`.`Order_Date`) AS `x_measure__0`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY 1
+  ) `t0` ON (`Staples`.`Customer_Name` IS NOT DISTINCT FROM `t0`.`customer_name`)
+    LEFT OUTER JOIN (
+    SELECT `t1`.`none_lod___fixed___1__copy_2__ok` AS `none_lod___fixed___1__copy_2__ok`,
+      1 AS `xtemp2_output`
+    FROM (
+      SELECT MIN(`Staples`.`Order_Date`) AS `none_lod___fixed___1__copy_2__ok`
+      FROM `tableau_tdvt`.`staples` `Staples`
+      GROUP BY `Staples`.`Customer_Name`
+      HAVING (NOT (MIN(`Staples`.`Order_Date`) IN (CAST('1997-01-03 00:00:00' AS TIMESTAMP), CAST('1997-01-07 00:00:00' AS TIMESTAMP), CAST('1997-01-11 00:00:00' AS TIMESTAMP))))
+    ) `t1`
+    GROUP BY 1
+  ) `t2` ON (`t0`.`x_measure__0` = `t2`.`none_lod___fixed___1__copy_2__ok`)
+  GROUP BY 1
+) `t3`
+  JOIN (
+  SELECT `t7`.`io_set_1_nk` AS `io_set_1_nk`,
+    AVG(`t7`.`x_measure__2`) AS `x_measure__1`
+  FROM (
+    SELECT (NOT (`t6`.`xtemp5_output` IS NULL)) AS `io_set_1_nk`,
+      SUM(`Staples`.`Sales_Total`) AS `x_measure__2`
+    FROM `tableau_tdvt`.`staples` `Staples`
+      JOIN (
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+        MIN(`Staples`.`Order_Date`) AS `x_measure__0`
+      FROM `tableau_tdvt`.`staples` `Staples`
+      GROUP BY 1
+    ) `t4` ON (`Staples`.`Customer_Name` IS NOT DISTINCT FROM `t4`.`customer_name`)
+      LEFT OUTER JOIN (
+      SELECT `t5`.`none_lod___fixed___1__copy_2__ok` AS `none_lod___fixed___1__copy_2__ok`,
+        1 AS `xtemp5_output`
+      FROM (
+        SELECT MIN(`Staples`.`Order_Date`) AS `none_lod___fixed___1__copy_2__ok`
+        FROM `tableau_tdvt`.`staples` `Staples`
+        GROUP BY `Staples`.`Customer_Name`
+        HAVING (NOT (MIN(`Staples`.`Order_Date`) IN (CAST('1997-01-03 00:00:00' AS TIMESTAMP), CAST('1997-01-07 00:00:00' AS TIMESTAMP), CAST('1997-01-11 00:00:00' AS TIMESTAMP))))
+      ) `t5`
+      GROUP BY 1
+    ) `t6` ON (`t4`.`x_measure__0` = `t6`.`none_lod___fixed___1__copy_2__ok`)
+    GROUP BY `Staples`.`Prod_Type1`,
+      1
+  ) `t7`
+  GROUP BY 1
+) `t8` ON (`t3`.`io_set_1_nk` = `t8`.`io_set_1_nk`)
+    ","4330452.9
+false
+12991359.0
+28565526.0
+true
+85696579.0","4330452.9
+false
+12991359.0
+28565526.0
+true
+85696579.0"
+databricks,logical.lod.databricks,Staples.databricks,lod.15_As Bin,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.15_As Bin.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.15_As Bin.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2083.0,"
+      SELECT FLOOR(`t0`.`x_measure__0` / 475) AS `lod___fixed___1__bin_`,
+  SUM(`Staples`.`Sales_Total`) AS `sum_sales_total_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+  JOIN (
+  SELECT `Staples`.`Market_Segment` AS `market_segment`,
+    SUM(`Staples`.`Product_Base_Margin`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+) `t0` ON (`Staples`.`Market_Segment` IS NOT DISTINCT FROM `t0`.`market_segment`)
+GROUP BY 1
+    ","11
+38580396.0
+14
+24513651.0
+21
+35593890.0","11
+38580396.0
+14
+24513651.0
+21
+35593890.0"
+databricks,logical.lod.databricks,Staples.databricks,lod.16_As Group,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.16_As Group.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.16_As Group.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,7035.0,"
+      SELECT `t1`.`lod___fixed___4__group_` AS `lod___fixed___4__group_`,
+  CAST(`t4`.`x_measure__1` AS DOUBLE) AS `avg_calculation_4821225012418421_ok`,
+  `t1`.`avg_price_ok` AS `avg_price_ok`,
+  `t7`.`x_measure__4` AS `sum_calculation_4621225004123988_ok`
+FROM (
+  SELECT (CASE WHEN (CAST((12 * YEAR(`Staples`.`Order_Date`) + MONTH(`Staples`.`Order_Date`)) - (12 * YEAR(`t0`.`x_measure__0`) + MONTH(`t0`.`x_measure__0`)) AS BIGINT) IN (0, 1, 2, 3, 4, 5, 6)) THEN 0 WHEN (CAST((12 * YEAR(`Staples`.`Order_Date`) + MONTH(`Staples`.`Order_Date`)) - (12 * YEAR(`t0`.`x_measure__0`) + MONTH(`t0`.`x_measure__0`)) AS BIGINT) IN (7, 8, 9, 10, 11, 12, 13, 14, 15)) THEN 7 WHEN (CAST((12 * YEAR(`Staples`.`Order_Date`) + MONTH(`Staples`.`Order_Date`)) - (12 * YEAR(`t0`.`x_measure__0`) + MONTH(`t0`.`x_measure__0`)) AS BIGINT) IN (16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64)) THEN 16 ELSE 71 END) AS `lod___fixed___4__group_`,
+    AVG(`Staples`.`Price`) AS `avg_price_ok`
+  FROM `tableau_tdvt`.`staples` `Staples`
+    JOIN (
+    SELECT MIN(`Staples`.`Order_Date`) AS `x_measure__0`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY 1.1000000000000001
+  ) `t0`
+  GROUP BY 1
+) `t1`
+  JOIN (
+  SELECT MIN(`Staples`.`Order_Date`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1.1000000000000001
+) `t2`
+  JOIN (
+  SELECT MONTH(`t3`.`x_measure__0`) AS `calculation_8741225012317469`,
+    SUM(`Staples`.`Order_Quantity`) AS `x_measure__1`
+  FROM `tableau_tdvt`.`staples` `Staples`
+    JOIN (
+    SELECT MIN(`Staples`.`Order_Date`) AS `x_measure__0`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY 1.1000000000000001
+  ) `t3`
+  GROUP BY 1
+) `t4` ON (MONTH(`t2`.`x_measure__0`) IS NOT DISTINCT FROM `t4`.`calculation_8741225012317469`)
+  JOIN (
+  SELECT `t6`.`lod___fixed___4__group_` AS `lod___fixed___4__group_`,
+    SUM(`t6`.`x_measure__3`) AS `x_measure__4`
+  FROM (
+    SELECT (CASE WHEN (CAST((12 * YEAR(`Staples`.`Order_Date`) + MONTH(`Staples`.`Order_Date`)) - (12 * YEAR(`t5`.`x_measure__0`) + MONTH(`t5`.`x_measure__0`)) AS BIGINT) IN (0, 1, 2, 3, 4, 5, 6)) THEN 0 WHEN (CAST((12 * YEAR(`Staples`.`Order_Date`) + MONTH(`Staples`.`Order_Date`)) - (12 * YEAR(`t5`.`x_measure__0`) + MONTH(`t5`.`x_measure__0`)) AS BIGINT) IN (7, 8, 9, 10, 11, 12, 13, 14, 15)) THEN 7 WHEN (CAST((12 * YEAR(`Staples`.`Order_Date`) + MONTH(`Staples`.`Order_Date`)) - (12 * YEAR(`t5`.`x_measure__0`) + MONTH(`t5`.`x_measure__0`)) AS BIGINT) IN (16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64)) THEN 16 ELSE 71 END) AS `lod___fixed___4__group_`,
+      SUM(`Staples`.`Sales_Total`) AS `x_measure__3`
+    FROM `tableau_tdvt`.`staples` `Staples`
+      JOIN (
+      SELECT MIN(`Staples`.`Order_Date`) AS `x_measure__0`
+      FROM `tableau_tdvt`.`staples` `Staples`
+      GROUP BY 1.1000000000000001
+    ) `t5`
+    GROUP BY 1,
+      `Staples`.`Prod_Type1`
+  ) `t6`
+  GROUP BY 1
+) `t7` ON (`t1`.`lod___fixed___4__group_` = `t7`.`lod___fixed___4__group_`)
+    ","0
+1390980.0
+83.376849
+9334296.5
+7
+1390980.0
+90.50068
+12192129.0
+16
+1390980.0
+85.679629
+67941185.0
+71
+1390980.0
+82.764691
+9220327.3","0
+1390980.0
+83.376849
+9334296.5
+7
+1390980.0
+90.50068
+12192129.0
+16
+1390980.0
+85.679629
+67941185.0
+71
+1390980.0
+82.764691
+9220327.3"
+databricks,logical.lod.databricks,Staples.databricks,lod.17_Nesting,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.17_Nesting.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.17_Nesting.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,9431.0,"
+      SELECT `t4`.`prod_type1` AS `prod_type1`,
+  `t4`.`ship_mode` AS `ship_mode`,
+  `t8`.`x_measure__0` AS `temp_attr_lod___nesting___1__copy__qk__1075333431__0_`,
+  `t8`.`x_measure__0` AS `temp_attr_lod___nesting___1__copy__qk__260755027__0_`,
+  `t4`.`avg_calculation_8601225013155991_ok` AS `avg_calculation_8601225013155991_ok`,
+  `t8`.`x_measure__3` AS `sum_calculation_9271225012544475_ok`,
+  `t8`.`x_measure__4` AS `sum_lod___nesting___2__copy__ok`,
+  `t10`.`x_measure__0` AS `sum_lod___nesting___3__copy__ok`
+FROM (
+  SELECT `Staples`.`Prod_Type1` AS `prod_type1`,
+    `Staples`.`Ship_Mode` AS `ship_mode`,
+    AVG((CASE WHEN `t3`.`x_measure__2` = 0 THEN NULL ELSE ((`t1`.`x_measure__0` + CAST(`t2`.`x_measure__1` AS DOUBLE)) + `Staples`.`Sales_Total`) / `t3`.`x_measure__2` END)) AS `avg_calculation_8601225013155991_ok`
+  FROM `tableau_tdvt`.`staples` `Staples`
+    JOIN (
+    SELECT `t0`.`prod_type1` AS `prod_type1`,
+      AVG(`t0`.`x_measure__1`) AS `x_measure__0`
+    FROM (
+      SELECT `Staples`.`Prod_Type1` AS `prod_type1`,
+        SUM(`Staples`.`Sales_Total`) AS `x_measure__1`
+      FROM `tableau_tdvt`.`staples` `Staples`
+      GROUP BY 1,
+        `Staples`.`Prod_Type2`,
+        `Staples`.`Prod_Type3`
+    ) `t0`
+    GROUP BY 1
+  ) `t1` ON (`Staples`.`Prod_Type1` IS NOT DISTINCT FROM `t1`.`prod_type1`)
+    JOIN (
+    SELECT `Staples`.`Prod_Type1` AS `prod_type1`,
+      `Staples`.`Ship_Mode` AS `ship_mode`,
+      SUM(`Staples`.`Sales_Total`) AS `x_measure__1`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY 1,
+      2
+  ) `t2` ON ((`Staples`.`Prod_Type1` IS NOT DISTINCT FROM `t2`.`prod_type1`) AND (`Staples`.`Ship_Mode` IS NOT DISTINCT FROM `t2`.`ship_mode`))
+    JOIN (
+    SELECT `Staples`.`Market_Segment` AS `market_segment`,
+      SUM(`Staples`.`Product_Base_Margin`) AS `x_measure__2`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY 1
+  ) `t3` ON (`Staples`.`Market_Segment` IS NOT DISTINCT FROM `t3`.`market_segment`)
+  GROUP BY 1,
+    2
+) `t4`
+  JOIN (
+  SELECT `t5`.`prod_type1` AS `prod_type1`,
+    `t5`.`ship_mode` AS `ship_mode`,
+    AVG(`t5`.`x_measure__1`) AS `x_measure__0`,
+    SUM(CAST(`t6`.`x_measure__1` AS DOUBLE)) AS `x_measure__3`,
+    SUM(CAST(`t7`.`x_measure__1` AS DOUBLE)) AS `x_measure__4`
+  FROM (
+    SELECT `Staples`.`Prod_Type1` AS `prod_type1`,
+      `Staples`.`Ship_Mode` AS `ship_mode`,
+      SUM(`Staples`.`Sales_Total`) AS `x_measure__1`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY 1,
+      `Staples`.`Prod_Type2`,
+      `Staples`.`Prod_Type3`,
+      2
+  ) `t5`
+    JOIN (
+    SELECT `Staples`.`Prod_Type1` AS `prod_type1`,
+      `Staples`.`Ship_Mode` AS `ship_mode`,
+      SUM(`Staples`.`Sales_Total`) AS `x_measure__1`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY 1,
+      2
+  ) `t6` ON ((`t5`.`prod_type1` IS NOT DISTINCT FROM `t6`.`prod_type1`) AND (`t5`.`ship_mode` IS NOT DISTINCT FROM `t6`.`ship_mode`))
+    JOIN (
+    SELECT `Staples`.`Prod_Type1` AS `prod_type1`,
+      SUM(`Staples`.`Sales_Total`) AS `x_measure__1`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY 1
+  ) `t7` ON (`t5`.`prod_type1` IS NOT DISTINCT FROM `t7`.`prod_type1`)
+  GROUP BY 1,
+    2
+) `t8` ON ((`t4`.`prod_type1` IS NOT DISTINCT FROM `t8`.`prod_type1`) AND (`t4`.`ship_mode` IS NOT DISTINCT FROM `t8`.`ship_mode`))
+  JOIN (
+  SELECT `t9`.`prod_type1` AS `prod_type1`,
+    AVG(`t9`.`x_measure__1`) AS `x_measure__0`
+  FROM (
+    SELECT `Staples`.`Prod_Type1` AS `prod_type1`,
+      SUM(`Staples`.`Sales_Total`) AS `x_measure__1`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY 1,
+      `Staples`.`Prod_Type2`,
+      `Staples`.`Prod_Type3`
+  ) `t9`
+  GROUP BY 1
+) `t10` ON (`t4`.`prod_type1` IS NOT DISTINCT FROM `t10`.`prod_type1`)
+    ","""FURNITURE""
+""DELIVERY TRUCK""
+4002620.2
+4002620.2
+4271.0757
+1.9612839e+08
+2.380636e+08
+2267272.4
+""FURNITURE""
+""EXPRESS AIR""
+76460.766
+76460.766
+443.56198
+9251752.7
+3.7409995e+08
+2267272.4
+""FURNITURE""
+""REGULAR AIR""
+468152.41
+468152.41
+1046.4216
+56646441.0
+3.7409995e+08
+2267272.4
+""OFFICE SUPPLIES""
+""DELIVERY TRUCK""
+819224.44
+819224.44
+435.20844
+7373020.0
+72044220.0
+649047.03
+""OFFICE SUPPLIES""
+""EXPRESS AIR""
+83280.028
+83280.028
+501.43046
+1.0201803e+08
+8.405159e+08
+649047.03
+""OFFICE SUPPLIES""
+""REGULAR AIR""
+532636.16
+532636.16
+2729.3706
+6.524793e+08
+8.405159e+08
+649047.03
+""TECHNOLOGY""
+""DELIVERY TRUCK""
+6038779.5
+6038779.5
+2386.7716
+24155118.0
+81328223.0
+4518234.6
+""TECHNOLOGY""
+""EXPRESS AIR""
+445944.71
+445944.71
+1143.9339
+28540462.0
+3.2531289e+08
+4518234.6
+""TECHNOLOGY""
+""REGULAR AIR""
+3127374.3
+3127374.3
+4182.9544
+2.0015196e+08
+3.2531289e+08
+4518234.6","""FURNITURE""
+""DELIVERY TRUCK""
+4002620.2
+4002620.2
+4271.0757
+1.9612839e+08
+2.380636e+08
+2267272.4
+""FURNITURE""
+""EXPRESS AIR""
+76460.766
+76460.766
+443.56198
+9251752.7
+3.7409995e+08
+2267272.4
+""FURNITURE""
+""REGULAR AIR""
+468152.41
+468152.41
+1046.4216
+56646441.0
+3.7409995e+08
+2267272.4
+""OFFICE SUPPLIES""
+""DELIVERY TRUCK""
+819224.44
+819224.44
+435.20844
+7373020.0
+72044220.0
+649047.03
+""OFFICE SUPPLIES""
+""EXPRESS AIR""
+83280.028
+83280.028
+501.43046
+1.0201803e+08
+8.405159e+08
+649047.03
+""OFFICE SUPPLIES""
+""REGULAR AIR""
+532636.16
+532636.16
+2729.3706
+6.524793e+08
+8.405159e+08
+649047.03
+""TECHNOLOGY""
+""DELIVERY TRUCK""
+6038779.5
+6038779.5
+2386.7716
+24155118.0
+81328223.0
+4518234.6
+""TECHNOLOGY""
+""EXPRESS AIR""
+445944.71
+445944.71
+1143.9339
+28540462.0
+3.2531289e+08
+4518234.6
+""TECHNOLOGY""
+""REGULAR AIR""
+3127374.3
+3127374.3
+4182.9544
+2.0015196e+08
+3.2531289e+08
+4518234.6"
+databricks,logical.lod.databricks,Staples.databricks,lod.1_Difference From with Cross Join,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.1_Difference From with Cross Join.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.1_Difference From with Cross Join.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2616.0,"
+      SELECT `Staples`.`Customer_Name` AS `customer_name`,
+  CAST((12 * YEAR(`Staples`.`Order_Date`) + MONTH(`Staples`.`Order_Date`)) - (12 * YEAR(`t0`.`x_measure__0`) + MONTH(`t0`.`x_measure__0`)) AS BIGINT) AS `lod___fixed___2__copy_`,
+  SUM(`Staples`.`Sales_Total`) AS `sum_sales_total_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+  JOIN (
+  SELECT MIN(`Staples`.`Order_Date`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1.1000000000000001
+) `t0`
+GROUP BY 1,
+  2
+    ","""Barbara Fisher""
+0
+2752.47
+""Barbara Fisher""
+1
+17041.71
+""Barbara Fisher""
+2
+9445.89
+""Barbara Fisher""
+3
+2911.44
+""Barbara Fisher""
+4
+4767.19
+""Barbara Fisher""
+5
+7983.44
+""Barbara Fisher""
+6
+10388.9
+""Barbara Fisher""
+7
+13702.02
+""Barbara Fisher""
+8
+416.77
+""Barbara Fisher""
+9
+40965.51
+""Barbara Fisher""
+10
+21988.56
+""Barbara Fisher""
+12
+22536.97
+""Barbara Fisher""
+13
+203.88
+""Barbara Fisher""
+15
+5198.15
+""Barbara Fisher""
+16
+26347.71
+""Barbara Fisher""
+17
+27919.72
+""Barbara Fisher""
+18
+9505.41
+""Barbara Fisher""
+19
+39623.98
+""Barbara Fisher""
+20
+24160.32
+""Barbara Fisher""
+21
+4667.81
+""Barbara Fisher""
+22
+5899.77
+""Barbara Fisher""
+23
+1954.74
+""Barbara Fisher""
+24
+4483.27
+""Barbara Fisher""
+25
+18439.47
+""Barbara Fisher""
+26
+33336.26
+""Barbara Fisher""
+28
+14581.07
+""Barbara Fisher""
+29
+37760.61
+""Barbara Fisher""
+30
+15019.14
+""Barbara Fisher""
+31
+39299.51
+""Barbara Fisher""
+32
+15460.42
+""Barbara Fisher""
+33
+155.77
+""Barbara Fisher""
+34
+23026.96
+""Barbara Fisher""
+35
+3603.8
+""Barbara Fisher""","""Barbara Fisher""
+0
+2752.47
+""Barbara Fisher""
+1
+17041.71
+""Barbara Fisher""
+2
+9445.89
+""Barbara Fisher""
+3
+2911.44
+""Barbara Fisher""
+4
+4767.19
+""Barbara Fisher""
+5
+7983.44
+""Barbara Fisher""
+6
+10388.9
+""Barbara Fisher""
+7
+13702.02
+""Barbara Fisher""
+8
+416.77
+""Barbara Fisher""
+9
+40965.51
+""Barbara Fisher""
+10
+21988.56
+""Barbara Fisher""
+12
+22536.97
+""Barbara Fisher""
+13
+203.88
+""Barbara Fisher""
+15
+5198.15
+""Barbara Fisher""
+16
+26347.71
+""Barbara Fisher""
+17
+27919.72
+""Barbara Fisher""
+18
+9505.41
+""Barbara Fisher""
+19
+39623.98
+""Barbara Fisher""
+20
+24160.32
+""Barbara Fisher""
+21
+4667.81
+""Barbara Fisher""
+22
+5899.77
+""Barbara Fisher""
+23
+1954.74
+""Barbara Fisher""
+24
+4483.27
+""Barbara Fisher""
+25
+18439.47
+""Barbara Fisher""
+26
+33336.26
+""Barbara Fisher""
+28
+14581.07
+""Barbara Fisher""
+29
+37760.61
+""Barbara Fisher""
+30
+15019.14
+""Barbara Fisher""
+31
+39299.51
+""Barbara Fisher""
+32
+15460.42
+""Barbara Fisher""
+33
+155.77
+""Barbara Fisher""
+34
+23026.96
+""Barbara Fisher""
+35
+3603.8
+""Barbara Fisher"""
+databricks,logical.lod.databricks,Staples.databricks,lod.2_Cross Join,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.2_Cross Join.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.2_Cross Join.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1301.0,"
+      SELECT `Staples`.`Prod_Type2` AS `prod_type2`,
+  SUM(`Staples`.`Sales_Total`) AS `temp_calculation_5921225003343476__1510386096__0_`,
+  SUM(`Staples`.`Sales_Total`) AS `temp_calculation_5921225003343476__2532235894__0_`,
+  SUM(`Staples`.`Sales_Total`) AS `temp_calculation_5921225003343476__357447720__0_`
+FROM `tableau_tdvt`.`staples` `Staples`
+GROUP BY 1
+    ","""APPLIANCES""
+5247729.0
+5247729.0
+5247729.0
+""BINDERS AND BINDER ACCESSORIES""
+5545569.2
+5545569.2
+5545569.2
+""BOOKCASES""
+5257672.7
+5257672.7
+5257672.7
+""CHAIRS & CHAIRMATS""
+10497117.0
+10497117.0
+10497117.0
+""COMPUTER PERIPHERALS""
+5278781.7
+5278781.7
+5278781.7
+""COPIERS AND FAX""
+6776923.2
+6776923.2
+6776923.2
+""ENVELOPES""
+858634.48
+858634.48
+858634.48
+""LABELS""
+400169.21
+400169.21
+400169.21
+""OFFICE FURNISHINGS""
+3999750.0
+3999750.0
+3999750.0
+""OFFICE MACHINES""
+15099693.0
+15099693.0
+15099693.0
+""PAPER""
+3098545.7
+3098545.7
+3098545.7
+""PENS & ART SUPPLIES""
+1209942.5
+1209942.5
+1209942.5
+""RUBBER BANDS""
+95324.04
+95324.04
+95324.04
+""SCISSORS, RULERS AND TRIMMERS""
+1072184.3
+1072184.3
+1072184.3
+""STORAGE & ORGANIZATION""
+6486641.5
+6486641.5
+6486641.5
+""TABLES""
+14254546.0
+14254546.0
+14254546.0
+""TELEPHONES AND COMMUNICATION""
+13508713.0
+13508713.0
+13508713.0","""APPLIANCES""
+5247729.0
+5247729.0
+5247729.0
+""BINDERS AND BINDER ACCESSORIES""
+5545569.2
+5545569.2
+5545569.2
+""BOOKCASES""
+5257672.7
+5257672.7
+5257672.7
+""CHAIRS & CHAIRMATS""
+10497117.0
+10497117.0
+10497117.0
+""COMPUTER PERIPHERALS""
+5278781.7
+5278781.7
+5278781.7
+""COPIERS AND FAX""
+6776923.2
+6776923.2
+6776923.2
+""ENVELOPES""
+858634.48
+858634.48
+858634.48
+""LABELS""
+400169.21
+400169.21
+400169.21
+""OFFICE FURNISHINGS""
+3999750.0
+3999750.0
+3999750.0
+""OFFICE MACHINES""
+15099693.0
+15099693.0
+15099693.0
+""PAPER""
+3098545.7
+3098545.7
+3098545.7
+""PENS & ART SUPPLIES""
+1209942.5
+1209942.5
+1209942.5
+""RUBBER BANDS""
+95324.04
+95324.04
+95324.04
+""SCISSORS, RULERS AND TRIMMERS""
+1072184.3
+1072184.3
+1072184.3
+""STORAGE & ORGANIZATION""
+6486641.5
+6486641.5
+6486641.5
+""TABLES""
+14254546.0
+14254546.0
+14254546.0
+""TELEPHONES AND COMMUNICATION""
+13508713.0
+13508713.0
+13508713.0"
+databricks,logical.lod.databricks,Staples.databricks,lod.3_Disjoint LOD,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.3_Disjoint LOD.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.3_Disjoint LOD.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,3264.0,"
+      SELECT `t0`.`prod_type2` AS `prod_type2`,
+  SUM(`t1`.`x_measure__1`) AS `sum_calculation_4501225003531668_ok`
+FROM (
+  SELECT `Staples`.`Market_Segment` AS `market_segment`,
+    `Staples`.`Prod_Type2` AS `prod_type2`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1,
+    2
+) `t0`
+  JOIN (
+  SELECT `Staples`.`Market_Segment` AS `market_segment`,
+    SUM(`Staples`.`Product_Base_Margin`) AS `x_measure__1`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+) `t1` ON (`t0`.`market_segment` IS NOT DISTINCT FROM `t1`.`market_segment`)
+GROUP BY 1
+    ","""APPLIANCES""
+28278.32
+""BINDERS AND BINDER ACCESSORIES""
+28278.32
+""BOOKCASES""
+28278.32
+""CHAIRS & CHAIRMATS""
+28278.32
+""COMPUTER PERIPHERALS""
+28278.32
+""COPIERS AND FAX""
+28278.32
+""ENVELOPES""
+28278.32
+""LABELS""
+28278.32
+""OFFICE FURNISHINGS""
+28278.32
+""OFFICE MACHINES""
+28278.32
+""PAPER""
+28278.32
+""PENS & ART SUPPLIES""
+28278.32
+""RUBBER BANDS""
+28278.32
+""SCISSORS, RULERS AND TRIMMERS""
+28278.32
+""STORAGE & ORGANIZATION""
+28278.32
+""TABLES""
+28278.32
+""TELEPHONES AND COMMUNICATION""
+28278.32","""APPLIANCES""
+28278.32
+""BINDERS AND BINDER ACCESSORIES""
+28278.32
+""BOOKCASES""
+28278.32
+""CHAIRS & CHAIRMATS""
+28278.32
+""COMPUTER PERIPHERALS""
+28278.32
+""COPIERS AND FAX""
+28278.32
+""ENVELOPES""
+28278.32
+""LABELS""
+28278.32
+""OFFICE FURNISHINGS""
+28278.32
+""OFFICE MACHINES""
+28278.32
+""PAPER""
+28278.32
+""PENS & ART SUPPLIES""
+28278.32
+""RUBBER BANDS""
+28278.32
+""SCISSORS, RULERS AND TRIMMERS""
+28278.32
+""STORAGE & ORGANIZATION""
+28278.32
+""TABLES""
+28278.32
+""TELEPHONES AND COMMUNICATION""
+28278.32"
+databricks,logical.lod.databricks,Staples.databricks,lod.4_Subset Fixed,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.4_Subset Fixed.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.4_Subset Fixed.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2009.0,"
+      SELECT `t0`.`market_segment` AS `market_segment`,
+  `t0`.`prod_type2` AS `prod_type2`,
+  `t1`.`x_measure__0` AS `sum_calculation_4501225003531668_ok`
+FROM (
+  SELECT `Staples`.`Market_Segment` AS `market_segment`,
+    `Staples`.`Prod_Type2` AS `prod_type2`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1,
+    2
+) `t0`
+  JOIN (
+  SELECT `Staples`.`Market_Segment` AS `market_segment`,
+    SUM(`Staples`.`Product_Base_Margin`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+) `t1` ON (`t0`.`market_segment` IS NOT DISTINCT FROM `t1`.`market_segment`)
+    ","""CONSUMER""
+""APPLIANCES""
+5570.93
+""CONSUMER""
+""BINDERS AND BINDER ACCESSORIES""
+5570.93
+""CONSUMER""
+""BOOKCASES""
+5570.93
+""CONSUMER""
+""CHAIRS & CHAIRMATS""
+5570.93
+""CONSUMER""
+""COMPUTER PERIPHERALS""
+5570.93
+""CONSUMER""
+""COPIERS AND FAX""
+5570.93
+""CONSUMER""
+""ENVELOPES""
+5570.93
+""CONSUMER""
+""LABELS""
+5570.93
+""CONSUMER""
+""OFFICE FURNISHINGS""
+5570.93
+""CONSUMER""
+""OFFICE MACHINES""
+5570.93
+""CONSUMER""
+""PAPER""
+5570.93
+""CONSUMER""
+""PENS & ART SUPPLIES""
+5570.93
+""CONSUMER""
+""RUBBER BANDS""
+5570.93
+""CONSUMER""
+""SCISSORS, RULERS AND TRIMMERS""
+5570.93
+""CONSUMER""
+""STORAGE & ORGANIZATION""
+5570.93
+""CONSUMER""
+""TABLES""
+5570.93
+""CONSUMER""
+""TELEPHONES AND COMMUNICATION""
+5570.93
+""CORPORATE""
+""APPLIANCES""
+10204.72
+""CORPORATE""
+""BINDERS AND BINDER ACCESSORIES""
+10204.72
+""CORPORATE""
+""BOOKCASES""
+10204.72
+""CORPORATE""
+""CHAIRS & CHAIRMATS""
+10204.72
+""CORPORATE""
+""COMPUTER PERIPHERALS""
+10204.72
+""CORPORATE""
+""COPIERS AND FAX""
+10204.72
+""CORPORATE""
+""ENVELOPES""
+10204.72
+""CORPORATE""
+""LABELS""
+10204.72
+""CORPORATE""
+""OFFICE FURNISHINGS""
+10204.72
+""CORPORATE""
+""OFFICE MACHINES""
+10204.72
+""CORPORATE""
+""PAPER""
+10204.72
+""CORPORATE""
+""PENS & ART SUPPLIES""
+10204.72
+""CORPORATE""
+""RUBBER BANDS""
+10204.72
+""CORPORATE""
+""SCISSORS, RULERS AND TRIMMERS""
+10204.72
+""CORPORATE""
+""STORAGE & ORGANIZATION""
+10204.72
+""CORPORATE""
+""TABLES""
+10204.72
+""CORPORATE""","""CONSUMER""
+""APPLIANCES""
+5570.93
+""CONSUMER""
+""BINDERS AND BINDER ACCESSORIES""
+5570.93
+""CONSUMER""
+""BOOKCASES""
+5570.93
+""CONSUMER""
+""CHAIRS & CHAIRMATS""
+5570.93
+""CONSUMER""
+""COMPUTER PERIPHERALS""
+5570.93
+""CONSUMER""
+""COPIERS AND FAX""
+5570.93
+""CONSUMER""
+""ENVELOPES""
+5570.93
+""CONSUMER""
+""LABELS""
+5570.93
+""CONSUMER""
+""OFFICE FURNISHINGS""
+5570.93
+""CONSUMER""
+""OFFICE MACHINES""
+5570.93
+""CONSUMER""
+""PAPER""
+5570.93
+""CONSUMER""
+""PENS & ART SUPPLIES""
+5570.93
+""CONSUMER""
+""RUBBER BANDS""
+5570.93
+""CONSUMER""
+""SCISSORS, RULERS AND TRIMMERS""
+5570.93
+""CONSUMER""
+""STORAGE & ORGANIZATION""
+5570.93
+""CONSUMER""
+""TABLES""
+5570.93
+""CONSUMER""
+""TELEPHONES AND COMMUNICATION""
+5570.93
+""CORPORATE""
+""APPLIANCES""
+10204.72
+""CORPORATE""
+""BINDERS AND BINDER ACCESSORIES""
+10204.72
+""CORPORATE""
+""BOOKCASES""
+10204.72
+""CORPORATE""
+""CHAIRS & CHAIRMATS""
+10204.72
+""CORPORATE""
+""COMPUTER PERIPHERALS""
+10204.72
+""CORPORATE""
+""COPIERS AND FAX""
+10204.72
+""CORPORATE""
+""ENVELOPES""
+10204.72
+""CORPORATE""
+""LABELS""
+10204.72
+""CORPORATE""
+""OFFICE FURNISHINGS""
+10204.72
+""CORPORATE""
+""OFFICE MACHINES""
+10204.72
+""CORPORATE""
+""PAPER""
+10204.72
+""CORPORATE""
+""PENS & ART SUPPLIES""
+10204.72
+""CORPORATE""
+""RUBBER BANDS""
+10204.72
+""CORPORATE""
+""SCISSORS, RULERS AND TRIMMERS""
+10204.72
+""CORPORATE""
+""STORAGE & ORGANIZATION""
+10204.72
+""CORPORATE""
+""TABLES""
+10204.72
+""CORPORATE"""
+databricks,logical.lod.databricks,Staples.databricks,lod.5_Subset Fixed - 2,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.5_Subset Fixed - 2.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.5_Subset Fixed - 2.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1970.0,"
+      SELECT `t0`.`market_segment` AS `market_segment`,
+  `t0`.`prod_type2` AS `prod_type2`,
+  CAST(`t1`.`x_measure__0` AS DOUBLE) AS `avg_lod___fixed___1__copy__ok`
+FROM (
+  SELECT `Staples`.`Market_Segment` AS `market_segment`,
+    `Staples`.`Prod_Type2` AS `prod_type2`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1,
+    2
+) `t0`
+  JOIN (
+  SELECT `Staples`.`Prod_Type2` AS `prod_type2`,
+    SUM(`Staples`.`Product_Base_Margin`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+) `t1` ON (`t0`.`prod_type2` IS NOT DISTINCT FROM `t1`.`prod_type2`)
+    ","""CONSUMER""
+""APPLIANCES""
+1554.89
+""CONSUMER""
+""BINDERS AND BINDER ACCESSORIES""
+2181.58
+""CONSUMER""
+""BOOKCASES""
+882.51
+""CONSUMER""
+""CHAIRS & CHAIRMATS""
+1530.77
+""CONSUMER""
+""COMPUTER PERIPHERALS""
+2990.1
+""CONSUMER""
+""COPIERS AND FAX""
+235.78
+""CONSUMER""
+""ENVELOPES""
+556.68
+""CONSUMER""
+""LABELS""
+759.24
+""CONSUMER""
+""OFFICE FURNISHINGS""
+2726.96
+""CONSUMER""
+""OFFICE MACHINES""
+1063.25
+""CONSUMER""
+""PAPER""
+2955.39
+""CONSUMER""
+""PENS & ART SUPPLIES""
+2443.31
+""CONSUMER""
+""RUBBER BANDS""
+552.35
+""CONSUMER""
+""SCISSORS, RULERS AND TRIMMERS""
+675.92
+""CONSUMER""
+""STORAGE & ORGANIZATION""
+2484.99
+""CONSUMER""
+""TABLES""
+1653.79
+""CONSUMER""
+""TELEPHONES AND COMMUNICATION""
+3030.81
+""CORPORATE""
+""APPLIANCES""
+1554.89
+""CORPORATE""
+""BINDERS AND BINDER ACCESSORIES""
+2181.58
+""CORPORATE""
+""BOOKCASES""
+882.51
+""CORPORATE""
+""CHAIRS & CHAIRMATS""
+1530.77
+""CORPORATE""
+""COMPUTER PERIPHERALS""
+2990.1
+""CORPORATE""
+""COPIERS AND FAX""
+235.78
+""CORPORATE""
+""ENVELOPES""
+556.68
+""CORPORATE""
+""LABELS""
+759.24
+""CORPORATE""
+""OFFICE FURNISHINGS""
+2726.96
+""CORPORATE""
+""OFFICE MACHINES""
+1063.25
+""CORPORATE""
+""PAPER""
+2955.39
+""CORPORATE""
+""PENS & ART SUPPLIES""
+2443.31
+""CORPORATE""
+""RUBBER BANDS""
+552.35
+""CORPORATE""
+""SCISSORS, RULERS AND TRIMMERS""
+675.92
+""CORPORATE""
+""STORAGE & ORGANIZATION""
+2484.99
+""CORPORATE""
+""TABLES""
+1653.79
+""CORPORATE""","""CONSUMER""
+""APPLIANCES""
+1554.89
+""CONSUMER""
+""BINDERS AND BINDER ACCESSORIES""
+2181.58
+""CONSUMER""
+""BOOKCASES""
+882.51
+""CONSUMER""
+""CHAIRS & CHAIRMATS""
+1530.77
+""CONSUMER""
+""COMPUTER PERIPHERALS""
+2990.1
+""CONSUMER""
+""COPIERS AND FAX""
+235.78
+""CONSUMER""
+""ENVELOPES""
+556.68
+""CONSUMER""
+""LABELS""
+759.24
+""CONSUMER""
+""OFFICE FURNISHINGS""
+2726.96
+""CONSUMER""
+""OFFICE MACHINES""
+1063.25
+""CONSUMER""
+""PAPER""
+2955.39
+""CONSUMER""
+""PENS & ART SUPPLIES""
+2443.31
+""CONSUMER""
+""RUBBER BANDS""
+552.35
+""CONSUMER""
+""SCISSORS, RULERS AND TRIMMERS""
+675.92
+""CONSUMER""
+""STORAGE & ORGANIZATION""
+2484.99
+""CONSUMER""
+""TABLES""
+1653.79
+""CONSUMER""
+""TELEPHONES AND COMMUNICATION""
+3030.81
+""CORPORATE""
+""APPLIANCES""
+1554.89
+""CORPORATE""
+""BINDERS AND BINDER ACCESSORIES""
+2181.58
+""CORPORATE""
+""BOOKCASES""
+882.51
+""CORPORATE""
+""CHAIRS & CHAIRMATS""
+1530.77
+""CORPORATE""
+""COMPUTER PERIPHERALS""
+2990.1
+""CORPORATE""
+""COPIERS AND FAX""
+235.78
+""CORPORATE""
+""ENVELOPES""
+556.68
+""CORPORATE""
+""LABELS""
+759.24
+""CORPORATE""
+""OFFICE FURNISHINGS""
+2726.96
+""CORPORATE""
+""OFFICE MACHINES""
+1063.25
+""CORPORATE""
+""PAPER""
+2955.39
+""CORPORATE""
+""PENS & ART SUPPLIES""
+2443.31
+""CORPORATE""
+""RUBBER BANDS""
+552.35
+""CORPORATE""
+""SCISSORS, RULERS AND TRIMMERS""
+675.92
+""CORPORATE""
+""STORAGE & ORGANIZATION""
+2484.99
+""CORPORATE""
+""TABLES""
+1653.79
+""CORPORATE"""
+databricks,logical.lod.databricks,Staples.databricks,lod.6_Include - 1,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.6_Include - 1.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.6_Include - 1.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2961.0,"
+      SELECT `t0`.`market_segment` AS `market_segment`,
+  `t2`.`x_measure__0` AS `sum_calculation_4621225004123988_ok`,
+  `t0`.`sum_sales_total_ok` AS `sum_sales_total_ok`
+FROM (
+  SELECT `Staples`.`Market_Segment` AS `market_segment`,
+    SUM(`Staples`.`Sales_Total`) AS `sum_sales_total_ok`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+) `t0`
+  JOIN (
+  SELECT `t1`.`market_segment` AS `market_segment`,
+    SUM(`t1`.`x_measure__1`) AS `x_measure__0`
+  FROM (
+    SELECT `Staples`.`Market_Segment` AS `market_segment`,
+      SUM(`Staples`.`Sales_Total`) AS `x_measure__1`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY 1,
+      `Staples`.`Prod_Type1`
+  ) `t1`
+  GROUP BY 1
+) `t2` ON (`t0`.`market_segment` IS NOT DISTINCT FROM `t2`.`market_segment`)
+    ","""CONSUMER""
+19889172.0
+19889172.0
+""CORPORATE""
+35593890.0
+35593890.0
+""HOME OFFICE""
+24513651.0
+24513651.0
+""SMALL BUSINESS""
+18691224.0
+18691224.0","""CONSUMER""
+19889172.0
+19889172.0
+""CORPORATE""
+35593890.0
+35593890.0
+""HOME OFFICE""
+24513651.0
+24513651.0
+""SMALL BUSINESS""
+18691224.0
+18691224.0"
+databricks,logical.lod.databricks,Staples.databricks,lod.7_Percent of Total 1,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.7_Percent of Total 1.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.7_Percent of Total 1.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1687.0,"
+      SELECT `t0`.`market_segment` AS `market_segment`,
+  `t0`.`prod_type1` AS `prod_type1`,
+  `t1`.`x_measure__0` AS `temp_calculation_5091225004312306__3462396638__0_`,
+  `t0`.`temp_calculation_5091225004312306__357447720__0_` AS `temp_calculation_5091225004312306__357447720__0_`,
+  `t1`.`x_measure__0` AS `temp_calculation_5091225004312306__61826508__0_`
+FROM (
+  SELECT `Staples`.`Market_Segment` AS `market_segment`,
+    `Staples`.`Prod_Type1` AS `prod_type1`,
+    SUM(`Staples`.`Sales_Total`) AS `temp_calculation_5091225004312306__357447720__0_`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1,
+    2
+) `t0`
+  JOIN (
+  SELECT `Staples`.`Market_Segment` AS `market_segment`,
+    SUM(`Staples`.`Sales_Total`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+) `t1` ON (`t0`.`market_segment` IS NOT DISTINCT FROM `t1`.`market_segment`)
+    ","""CONSUMER""
+""FURNITURE""
+19889172.0
+6987300.0
+19889172.0
+""CONSUMER""
+""OFFICE SUPPLIES""
+19889172.0
+4599668.9
+19889172.0
+""CONSUMER""
+""TECHNOLOGY""
+19889172.0
+8302202.8
+19889172.0
+""CORPORATE""
+""FURNITURE""
+35593890.0
+12325807.0
+35593890.0
+""CORPORATE""
+""OFFICE SUPPLIES""
+35593890.0
+8644838.2
+35593890.0
+""CORPORATE""
+""TECHNOLOGY""
+35593890.0
+14623245.0
+35593890.0
+""HOME OFFICE""
+""FURNITURE""
+24513651.0
+8354019.3
+24513651.0
+""HOME OFFICE""
+""OFFICE SUPPLIES""
+24513651.0
+6116307.0
+24513651.0
+""HOME OFFICE""
+""TECHNOLOGY""
+24513651.0
+10043325.0
+24513651.0
+""SMALL BUSINESS""
+""FURNITURE""
+18691224.0
+6341959.4
+18691224.0
+""SMALL BUSINESS""
+""OFFICE SUPPLIES""
+18691224.0
+4653925.8
+18691224.0
+""SMALL BUSINESS""
+""TECHNOLOGY""
+18691224.0
+7695338.8
+18691224.0","""CONSUMER""
+""FURNITURE""
+19889172.0
+6987300.0
+19889172.0
+""CONSUMER""
+""OFFICE SUPPLIES""
+19889172.0
+4599668.9
+19889172.0
+""CONSUMER""
+""TECHNOLOGY""
+19889172.0
+8302202.8
+19889172.0
+""CORPORATE""
+""FURNITURE""
+35593890.0
+12325807.0
+35593890.0
+""CORPORATE""
+""OFFICE SUPPLIES""
+35593890.0
+8644838.2
+35593890.0
+""CORPORATE""
+""TECHNOLOGY""
+35593890.0
+14623245.0
+35593890.0
+""HOME OFFICE""
+""FURNITURE""
+24513651.0
+8354019.3
+24513651.0
+""HOME OFFICE""
+""OFFICE SUPPLIES""
+24513651.0
+6116307.0
+24513651.0
+""HOME OFFICE""
+""TECHNOLOGY""
+24513651.0
+10043325.0
+24513651.0
+""SMALL BUSINESS""
+""FURNITURE""
+18691224.0
+6341959.4
+18691224.0
+""SMALL BUSINESS""
+""OFFICE SUPPLIES""
+18691224.0
+4653925.8
+18691224.0
+""SMALL BUSINESS""
+""TECHNOLOGY""
+18691224.0
+7695338.8
+18691224.0"
+databricks,logical.lod.databricks,Staples.databricks,lod.8_Precent of Total 2,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.8_Precent of Total 2.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.8_Precent of Total 2.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1742.0,"
+      SELECT `t0`.`prod_type1` AS `prod_type1`,
+  `t0`.`prod_type2` AS `prod_type2`,
+  `t1`.`x_measure__0` AS `temp_lod___percent_of_total__copy___342855174__0_`,
+  `t1`.`x_measure__0` AS `temp_lod___percent_of_total__copy___3499937668__0_`,
+  `t0`.`temp_lod___percent_of_total__copy___357447720__0_` AS `temp_lod___percent_of_total__copy___357447720__0_`
+FROM (
+  SELECT `Staples`.`Prod_Type1` AS `prod_type1`,
+    `Staples`.`Prod_Type2` AS `prod_type2`,
+    SUM(`Staples`.`Sales_Total`) AS `temp_lod___percent_of_total__copy___357447720__0_`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1,
+    2
+) `t0`
+  JOIN (
+  SELECT `Staples`.`Prod_Type1` AS `prod_type1`,
+    SUM(`Staples`.`Sales_Total`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+) `t1` ON (`t0`.`prod_type1` IS NOT DISTINCT FROM `t1`.`prod_type1`)
+    ","""FURNITURE""
+""BOOKCASES""
+34009086.0
+34009086.0
+5257672.7
+""FURNITURE""
+""CHAIRS & CHAIRMATS""
+34009086.0
+34009086.0
+10497117.0
+""FURNITURE""
+""OFFICE FURNISHINGS""
+34009086.0
+34009086.0
+3999750.0
+""FURNITURE""
+""TABLES""
+34009086.0
+34009086.0
+14254546.0
+""OFFICE SUPPLIES""
+""APPLIANCES""
+24014740.0
+24014740.0
+5247729.0
+""OFFICE SUPPLIES""
+""BINDERS AND BINDER ACCESSORIES""
+24014740.0
+24014740.0
+5545569.2
+""OFFICE SUPPLIES""
+""ENVELOPES""
+24014740.0
+24014740.0
+858634.48
+""OFFICE SUPPLIES""
+""LABELS""
+24014740.0
+24014740.0
+400169.21
+""OFFICE SUPPLIES""
+""PAPER""
+24014740.0
+24014740.0
+3098545.7
+""OFFICE SUPPLIES""
+""PENS & ART SUPPLIES""
+24014740.0
+24014740.0
+1209942.5
+""OFFICE SUPPLIES""
+""RUBBER BANDS""
+24014740.0
+24014740.0
+95324.04
+""OFFICE SUPPLIES""
+""SCISSORS, RULERS AND TRIMMERS""
+24014740.0
+24014740.0
+1072184.3
+""OFFICE SUPPLIES""
+""STORAGE & ORGANIZATION""
+24014740.0
+24014740.0
+6486641.5
+""TECHNOLOGY""
+""COMPUTER PERIPHERALS""
+40664111.0
+40664111.0
+5278781.7
+""TECHNOLOGY""
+""COPIERS AND FAX""
+40664111.0
+40664111.0
+6776923.2
+""TECHNOLOGY""
+""OFFICE MACHINES""
+40664111.0
+40664111.0
+15099693.0
+""TECHNOLOGY""
+""TELEPHONES AND COMMUNICATION""
+40664111.0
+40664111.0
+13508713.0","""FURNITURE""
+""BOOKCASES""
+34009086.0
+34009086.0
+5257672.7
+""FURNITURE""
+""CHAIRS & CHAIRMATS""
+34009086.0
+34009086.0
+10497117.0
+""FURNITURE""
+""OFFICE FURNISHINGS""
+34009086.0
+34009086.0
+3999750.0
+""FURNITURE""
+""TABLES""
+34009086.0
+34009086.0
+14254546.0
+""OFFICE SUPPLIES""
+""APPLIANCES""
+24014740.0
+24014740.0
+5247729.0
+""OFFICE SUPPLIES""
+""BINDERS AND BINDER ACCESSORIES""
+24014740.0
+24014740.0
+5545569.2
+""OFFICE SUPPLIES""
+""ENVELOPES""
+24014740.0
+24014740.0
+858634.48
+""OFFICE SUPPLIES""
+""LABELS""
+24014740.0
+24014740.0
+400169.21
+""OFFICE SUPPLIES""
+""PAPER""
+24014740.0
+24014740.0
+3098545.7
+""OFFICE SUPPLIES""
+""PENS & ART SUPPLIES""
+24014740.0
+24014740.0
+1209942.5
+""OFFICE SUPPLIES""
+""RUBBER BANDS""
+24014740.0
+24014740.0
+95324.04
+""OFFICE SUPPLIES""
+""SCISSORS, RULERS AND TRIMMERS""
+24014740.0
+24014740.0
+1072184.3
+""OFFICE SUPPLIES""
+""STORAGE & ORGANIZATION""
+24014740.0
+24014740.0
+6486641.5
+""TECHNOLOGY""
+""COMPUTER PERIPHERALS""
+40664111.0
+40664111.0
+5278781.7
+""TECHNOLOGY""
+""COPIERS AND FAX""
+40664111.0
+40664111.0
+6776923.2
+""TECHNOLOGY""
+""OFFICE MACHINES""
+40664111.0
+40664111.0
+15099693.0
+""TECHNOLOGY""
+""TELEPHONES AND COMMUNICATION""
+40664111.0
+40664111.0
+13508713.0"
+databricks,logical.lod.databricks,Staples.databricks,lod.9_Fixed as Dimension,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.9_Fixed as Dimension.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.9_Fixed as Dimension.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1883.0,"
+      SELECT CAST(FLOOR(SUM(`Staples`.`Sales_Total`)) AS BIGINT) AS `sum_sales_total_ok`,
+  FLOOR((14 + DATEDIFF(`t0`.`x_measure__0`, TRUNC(`t0`.`x_measure__0`,'YY')) + DATEDIFF(TRUNC(`t0`.`x_measure__0`,'YY'),NEXT_DAY(TRUNC(`t0`.`x_measure__0`,'YY'),'SU')))/7) AS `wk_lod___fixed___1__copy_2__ok`,
+  YEAR(`Staples`.`Order_Date`) AS `yr_order_date_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+  JOIN (
+  SELECT `Staples`.`Customer_Name` AS `customer_name`,
+    MIN(`Staples`.`Order_Date`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+) `t0` ON (`Staples`.`Customer_Name` IS NOT DISTINCT FROM `t0`.`customer_name`)
+GROUP BY 2,
+  3
+    ","143086.0
+7
+1997
+155398.0
+6
+2000
+171196.0
+7
+2000
+203969.0
+7
+2002
+210031.0
+7
+1999
+229542.0
+7
+2001
+250933.0
+6
+1999
+270968.0
+6
+2002
+272984.0
+6
+1997
+275541.0
+7
+1998
+292277.0
+6
+2001
+333289.0
+6
+1998
+602266.0
+5
+2001
+602510.0
+5
+2000
+631772.0
+5
+1999
+661241.0
+5
+1997
+711393.0
+5
+1998
+740353.0
+5
+2002
+1589284.0
+4
+2001
+1639958.0
+4
+2002
+1658149.0
+4
+1998
+1681972.0
+4
+1997
+1766892.0
+4
+2000
+1847329.0
+4
+1999
+2581528.0
+3
+2002
+2817285.0
+3
+1997
+2903749.0
+3
+2000
+2936721.0
+3
+1999
+2983885.0
+3
+1998
+3106220.0
+3
+2001
+4820443.0
+1
+2002
+4950468.0
+1
+2000
+4953826.0
+1
+1999
+4985164.0","143086.0
+7
+1997
+155398.0
+6
+2000
+171196.0
+7
+2000
+203969.0
+7
+2002
+210031.0
+7
+1999
+229542.0
+7
+2001
+250933.0
+6
+1999
+270968.0
+6
+2002
+272984.0
+6
+1997
+275541.0
+7
+1998
+292277.0
+6
+2001
+333289.0
+6
+1998
+602266.0
+5
+2001
+602510.0
+5
+2000
+631772.0
+5
+1999
+661241.0
+5
+1997
+711393.0
+5
+1998
+740353.0
+5
+2002
+1589284.0
+4
+2001
+1639958.0
+4
+2002
+1658149.0
+4
+1998
+1681972.0
+4
+1997
+1766892.0
+4
+2000
+1847329.0
+4
+1999
+2581528.0
+3
+2002
+2817285.0
+3
+1997
+2903749.0
+3
+2000
+2936721.0
+3
+1999
+2983885.0
+3
+1998
+3106220.0
+3
+2001
+4820443.0
+1
+2002
+4950468.0
+1
+2000
+4953826.0
+1
+1999
+4985164.0"
+databricks,logical.lod.databricks,Staples.databricks,lod.calc.1.TopN,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.1.TopN.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.1.TopN.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2488.0,"
+      SELECT `Staples`.`Prod_Type2` AS `prod_type2`,
+  CAST(FLOOR(SUM(`Staples`.`Sales_Total`)) AS BIGINT) AS `sum_sales_total_ok`
+FROM `tableau_tdvt`.`staples` `Staples`
+  JOIN (
+  SELECT `t0`.`market_segment` AS `market_segment`,
+    SUM(`t0`.`x_measure__1`) AS `x__alias__0`
+  FROM (
+    SELECT `Staples`.`Market_Segment` AS `market_segment`,
+      SUM(`Staples`.`Sales_Total`) AS `x_measure__1`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY 1,
+      `Staples`.`Prod_Type1`
+  ) `t0`
+  GROUP BY 1
+  ORDER BY `x__alias__0` DESC
+  LIMIT 2
+) `t1` ON (`Staples`.`Market_Segment` = `t1`.`market_segment`)
+GROUP BY 1
+    ","""APPLIANCES""
+3211255.0
+""BINDERS AND BINDER ACCESSORIES""
+3486043.0
+""BOOKCASES""
+3192047.0
+""CHAIRS & CHAIRMATS""
+6394825.0
+""COMPUTER PERIPHERALS""
+3181279.0
+""COPIERS AND FAX""
+3937480.0
+""ENVELOPES""
+499500.0
+""LABELS""
+252067.0
+""OFFICE FURNISHINGS""
+2445700.0
+""OFFICE MACHINES""
+9186301.0
+""PAPER""
+1886099.0
+""PENS & ART SUPPLIES""
+728282.0
+""RUBBER BANDS""
+59076.0
+""SCISSORS, RULERS AND TRIMMERS""
+717918.0
+""STORAGE & ORGANIZATION""
+3920902.0
+""TABLES""
+8647254.0
+""TELEPHONES AND COMMUNICATION""
+8361507.0","""APPLIANCES""
+3211255.0
+""BINDERS AND BINDER ACCESSORIES""
+3486043.0
+""BOOKCASES""
+3192047.0
+""CHAIRS & CHAIRMATS""
+6394825.0
+""COMPUTER PERIPHERALS""
+3181279.0
+""COPIERS AND FAX""
+3937480.0
+""ENVELOPES""
+499500.0
+""LABELS""
+252067.0
+""OFFICE FURNISHINGS""
+2445700.0
+""OFFICE MACHINES""
+9186301.0
+""PAPER""
+1886099.0
+""PENS & ART SUPPLIES""
+728282.0
+""RUBBER BANDS""
+59076.0
+""SCISSORS, RULERS AND TRIMMERS""
+717918.0
+""STORAGE & ORGANIZATION""
+3920902.0
+""TABLES""
+8647254.0
+""TELEPHONES AND COMMUNICATION""
+8361507.0"
+databricks,logical.lod.databricks,Staples.databricks,lod.calc.11.Exclude,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.11.Exclude.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.11.Exclude.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1330.0,"
+      SELECT `t0`.`market_segment` AS `market_segment`,
+  `t1`.`x_measure__0` AS `sum_calculation_0040203110812011_ok`
+FROM (
+  SELECT `Staples`.`Market_Segment` AS `market_segment`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+) `t0`
+  JOIN (
+  SELECT SUM(`Staples`.`Sales_Total`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1.1000000000000001
+) `t1`
+    ","""CONSUMER""
+98687937.0
+""CORPORATE""
+98687937.0
+""HOME OFFICE""
+98687937.0
+""SMALL BUSINESS""
+98687937.0","""CONSUMER""
+98687937.0
+""CORPORATE""
+98687937.0
+""HOME OFFICE""
+98687937.0
+""SMALL BUSINESS""
+98687937.0"
+databricks,logical.lod.databricks,Staples.databricks,lod.calc.2.Two-level Agg,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.2.Two-level Agg.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.2.Two-level Agg.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2328.0,"
+      SELECT `t0`.`call_center_region` AS `call_center_region`,
+  SUM(`t2`.`x_measure__1`) AS `sum_calculation_4560203111140559_ok`
+FROM (
+  SELECT `Staples`.`Call_Center_Region` AS `call_center_region`,
+    `Staples`.`Customer_State` AS `customer_state`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1,
+    2
+) `t0`
+  JOIN (
+  SELECT `t1`.`customer_state` AS `customer_state`,
+    AVG(`t1`.`x_measure__2`) AS `x_measure__1`
+  FROM (
+    SELECT `Staples`.`Customer_State` AS `customer_state`,
+      SUM(`Staples`.`Sales_Total`) AS `x_measure__2`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY `Staples`.`Call_Center_Region`,
+      1
+  ) `t1`
+  GROUP BY 1
+) `t2` ON (`t0`.`customer_state` = `t2`.`customer_state`)
+GROUP BY 1
+    ","""CENTRAL""
+21059849.0
+""EAST""
+50720765.0
+""WEST""
+26907323.0","""CENTRAL""
+21059849.0
+""EAST""
+50720765.0
+""WEST""
+26907323.0"
+databricks,logical.lod.databricks,Staples.databricks,lod.calc.3.LOD Metadata,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.3.LOD Metadata.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.3.LOD Metadata.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2225.0,"
+      SELECT `t0`.`prod_type1` AS `prod_type1`,
+  `t0`.`x_measure__0` AS `sum_calculation_0140203111132437_ok`,
+  `t3`.`x_measure__1` AS `sum_calculation_8060203111105400_ok`
+FROM (
+  SELECT `Staples`.`Prod_Type1` AS `prod_type1`,
+    SUM(`Staples`.`Sales_Total`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+) `t0`
+  JOIN (
+  SELECT `t1`.`prod_type1` AS `prod_type1`,
+    SUM(`t2`.`x_measure__2`) AS `x_measure__1`
+  FROM (
+    SELECT `Staples`.`Market_Segment` AS `market_segment`,
+      `Staples`.`Prod_Type1` AS `prod_type1`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY 1,
+      2
+  ) `t1`
+    JOIN (
+    SELECT `Staples`.`Market_Segment` AS `market_segment`,
+      SUM(`Staples`.`Product_Base_Margin`) AS `x_measure__2`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY 1
+  ) `t2` ON (`t1`.`market_segment` = `t2`.`market_segment`)
+  GROUP BY 1
+) `t3` ON (`t0`.`prod_type1` = `t3`.`prod_type1`)
+    ","""FURNITURE""
+34009086.0
+28278.32
+""OFFICE SUPPLIES""
+24014740.0
+28278.32
+""TECHNOLOGY""
+40664111.0
+28278.32","""FURNITURE""
+34009086.0
+28278.32
+""OFFICE SUPPLIES""
+24014740.0
+28278.32
+""TECHNOLOGY""
+40664111.0
+28278.32"
+databricks,logical.lod.databricks,Staples.databricks,lod.calc.4.Lookup,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.4.Lookup.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.4.Lookup.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1176.0,"
+      SELECT `t0`.`market_segment` AS `market_segment`,
+  `t0`.`prod_type1` AS `prod_type1`,
+  CAST(`t1`.`x_measure__0` AS DOUBLE) AS `temp_calculation_8290203111048369__2626528331__0_`,
+  `t0`.`temp_calculation_8290203111048369__357447720__0_` AS `temp_calculation_8290203111048369__357447720__0_`
+FROM (
+  SELECT `Staples`.`Market_Segment` AS `market_segment`,
+    `Staples`.`Prod_Type1` AS `prod_type1`,
+    SUM(`Staples`.`Sales_Total`) AS `temp_calculation_8290203111048369__357447720__0_`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1,
+    2
+) `t0`
+  JOIN (
+  SELECT `Staples`.`Market_Segment` AS `market_segment`,
+    SUM(`Staples`.`Sales_Total`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+) `t1` ON (`t0`.`market_segment` = `t1`.`market_segment`)
+    ","""CONSUMER""
+""FURNITURE""
+19889172.0
+6987300.0
+""CONSUMER""
+""OFFICE SUPPLIES""
+19889172.0
+4599668.9
+""CONSUMER""
+""TECHNOLOGY""
+19889172.0
+8302202.8
+""CORPORATE""
+""FURNITURE""
+35593890.0
+12325807.0
+""CORPORATE""
+""OFFICE SUPPLIES""
+35593890.0
+8644838.2
+""CORPORATE""
+""TECHNOLOGY""
+35593890.0
+14623245.0
+""HOME OFFICE""
+""FURNITURE""
+24513651.0
+8354019.3
+""HOME OFFICE""
+""OFFICE SUPPLIES""
+24513651.0
+6116307.0
+""HOME OFFICE""
+""TECHNOLOGY""
+24513651.0
+10043325.0
+""SMALL BUSINESS""
+""FURNITURE""
+18691224.0
+6341959.4
+""SMALL BUSINESS""
+""OFFICE SUPPLIES""
+18691224.0
+4653925.8
+""SMALL BUSINESS""
+""TECHNOLOGY""
+18691224.0
+7695338.8","""CONSUMER""
+""FURNITURE""
+19889172.0
+6987300.0
+""CONSUMER""
+""OFFICE SUPPLIES""
+19889172.0
+4599668.9
+""CONSUMER""
+""TECHNOLOGY""
+19889172.0
+8302202.8
+""CORPORATE""
+""FURNITURE""
+35593890.0
+12325807.0
+""CORPORATE""
+""OFFICE SUPPLIES""
+35593890.0
+8644838.2
+""CORPORATE""
+""TECHNOLOGY""
+35593890.0
+14623245.0
+""HOME OFFICE""
+""FURNITURE""
+24513651.0
+8354019.3
+""HOME OFFICE""
+""OFFICE SUPPLIES""
+24513651.0
+6116307.0
+""HOME OFFICE""
+""TECHNOLOGY""
+24513651.0
+10043325.0
+""SMALL BUSINESS""
+""FURNITURE""
+18691224.0
+6341959.4
+""SMALL BUSINESS""
+""OFFICE SUPPLIES""
+18691224.0
+4653925.8
+""SMALL BUSINESS""
+""TECHNOLOGY""
+18691224.0
+7695338.8"
+databricks,logical.lod.databricks,Staples.databricks,lod.calc.5.LOD Set,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.5.LOD Set.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.5.LOD Set.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1014.0,"
+      SELECT `t0`.`calculation_4190203111004094` AS `calculation_4190203111004094`,
+  false AS `io_set_1_nk`
+FROM (
+  SELECT SUM(`Staples`.`Item_Count`) AS `calculation_4190203111004094`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY `Staples`.`Market_Segment`
+) `t0`
+GROUP BY 1
+    ","10547
+false
+10807
+false
+13674
+false
+19832
+false","10547
+false
+10807
+false
+13674
+false
+19832
+false"
+databricks,logical.lod.databricks,Staples.databricks,lod.calc.6. LOD Dimension,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.6. LOD Dimension.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.6. LOD Dimension.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,2524.0,"
+      SELECT `t1`.`calculation_6680203110931647` AS `calculation_6680203110931647`,
+  `t1`.`market_segment` AS `market_segment`,
+  `t4`.`x_measure__1` AS `sum_calculation_1720203110953093_ok`,
+  `t1`.`sum_sales_total_ok` AS `sum_sales_total_ok`
+FROM (
+  SELECT `t0`.`x_measure__0` AS `calculation_6680203110931647`,
+    `Staples`.`Market_Segment` AS `market_segment`,
+    SUM(`Staples`.`Sales_Total`) AS `sum_sales_total_ok`
+  FROM `tableau_tdvt`.`staples` `Staples`
+    JOIN (
+    SELECT `Staples`.`Market_Segment` AS `market_segment`,
+      SUM(`Staples`.`Item_Count`) AS `x_measure__0`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY 1
+  ) `t0` ON (`Staples`.`Market_Segment` = `t0`.`market_segment`)
+  GROUP BY 1,
+    2
+) `t1`
+  JOIN (
+  SELECT `t3`.`calculation_6680203110931647` AS `calculation_6680203110931647`,
+    `t3`.`market_segment` AS `market_segment`,
+    SUM(`t3`.`x_measure__2`) AS `x_measure__1`
+  FROM (
+    SELECT `t2`.`x_measure__0` AS `calculation_6680203110931647`,
+      `Staples`.`Market_Segment` AS `market_segment`,
+      SUM(`Staples`.`Sales_Total`) AS `x_measure__2`
+    FROM `tableau_tdvt`.`staples` `Staples`
+      JOIN (
+      SELECT `Staples`.`Market_Segment` AS `market_segment`,
+        SUM(`Staples`.`Item_Count`) AS `x_measure__0`
+      FROM `tableau_tdvt`.`staples` `Staples`
+      GROUP BY 1
+    ) `t2` ON (`Staples`.`Market_Segment` = `t2`.`market_segment`)
+    GROUP BY 1,
+      2,
+      `Staples`.`Prod_Type1`
+  ) `t3`
+  GROUP BY 1,
+    2
+) `t4` ON ((`t1`.`calculation_6680203110931647` = `t4`.`calculation_6680203110931647`) AND (`t1`.`market_segment` = `t4`.`market_segment`))
+    ","10547
+""SMALL BUSINESS""
+18691224.0
+18691224.0
+10807
+""CONSUMER""
+19889172.0
+19889172.0
+13674
+""HOME OFFICE""
+24513651.0
+24513651.0
+19832
+""CORPORATE""
+35593890.0
+35593890.0","10547
+""SMALL BUSINESS""
+18691224.0
+18691224.0
+10807
+""CONSUMER""
+19889172.0
+19889172.0
+13674
+""HOME OFFICE""
+24513651.0
+24513651.0
+19832
+""CORPORATE""
+35593890.0
+35593890.0"
+databricks,logical.lod.databricks,Staples.databricks,lod.calc.7. LOD Bins,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.7. LOD Bins.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.7. LOD Bins.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,990.0,"
+      SELECT `t0`.`staples__testv1____lod_bins__bin_` AS `staples__testv1____lod_bins__bin_`,
+  SUM(1) AS `cnt_calculation_8910203110915053_ok`
+FROM (
+  SELECT FLOOR(SUM(`Staples`.`Item_Count`) / 1000) AS `staples__testv1____lod_bins__bin_`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY `Staples`.`Market_Segment`
+) `t0`
+GROUP BY 1
+    ","10
+2
+13
+1
+19
+1","10
+2
+13
+1
+19
+1"
+databricks,logical.lod.databricks,Staples.databricks,lod.calc.8. Include,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.8. Include.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.8. Include.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1670.0,"
+      SELECT `t0`.`market_segment` AS `market_segment`,
+  `t2`.`x_measure__0` AS `sum_calculation_6390203110846546_ok`,
+  `t0`.`sum_sales_total_ok` AS `sum_sales_total_ok`
+FROM (
+  SELECT `Staples`.`Market_Segment` AS `market_segment`,
+    SUM(`Staples`.`Sales_Total`) AS `sum_sales_total_ok`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+) `t0`
+  JOIN (
+  SELECT `t1`.`market_segment` AS `market_segment`,
+    SUM(`t1`.`x_measure__1`) AS `x_measure__0`
+  FROM (
+    SELECT `Staples`.`Market_Segment` AS `market_segment`,
+      SUM(`Staples`.`Sales_Total`) AS `x_measure__1`
+    FROM `tableau_tdvt`.`staples` `Staples`
+    GROUP BY 1,
+      `Staples`.`Prod_Type1`
+  ) `t1`
+  GROUP BY 1
+) `t2` ON (`t0`.`market_segment` = `t2`.`market_segment`)
+    ","""CONSUMER""
+19889172.0
+19889172.0
+""CORPORATE""
+35593890.0
+35593890.0
+""HOME OFFICE""
+24513651.0
+24513651.0
+""SMALL BUSINESS""
+18691224.0
+18691224.0","""CONSUMER""
+19889172.0
+19889172.0
+""CORPORATE""
+35593890.0
+35593890.0
+""HOME OFFICE""
+24513651.0
+24513651.0
+""SMALL BUSINESS""
+18691224.0
+18691224.0"
+databricks,logical.lod.databricks,Staples.databricks,lod.calc.9.Fixed,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.9.Fixed.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/lod\setup.lod.calc.9.Fixed.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,1563.0,"
+      SELECT `t0`.`prod_type2` AS `prod_type2`,
+  SUM(`t1`.`x_measure__1`) AS `sum_calculation_8940203110829613_ok`
+FROM (
+  SELECT `Staples`.`Market_Segment` AS `market_segment`,
+    `Staples`.`Prod_Type2` AS `prod_type2`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1,
+    2
+) `t0`
+  JOIN (
+  SELECT `Staples`.`Market_Segment` AS `market_segment`,
+    SUM(`Staples`.`Product_Base_Margin`) AS `x_measure__1`
+  FROM `tableau_tdvt`.`staples` `Staples`
+  GROUP BY 1
+) `t1` ON (`t0`.`market_segment` = `t1`.`market_segment`)
+GROUP BY 1
+    ","""APPLIANCES""
+28278.32
+""BINDERS AND BINDER ACCESSORIES""
+28278.32
+""BOOKCASES""
+28278.32
+""CHAIRS & CHAIRMATS""
+28278.32
+""COMPUTER PERIPHERALS""
+28278.32
+""COPIERS AND FAX""
+28278.32
+""ENVELOPES""
+28278.32
+""LABELS""
+28278.32
+""OFFICE FURNISHINGS""
+28278.32
+""OFFICE MACHINES""
+28278.32
+""PAPER""
+28278.32
+""PENS & ART SUPPLIES""
+28278.32
+""RUBBER BANDS""
+28278.32
+""SCISSORS, RULERS AND TRIMMERS""
+28278.32
+""STORAGE & ORGANIZATION""
+28278.32
+""TABLES""
+28278.32
+""TELEPHONES AND COMMUNICATION""
+28278.32","""APPLIANCES""
+28278.32
+""BINDERS AND BINDER ACCESSORIES""
+28278.32
+""BOOKCASES""
+28278.32
+""CHAIRS & CHAIRMATS""
+28278.32
+""COMPUTER PERIPHERALS""
+28278.32
+""COPIERS AND FAX""
+28278.32
+""ENVELOPES""
+28278.32
+""LABELS""
+28278.32
+""OFFICE FURNISHINGS""
+28278.32
+""OFFICE MACHINES""
+28278.32
+""PAPER""
+28278.32
+""PENS & ART SUPPLIES""
+28278.32
+""RUBBER BANDS""
+28278.32
+""SCISSORS, RULERS AND TRIMMERS""
+28278.32
+""STORAGE & ORGANIZATION""
+28278.32
+""TABLES""
+28278.32
+""TELEPHONES AND COMMUNICATION""
+28278.32"
+databricks,logical.union.databricks,cast_calcs.databricks,calcs.union,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/union\setup.calcs.union.tableau_tdvt.xml,True,0,0,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\logicaltests/setup/union\setup.calcs.union.tableau_tdvt.xml,logical,"Attempting to run query...
+Run query successful! Check output file
+",None,None,916.0,"
+      SELECT 1 AS `number_of_records`,
+  `t0`.`table_name` AS `table_name`,
+  `t0`.`int0` AS `int0`,
+  `t0`.`int1` AS `int1`,
+  `t0`.`int2` AS `int2`,
+  `t0`.`int3` AS `int3`,
+  `t0`.`key` AS `key`,
+  `t0`.`str0` AS `str0`,
+  `t0`.`str1` AS `str1`,
+  `t0`.`str2` AS `str2`,
+  `t0`.`str3` AS `str3`
+FROM (
+  
+  SELECT `t1`.`int0` AS `int0`, `t1`.`int1` AS `int1`, `t1`.`int2` AS `int2`, `t1`.`int3` AS `int3`, `t1`.`key` AS `key`, `t1`.`str0` AS `str0`, `t1`.`str1` AS `str1`, `t1`.`str2` AS `str2`, `t1`.`str3` AS `str3`, `t1`.`table_name` AS `table_name`
+  FROM (
+    SELECT `Calcs`.`int0` AS `int0`,
+      `Calcs`.`int1` AS `int1`,
+      `Calcs`.`int2` AS `int2`,
+      `Calcs`.`int3` AS `int3`,
+      `Calcs`.`key` AS `key`,
+      `Calcs`.`str0` AS `str0`,
+      `Calcs`.`str1` AS `str1`,
+      `Calcs`.`str2` AS `str2`,
+      `Calcs`.`str3` AS `str3`,
+      'Calcs' AS `table_name`
+    FROM `tableau_tdvt`.`calcs` `Calcs`
+  ) `t1`
+  
+   UNION  ALL 
+  
+  SELECT `t2`.`int0` AS `int0`, `t2`.`int1` AS `int1`, `t2`.`int2` AS `int2`, `t2`.`int3` AS `int3`, `t2`.`key` AS `key`, `t2`.`str0` AS `str0`, `t2`.`str1` AS `str1`, `t2`.`str2` AS `str2`, `t2`.`str3` AS `str3`, `t2`.`table_name` AS `table_name`
+  FROM (
+    SELECT `Calcs1`.`int0` AS `int0`,
+      `Calcs1`.`int1` AS `int1`,
+      `Calcs1`.`int2` AS `int2`,
+      `Calcs1`.`int3` AS `int3`,
+      `Calcs1`.`key` AS `key`,
+      `Calcs1`.`str0` AS `str0`,
+      `Calcs1`.`str1` AS `str1`,
+      `Calcs1`.`str2` AS `str2`,
+      `Calcs1`.`str3` AS `str3`,
+      'Calcs1' AS `table_name`
+    FROM `tableau_tdvt`.`calcs` `Calcs1`
+  ) `t2`
+  
+) `t0`
+LIMIT 1000
+    ","1
+""Calcs""
+%null%
+%null%
+0
+11
+""key12""
+""TECHNOLOGY""
+""CORDED KEYBOARDS""
+%null%
+%null%
+1
+""Calcs""
+%null%
+%null%
+5
+2
+""key02""
+""OFFICE SUPPLIES""
+""AIR PURIFIERS""
+""three""
+""e""
+1
+""Calcs""
+%null%
+-6
+-4
+13
+""key01""
+""FURNITURE""
+""CLOCKS""
+""two""
+""e""
+1
+""Calcs""
+%null%
+-4
+-5
+5
+""key03""
+""OFFICE SUPPLIES""
+""BINDER ACCESSORIES""
+%null%
+""e""
+1
+""Calcs""
+%null%
+2
+0
+3
+""key07""
+""OFFICE SUPPLIES""
+""BUSINESS ENVELOPES""
+""eight""
+""e""
+1
+""Calcs""
+%null%
+3
+-6
+17
+""key08""
+""TECHNOLOGY""
+""ANSWERING MACHINES""
+""nine""
+%null%
+1
+""Calcs""
+1
+-3
+5
+8
+""key00""
+""FURNITURE""
+""CLAMP ON LAMPS""
+""one""
+""e""
+1
+""Calcs""
+3
+%null%
+2
+7
+""key05""
+""OFFICE SUPPLIES""
+""BINDING MACHINES""
+""six""
+%null%
+1
+""Calcs""
+4
+%null%
+-9
+11
+""key15""
+""TECHNOLOGY""
+""DVD""
+""sixteen""
+""e""
+1","1
+""Calcs""
+%null%
+%null%
+0
+11
+""key12""
+""TECHNOLOGY""
+""CORDED KEYBOARDS""
+%null%
+%null%
+1
+""Calcs""
+%null%
+%null%
+5
+2
+""key02""
+""OFFICE SUPPLIES""
+""AIR PURIFIERS""
+""three""
+""e""
+1
+""Calcs""
+%null%
+-6
+-4
+13
+""key01""
+""FURNITURE""
+""CLOCKS""
+""two""
+""e""
+1
+""Calcs""
+%null%
+-4
+-5
+5
+""key03""
+""OFFICE SUPPLIES""
+""BINDER ACCESSORIES""
+%null%
+""e""
+1
+""Calcs""
+%null%
+2
+0
+3
+""key07""
+""OFFICE SUPPLIES""
+""BUSINESS ENVELOPES""
+""eight""
+""e""
+1
+""Calcs""
+%null%
+3
+-6
+17
+""key08""
+""TECHNOLOGY""
+""ANSWERING MACHINES""
+""nine""
+%null%
+1
+""Calcs""
+1
+-3
+5
+8
+""key00""
+""FURNITURE""
+""CLAMP ON LAMPS""
+""one""
+""e""
+1
+""Calcs""
+3
+%null%
+2
+7
+""key05""
+""OFFICE SUPPLIES""
+""BINDING MACHINES""
+""six""
+%null%
+1
+""Calcs""
+4
+%null%
+-9
+11
+""key15""
+""TECHNOLOGY""
+""DVD""
+""sixteen""
+""e""
+1"
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.avg,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.avg.txt,True,0,0,AVG([int0]),expression,,None,None,670.0,"
+      SELECT AVG(CAST(`calcs`.`int0` AS DOUBLE)) AS `temp_test__3952218057__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",6.1818182,6.1818182
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.avg,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.avg.txt,True,0,0,AVG([num4]),expression,,None,None,889.0,"
+      SELECT AVG(`calcs`.`num4`) AS `temp_test__1371989636__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",2.0016667,2.0016667
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.count,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.count.txt,True,0,0,COUNT([int0]),expression,,None,None,1222.0,"
+      SELECT COUNT(`calcs`.`int0`) AS `temp_test__3910975586__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",11,11
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.count,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.count.txt,True,0,0,COUNT([bool0]),expression,,None,None,1764.0,"
+      SELECT COUNT(CASE WHEN `calcs`.`bool0` THEN 1 WHEN NOT `calcs`.`bool0` THEN 0 ELSE NULL END) AS `temp_test__1133866179__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",10,10
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.count,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.count.txt,True,0,0,COUNT([date3]),expression,,None,None,731.0,"
+      SELECT COUNT(`calcs`.`date3`) AS `temp_test__3590771088__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",9,9
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.count,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.count.txt,True,0,0,COUNT([num4]),expression,,None,None,1577.0,"
+      SELECT COUNT(`calcs`.`num4`) AS `temp_test__1804085677__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",12,12
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.count,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.count.txt,True,0,0,COUNT([str2]),expression,,None,None,1111.0,"
+      SELECT COUNT(`calcs`.`str2`) AS `temp_test__2760211945__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",13,13
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.countd,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.countd.txt,True,0,0,COUNTD([int0]),expression,,None,None,2729.0,"
+      SELECT COUNT(DISTINCT `calcs`.`int0`) AS `temp_test__1467453495__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",7,7
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.countd,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.countd.txt,True,0,0,COUNTD([bool0]),expression,,None,None,2200.0,"
+      SELECT COUNT(DISTINCT (CASE WHEN `calcs`.`bool0` THEN 1 WHEN NOT `calcs`.`bool0` THEN 0 ELSE NULL END)) AS `temp_test__1408008556__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",2,2
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.countd,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.countd.txt,True,0,0,COUNTD([date3]),expression,,None,None,1310.0,"
+      SELECT COUNT(DISTINCT `calcs`.`date3`) AS `temp_test__175600811__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",9,9
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.countd,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.countd.txt,True,0,0,COUNTD([num4]),expression,,None,None,2131.0,"
+      SELECT COUNT(DISTINCT `calcs`.`num4`) AS `temp_test__41874160__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",12,12
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.countd,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.countd.txt,True,0,0,COUNTD([str2]),expression,,None,None,2104.0,"
+      SELECT COUNT(DISTINCT `calcs`.`str2`) AS `temp_test__2954817995__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",13,13
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.max,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.max.txt,True,0,0,MAX([int0]),expression,,None,None,902.0,"
+      SELECT MAX(`calcs`.`int0`) AS `temp_test__56370746__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",11,11
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.max,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.max.txt,True,0,0,MAX([date3]),expression,,None,None,688.0,"
+      SELECT MAX(`calcs`.`date3`) AS `temp_test__277748206__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",#1999-08-20#,#1999-08-20#
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.max,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.max.txt,True,0,0,MAX([num4]),expression,,None,None,837.0,"
+      SELECT MAX(`calcs`.`num4`) AS `temp_test__4154938655__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",19.39,19.39
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.max,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.max.txt,True,0,0,MAX([str2]),expression,,None,None,782.0,"
+      SELECT MAX(`calcs`.`str2`) AS `temp_test__1812249092__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ","""two""","""two"""
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.max,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.max.txt,True,0,0,"MAX([int0], [int1])",expression,,None,None,1097.0,"
+      SELECT (CASE
+	WHEN (`calcs`.`int0` IS NULL) OR (`calcs`.`int1` IS NULL) THEN NULL
+	WHEN `calcs`.`int0` > `calcs`.`int1` THEN `calcs`.`int0`
+	ELSE `calcs`.`int1` END) AS `temp_test__1523549003__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+1
+8
+10","%null%
+1
+8
+10"
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.min,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.min.txt,True,0,0,MIN([int0]),expression,,None,None,1098.0,"
+      SELECT MIN(`calcs`.`int0`) AS `temp_test__4016644369__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",1,1
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.min,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.min.txt,True,0,0,MIN([date3]),expression,,None,None,1072.0,"
+      SELECT MIN(`calcs`.`date3`) AS `temp_test__3378300904__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",#1979-04-01#,#1979-04-01#
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.min,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.min.txt,True,0,0,MIN([num4]),expression,,None,None,988.0,"
+      SELECT MIN(`calcs`.`num4`) AS `temp_test__512350875__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",-14.21,-14.21
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.min,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.min.txt,True,0,0,MIN([str2]),expression,,None,None,1073.0,"
+      SELECT MIN(`calcs`.`str2`) AS `temp_test__3910790823__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ","""eight""","""eight"""
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.min,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.min.txt,True,0,0,"MIN([int0], [int1])",expression,,None,None,1037.0,"
+      SELECT (CASE
+	WHEN (`calcs`.`int0` IS NULL) OR (`calcs`.`int1` IS NULL) THEN NULL
+	WHEN `calcs`.`int0` < `calcs`.`int1` THEN `calcs`.`int0`
+	ELSE `calcs`.`int1` END) AS `temp_test__3683900016__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-9
+-8
+-3
+3","%null%
+-9
+-8
+-3
+3"
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.stddev,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.stddev.txt,True,0,0,STDEV([num4]),expression,,None,None,1335.0,"
+      SELECT (CASE WHEN COUNT(`calcs`.`num4`) > 1 THEN STDDEV_SAMP(`calcs`.`num4`) ELSE NULL END) AS `temp_test__2430775290__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",10.654484,10.654484
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.stddev,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.stddev.txt,True,0,0,STDEVP([num4]),expression,,None,None,1353.0,"
+      SELECT STDDEV_POP(`calcs`.`num4`) AS `temp_test__3542464170__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",10.200892,10.200892
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.sum,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.sum.txt,True,0,0,SUM([int0]),expression,,None,None,1260.0,"
+      SELECT SUM(`calcs`.`int0`) AS `temp_test__645427419__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",68,68
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.sum,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.sum.txt,True,0,0,SUM([num4]),expression,,None,None,1095.0,"
+      SELECT SUM(`calcs`.`num4`) AS `temp_test__1450575838__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",24.02,24.02
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.var,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.var.txt,True,0,0,VAR([num4]),expression,,None,None,1206.0,"
+      SELECT (CASE WHEN COUNT(`calcs`.`num4`) > 1 THEN VAR_SAMP(`calcs`.`num4`) ELSE NULL END) AS `temp_test__1358865__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",113.51803,113.51803
+databricks,expression.standard.databricks,cast_calcs.databricks,agg.var,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.agg.var.txt,True,0,0,VARP([num4]),expression,,None,None,1153.0,"
+      SELECT VAR_POP(`calcs`.`num4`) AS `temp_test__2532468070__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",104.0582,104.0582
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,bool0,expression,,None,None,1101.0,"
+      SELECT `calcs`.`bool0` AS `temp_test__3428507074__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,bool1,expression,,None,None,601.0,"
+      SELECT `calcs`.`bool1` AS `temp_test__1935567978__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,bool2,expression,,None,None,1412.0,"
+      SELECT `calcs`.`bool2` AS `temp_test__3179501244__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","false
+true","false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,bool3,expression,,None,None,989.0,"
+      SELECT `calcs`.`bool3` AS `temp_test__1288552116__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,date0,expression,,None,None,536.0,"
+      SELECT `calcs`.`date0` AS `temp_test__1090544928__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1972-07-04#
+#1975-11-12#
+#2004-04-15#
+#2004-06-04#
+#2004-06-19#","%null%
+#1972-07-04#
+#1975-11-12#
+#2004-04-15#
+#2004-06-04#
+#2004-06-19#"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,date1,expression,,None,None,877.0,"
+      SELECT `calcs`.`date1` AS `temp_test__1295100109__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-04-01#
+#2004-04-02#
+#2004-04-03#
+#2004-04-04#
+#2004-04-05#
+#2004-04-06#
+#2004-04-07#
+#2004-04-08#
+#2004-04-09#
+#2004-04-10#
+#2004-04-11#
+#2004-04-12#
+#2004-04-13#
+#2004-04-14#
+#2004-04-15#
+#2004-04-16#
+#2004-04-17#","#2004-04-01#
+#2004-04-02#
+#2004-04-03#
+#2004-04-04#
+#2004-04-05#
+#2004-04-06#
+#2004-04-07#
+#2004-04-08#
+#2004-04-09#
+#2004-04-10#
+#2004-04-11#
+#2004-04-12#
+#2004-04-13#
+#2004-04-14#
+#2004-04-15#
+#2004-04-16#
+#2004-04-17#"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,date2,expression,,None,None,678.0,"
+      SELECT `calcs`.`date2` AS `temp_test__2028340584__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-12#
+#1974-03-17#
+#1974-05-03#
+#1976-09-09#
+#1977-02-08#
+#1977-04-20#
+#1980-07-26#
+#1980-11-07#
+#1988-01-05#
+#1994-04-20#
+#1995-06-04#
+#1995-09-03#
+#1997-05-30#
+#1997-09-19#
+#1998-08-12#
+#2001-02-04#
+#2002-04-27#","#1972-07-12#
+#1974-03-17#
+#1974-05-03#
+#1976-09-09#
+#1977-02-08#
+#1977-04-20#
+#1980-07-26#
+#1980-11-07#
+#1988-01-05#
+#1994-04-20#
+#1995-06-04#
+#1995-09-03#
+#1997-05-30#
+#1997-09-19#
+#1998-08-12#
+#2001-02-04#
+#2002-04-27#"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,date3,expression,,None,None,1030.0,"
+      SELECT `calcs`.`date3` AS `temp_test__550459061__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1979-04-01#
+#1983-05-22#
+#1986-03-20#
+#1986-11-08#
+#1992-01-18#
+#1996-03-07#
+#1996-05-13#
+#1997-02-02#
+#1999-08-20#","%null%
+#1979-04-01#
+#1983-05-22#
+#1986-03-20#
+#1986-11-08#
+#1992-01-18#
+#1996-03-07#
+#1996-05-13#
+#1997-02-02#
+#1999-08-20#"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,datetime0,expression,,None,None,938.0,"
+      SELECT `calcs`.`datetime0` AS `temp_test__3848052829__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 22:49:28#
+#2004-07-05 13:14:20#
+#2004-07-09 10:17:35#
+#2004-07-12 17:30:16#
+#2004-07-14 07:43:00#
+#2004-07-14 08:16:44#
+#2004-07-17 14:01:56#
+#2004-07-19 22:21:31#
+#2004-07-22 00:30:23#
+#2004-07-23 21:13:37#
+#2004-07-25 15:22:26#
+#2004-07-26 12:30:34#
+#2004-07-28 06:54:50#
+#2004-07-28 12:34:28#
+#2004-07-28 23:30:22#
+#2004-07-31 11:57:52#
+#2004-08-02 07:59:23#","#2004-07-04 22:49:28#
+#2004-07-05 13:14:20#
+#2004-07-09 10:17:35#
+#2004-07-12 17:30:16#
+#2004-07-14 07:43:00#
+#2004-07-14 08:16:44#
+#2004-07-17 14:01:56#
+#2004-07-19 22:21:31#
+#2004-07-22 00:30:23#
+#2004-07-23 21:13:37#
+#2004-07-25 15:22:26#
+#2004-07-26 12:30:34#
+#2004-07-28 06:54:50#
+#2004-07-28 12:34:28#
+#2004-07-28 23:30:22#
+#2004-07-31 11:57:52#
+#2004-08-02 07:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,datetime1,expression,,None,None,757.0,"
+      SELECT `calcs`.`datetime1` AS `temp_test__1108086785__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,key,expression,,None,None,963.0,"
+      SELECT `calcs`.`key` AS `temp_test__3382465274__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""key00""
+""key01""
+""key02""
+""key03""
+""key04""
+""key05""
+""key06""
+""key07""
+""key08""
+""key09""
+""key10""
+""key11""
+""key12""
+""key13""
+""key14""
+""key15""
+""key16""","""key00""
+""key01""
+""key02""
+""key03""
+""key04""
+""key05""
+""key06""
+""key07""
+""key08""
+""key09""
+""key10""
+""key11""
+""key12""
+""key13""
+""key14""
+""key15""
+""key16"""
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,str0,expression,,None,None,935.0,"
+      SELECT `calcs`.`str0` AS `temp_test__55415805__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""FURNITURE""
+""OFFICE SUPPLIES""
+""TECHNOLOGY""","""FURNITURE""
+""OFFICE SUPPLIES""
+""TECHNOLOGY"""
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,str1,expression,,None,None,742.0,"
+      SELECT `calcs`.`str1` AS `temp_test__2285743265__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""AIR PURIFIERS""
+""ANSWERING MACHINES""
+""BINDER ACCESSORIES""
+""BINDER CLIPS""
+""BINDING MACHINES""
+""BINDING SUPPLIES""
+""BUSINESS COPIERS""
+""BUSINESS ENVELOPES""
+""CD-R MEDIA""
+""CLAMP ON LAMPS""
+""CLOCKS""
+""CONFERENCE PHONES""
+""CORDED KEYBOARDS""
+""CORDLESS KEYBOARDS""
+""DOT MATRIX PRINTERS""
+""DVD""
+""ERICSSON""","""AIR PURIFIERS""
+""ANSWERING MACHINES""
+""BINDER ACCESSORIES""
+""BINDER CLIPS""
+""BINDING MACHINES""
+""BINDING SUPPLIES""
+""BUSINESS COPIERS""
+""BUSINESS ENVELOPES""
+""CD-R MEDIA""
+""CLAMP ON LAMPS""
+""CLOCKS""
+""CONFERENCE PHONES""
+""CORDED KEYBOARDS""
+""CORDLESS KEYBOARDS""
+""DOT MATRIX PRINTERS""
+""DVD""
+""ERICSSON"""
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,str2,expression,,None,None,736.0,"
+      SELECT `calcs`.`str2` AS `temp_test__3228347817__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two""","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two"""
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,str3,expression,,None,None,838.0,"
+      SELECT `calcs`.`str3` AS `temp_test__286811776__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""e""","%null%
+""e"""
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,time0,expression,,None,None,953.0,"
+      SELECT `calcs`.`time0` AS `temp_test__4245842207__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#21:07:32#
+#22:15:40#
+#22:24:08#
+#22:42:43#
+#1900-01-01 01:31:32#
+#1900-01-01 04:57:51#
+#1900-01-01 07:37:48#
+#1900-01-01 08:59:39#
+#1900-01-01 09:00:59#
+#1900-01-01 11:58:29#
+#1900-01-01 13:48:48#
+#1900-01-01 13:53:46#
+#1900-01-01 15:01:19#
+#1900-01-01 18:21:08#
+#1900-01-01 18:51:48#
+#1900-01-01 19:45:54#
+#1900-01-01 20:36:00#","#21:07:32#
+#22:15:40#
+#22:24:08#
+#22:42:43#
+#1900-01-01 01:31:32#
+#1900-01-01 04:57:51#
+#1900-01-01 07:37:48#
+#1900-01-01 08:59:39#
+#1900-01-01 09:00:59#
+#1900-01-01 11:58:29#
+#1900-01-01 13:48:48#
+#1900-01-01 13:53:46#
+#1900-01-01 15:01:19#
+#1900-01-01 18:21:08#
+#1900-01-01 18:51:48#
+#1900-01-01 19:45:54#
+#1900-01-01 20:36:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,False,3,12,time1,expression,,Actual does not match expected.,Actual does not match expected.,1242.0,"
+      SELECT `calcs`.`time1` AS `temp_test__665897456__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#2020-02-28 00:05:57#
+#2020-02-28 02:05:25#
+#2020-02-28 04:40:49#
+#2020-02-28 04:48:07#
+#2020-02-28 09:33:31#
+#2020-02-28 12:33:57#
+#2020-02-28 18:58:41#
+#2020-02-28 19:36:22#
+#2020-02-28 19:48:23#
+#2020-02-28 19:57:33#
+#2020-02-28 22:20:14#
+#2020-02-28 22:50:16#","%null%
+#1901-01-31 00:05:57#
+#1901-01-31 02:05:25#
+#1901-01-31 04:40:49#
+#1901-01-31 04:48:07#
+#1901-01-31 09:33:31#
+#1901-01-31 12:33:57#
+#1901-01-31 18:58:41#
+#1901-01-31 19:36:22#
+#1901-01-31 19:48:23#
+#1901-01-31 19:57:33#
+#1901-01-31 22:20:14#
+#1901-01-31 22:50:16#"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,zzz,expression,,None,None,540.0,"
+      SELECT `calcs`.`zzz` AS `temp_test__1729594319__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""a""
+""b""
+""c""
+""d""
+""e""
+""f""
+""g""
+""h""
+""i""
+""j""
+""k""
+""l""
+""m""
+""n""
+""o""
+""p""
+""q""","""a""
+""b""
+""c""
+""d""
+""e""
+""f""
+""g""
+""h""
+""i""
+""j""
+""k""
+""l""
+""m""
+""n""
+""o""
+""p""
+""q"""
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,int0,expression,,None,None,899.0,"
+      SELECT `calcs`.`int0` AS `temp_test__3174765981__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+1
+3
+4
+7
+8
+10
+11","%null%
+1
+3
+4
+7
+8
+10
+11"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,int1,expression,,None,None,714.0,"
+      SELECT `calcs`.`int1` AS `temp_test__2829869592__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-9
+-8
+-6
+-4
+-3
+2
+3","%null%
+-9
+-8
+-6
+-4
+-3
+2
+3"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,int2,expression,,None,None,692.0,"
+      SELECT `calcs`.`int2` AS `temp_test__551775594__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-9
+-8
+-6
+-5
+-4
+-3
+0
+2
+3
+4
+5
+6
+9","-9
+-8
+-6
+-5
+-4
+-3
+0
+2
+3
+4
+5
+6
+9"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,int3,expression,,None,None,853.0,"
+      SELECT `calcs`.`int3` AS `temp_test__524492059__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","0
+2
+3
+5
+7
+8
+9
+11
+13
+17
+18","0
+2
+3
+5
+7
+8
+9
+11
+13
+17
+18"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,num0,expression,,None,None,726.0,"
+      SELECT `calcs`.`num0` AS `temp_test__3934956185__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-15.7
+-12.3
+-3.5
+0.0
+3.5
+10.0
+12.3
+15.7","%null%
+-15.7
+-12.3
+-3.5
+0.0
+3.5
+10.0
+12.3
+15.7"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,num1,expression,,None,None,571.0,"
+      SELECT `calcs`.`num1` AS `temp_test__129981160__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","2.47
+6.71
+7.1
+7.12
+7.43
+8.42
+9.05
+9.38
+9.47
+9.78
+10.32
+10.37
+11.38
+12.05
+12.4
+16.42
+16.81","2.47
+6.71
+7.1
+7.12
+7.43
+8.42
+9.05
+9.38
+9.47
+9.78
+10.32
+10.37
+11.38
+12.05
+12.4
+16.42
+16.81"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,num2,expression,,None,None,698.0,"
+      SELECT `calcs`.`num2` AS `temp_test__1053269056__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+3.79
+6.46
+6.8
+7.87
+8.51
+8.98
+10.98
+11.5
+11.69
+13.04
+16.73
+17.25
+17.86","%null%
+3.79
+6.46
+6.8
+7.87
+8.51
+8.98
+10.98
+11.5
+11.69
+13.04
+16.73
+17.25
+17.86"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,num3,expression,,None,None,818.0,"
+      SELECT `calcs`.`num3` AS `temp_test__3320504981__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-19.96
+-18.43
+-13.38
+-12.17
+-11.52
+-10.98
+-10.81
+-10.56
+-9.31
+-7.25
+-6.62
+-4.79
+-2.6
+3.64
+6.84
+10.93
+12.93","-19.96
+-18.43
+-13.38
+-12.17
+-11.52
+-10.98
+-10.81
+-10.56
+-9.31
+-7.25
+-6.62
+-4.79
+-2.6
+3.64
+6.84
+10.93
+12.93"
+databricks,expression.standard.databricks,cast_calcs.databricks,calcs_data,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.calcs_data.txt,True,3,0,num4,expression,,None,None,731.0,"
+      SELECT `calcs`.`num4` AS `temp_test__3786834202__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-14.21
+-13.47
+-10.24
+-6.05
+3.38
+3.82
+4.77
+6.75
+8.32
+10.71
+10.85
+19.39","%null%
+-14.21
+-13.47
+-10.24
+-6.05
+3.38
+3.82
+4.77
+6.75
+8.32
+10.71
+10.85
+19.39"
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.float.string,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.float.string.txt,True,0,0,"float(""1234."" + RIGHT([key],2))",expression,,None,None,891.0,"
+      SELECT CAST(CONCAT('1234.',(CASE WHEN 2 >= 0 THEN IF(LENGTH(`calcs`.`key`) < 2 + 1, `calcs`.`key`, SUBSTRING(`calcs`.`key`, LENGTH(`calcs`.`key`) - CAST(2 AS INT) + 1)) ELSE NULL END)) AS DOUBLE) AS `temp_test__93928613__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1234.0
+1234.01
+1234.02
+1234.03
+1234.04
+1234.05
+1234.06
+1234.07
+1234.08
+1234.09
+1234.1
+1234.11
+1234.12
+1234.13
+1234.14
+1234.15
+1234.16","1234.0
+1234.01
+1234.02
+1234.03
+1234.04
+1234.05
+1234.06
+1234.07
+1234.08
+1234.09
+1234.1
+1234.11
+1234.12
+1234.13
+1234.14
+1234.15
+1234.16"
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.float,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.float.txt,True,0,0,FLOAT([int1]),expression,,None,None,646.0,"
+      SELECT CAST(`calcs`.`int1` AS DOUBLE) AS `temp_test__1533389080__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-9.0
+-8.0
+-6.0
+-4.0
+-3.0
+2.0
+3.0","%null%
+-9.0
+-8.0
+-6.0
+-4.0
+-3.0
+2.0
+3.0"
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.float,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.float.txt,True,0,0,FLOAT([bool0]),expression,,None,None,706.0,"
+      SELECT (CASE
+	WHEN `calcs`.`bool0` THEN 1.0
+	WHEN NOT `calcs`.`bool0` THEN 0.0
+	ELSE NULL END) AS `temp_test__2538631291__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0.0
+1.0","%null%
+0.0
+1.0"
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.float,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.float.txt,True,0,0,FLOAT([date0]),expression,,None,None,457.0,"
+      SELECT DATEDIFF(CAST(`calcs`.`date0` AS DATE), CAST('1900-01-01' AS DATE)) AS `temp_test__64617177__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+26482.0
+27708.0
+38090.0
+38140.0
+38155.0","%null%
+26482.0
+27708.0
+38090.0
+38140.0
+38155.0"
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.float,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.float.txt,True,0,0,FLOAT([num2]),expression,,None,None,529.0,"
+      SELECT CAST(`calcs`.`num2` AS DOUBLE) AS `temp_test__2707307071__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+3.79
+6.46
+6.8
+7.87
+8.51
+8.98
+10.98
+11.5
+11.69
+13.04
+16.73
+17.25
+17.86","%null%
+3.79
+6.46
+6.8
+7.87
+8.51
+8.98
+10.98
+11.5
+11.69
+13.04
+16.73
+17.25
+17.86"
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.int.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.int.nulls.txt,True,0,0,INT([num4]),expression,,None,None,579.0,"
+      SELECT CAST(`calcs`.`num4` AS BIGINT) AS `temp_test__663412696__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-14
+-13
+-10
+-6
+3
+4
+6
+8
+10
+19","%null%
+-14
+-13
+-10
+-6
+3
+4
+6
+8
+10
+19"
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.int.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.int.nulls.txt,True,0,0,int(str(num4)+str(int0)),expression,,None,None,582.0,"
+      SELECT CAST(CAST(CONCAT(CAST(`calcs`.`num4` AS STRING),CAST(`calcs`.`int0` AS STRING)) AS DOUBLE) AS BIGINT) AS `temp_test__1616170242__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-14
+3
+6
+8
+10
+19","%null%
+-14
+3
+6
+8
+10
+19"
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.int,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.int.txt,True,0,0,INT([int1]),expression,,None,None,388.0,"
+      SELECT CAST(`calcs`.`int1` AS BIGINT) AS `temp_test__551720338__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-9
+-8
+-6
+-4
+-3
+2
+3","%null%
+-9
+-8
+-6
+-4
+-3
+2
+3"
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.int,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.int.txt,True,0,0,INT([bool0]),expression,,None,None,636.0,"
+      SELECT (CASE
+	WHEN `calcs`.`bool0` THEN 1
+	WHEN NOT `calcs`.`bool0` THEN 0
+	ELSE NULL END) AS `temp_test__2695057561__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0
+1","%null%
+0
+1"
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.int,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.int.txt,True,0,0,INT([date0]),expression,,None,None,582.0,"
+      SELECT DATEDIFF(CAST(`calcs`.`date0` AS DATE), CAST('1900-01-01' AS DATE)) AS `temp_test__2234960540__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+26482
+27708
+38090
+38140
+38155","%null%
+26482
+27708
+38090
+38140
+38155"
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.int,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.int.txt,True,0,0,INT([num2]),expression,,None,None,571.0,"
+      SELECT CAST(`calcs`.`num2` AS BIGINT) AS `temp_test__1665700248__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+3
+6
+7
+8
+10
+11
+13
+16
+17","%null%
+3
+6
+7
+8
+10
+11
+13
+16
+17"
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.str.date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.str.date.txt,True,0,0,DATE(STR([date0])),expression,,None,None,526.0,"
+      SELECT CAST(CAST(CAST(`calcs`.`date0` AS STRING) AS TIMESTAMP) AS DATE) AS `temp_test__3072781275__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1972-07-04#
+#1975-11-12#
+#2004-04-15#
+#2004-06-04#
+#2004-06-19#","%null%
+#1972-07-04#
+#1975-11-12#
+#2004-04-15#
+#2004-06-04#
+#2004-06-19#"
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.str.date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.str.date.txt,True,0,0,DATE(STR([date2])),expression,,None,None,562.0,"
+      SELECT CAST(CAST(CAST(`calcs`.`date2` AS STRING) AS TIMESTAMP) AS DATE) AS `temp_test__3232345613__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-12#
+#1974-03-17#
+#1974-05-03#
+#1976-09-09#
+#1977-02-08#
+#1977-04-20#
+#1980-07-26#
+#1980-11-07#
+#1988-01-05#
+#1994-04-20#
+#1995-06-04#
+#1995-09-03#
+#1997-05-30#
+#1997-09-19#
+#1998-08-12#
+#2001-02-04#
+#2002-04-27#","#1972-07-12#
+#1974-03-17#
+#1974-05-03#
+#1976-09-09#
+#1977-02-08#
+#1977-04-20#
+#1980-07-26#
+#1980-11-07#
+#1988-01-05#
+#1994-04-20#
+#1995-06-04#
+#1995-09-03#
+#1997-05-30#
+#1997-09-19#
+#1998-08-12#
+#2001-02-04#
+#2002-04-27#"
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.str.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.str.str.txt,True,0,0,STR(STR([str2])),expression,,None,None,427.0,"
+      SELECT CAST(`calcs`.`str2` AS STRING) AS `temp_test__2730627169__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two""","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two"""
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.str.txt,True,1,0,STR([int1]),expression,,None,None,583.0,"
+      SELECT CAST(`calcs`.`int1` AS STRING) AS `temp_test__2617331766__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""-3""
+""-4""
+""-6""
+""-8""
+""-9""
+""2""
+""3""","%null%
+""-3""
+""-4""
+""-6""
+""-8""
+""-9""
+""2""
+""3"""
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.str.txt,True,1,0,STR([bool0]),expression,,None,None,828.0,"
+      SELECT (CASE
+	WHEN `calcs`.`bool0` THEN '1'
+	WHEN NOT `calcs`.`bool0` THEN '0'
+	ELSE NULL END) AS `temp_test__3200082645__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""0""
+""1""","%null%
+""0""
+""1"""
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.str.txt,True,1,0,STR([num2]),expression,,None,None,457.0,"
+      SELECT CAST(`calcs`.`num2` AS STRING) AS `temp_test__3049448927__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""10.98""
+""11.5""
+""11.69""
+""13.04""
+""16.73""
+""17.25""
+""17.86""
+""3.79""
+""6.46""
+""6.8""
+""7.87""
+""8.51""
+""8.98""","%null%
+""10.98""
+""11.5""
+""11.69""
+""13.04""
+""16.73""
+""17.25""
+""17.86""
+""3.79""
+""6.46""
+""6.8""
+""7.87""
+""8.51""
+""8.98"""
+databricks,expression.standard.databricks,cast_calcs.databricks,cast.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.cast.str.txt,True,1,0,STR([str2]),expression,,None,None,659.0,"
+      SELECT CAST(`calcs`.`str2` AS STRING) AS `temp_test__3494867617__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two""","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.B639952,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.B639952.txt,True,1,0,SUM([date0]-1-[date1]),expression,,None,None,694.0,"
+      SELECT SUM((UNIX_TIMESTAMP(CAST(DATE_ADD(`calcs`.`date0`, CAST(-(1) AS INT)) AS DATE)) - UNIX_TIMESTAMP(`calcs`.`date1`)) / 86400.0) AS `temp_test__852777247__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",-21820.0,-21820.0
+databricks,expression.standard.databricks,cast_calcs.databricks,date.B639952,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.B639952.txt,True,1,0,SUM([date0]+300-[date1]),expression,,None,None,614.0,"
+      SELECT SUM((UNIX_TIMESTAMP(CAST(DATE_ADD(`calcs`.`date0`, CAST(300 AS INT)) AS DATE)) - UNIX_TIMESTAMP(`calcs`.`date1`)) / 86400.0) AS `temp_test__3920605433__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",-20315.0,-20315.0
+databricks,expression.standard.databricks,cast_calcs.databricks,date.B639952,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.B639952.txt,True,1,0,[date0]-([date1]-1-[date2]),expression,,None,None,573.0,"
+      SELECT CAST(FROM_UNIXTIME(CAST(CAST(`calcs`.`date0` AS TIMESTAMP) AS BIGINT) - CAST(((UNIX_TIMESTAMP(CAST(DATE_ADD(`calcs`.`date1`, CAST(-(1) AS INT)) AS DATE)) - UNIX_TIMESTAMP(`calcs`.`date2`)) / 86400.0) * 86400 AS INT)) AS TIMESTAMP) AS `temp_test__750868662__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1963-12-06 00:00:00#
+#1969-04-30 00:00:00#
+#1977-05-05 00:00:00#
+#1980-09-26 00:00:00#
+#1997-08-14 00:00:00#","%null%
+#1963-12-06 00:00:00#
+#1969-04-30 00:00:00#
+#1977-05-05 00:00:00#
+#1980-09-26 00:00:00#
+#1997-08-14 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.B639952,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.B639952.txt,True,1,0,[date1]-([date3]+500-[date2]),expression,,None,None,600.0,"
+      SELECT CAST(FROM_UNIXTIME(CAST(CAST(`calcs`.`date1` AS TIMESTAMP) AS BIGINT) - CAST(((UNIX_TIMESTAMP(CAST(DATE_ADD(`calcs`.`date3`, CAST(500 AS INT)) AS DATE)) - UNIX_TIMESTAMP(`calcs`.`date2`)) / 86400.0) * 86400 AS INT)) AS TIMESTAMP) AS `temp_test__2315954727__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1977-06-25 00:00:00#
+#1988-08-05 00:00:00#
+#1993-12-19 00:00:00#
+#1994-07-25 00:00:00#
+#1996-03-16 00:00:00#
+#2003-07-07 00:00:00#
+#2004-02-14 00:00:00#
+#2004-07-01 00:00:00#
+#2013-03-13 00:00:00#","%null%
+#1977-06-25 00:00:00#
+#1988-08-05 00:00:00#
+#1993-12-19 00:00:00#
+#1994-07-25 00:00:00#
+#1996-03-16 00:00:00#
+#2003-07-07 00:00:00#
+#2004-02-14 00:00:00#
+#2004-07-01 00:00:00#
+#2013-03-13 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.B639952,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.B639952.txt,True,1,0,[date1]-([date3]+500-[date2])+([date3]-[date0]),expression,,None,None,626.0,"
+      SELECT CAST(FROM_UNIXTIME(CAST(CAST(CAST(FROM_UNIXTIME(CAST(CAST(`calcs`.`date1` AS TIMESTAMP) AS BIGINT) - CAST(((UNIX_TIMESTAMP(CAST(DATE_ADD(`calcs`.`date3`, CAST(500 AS INT)) AS DATE)) - UNIX_TIMESTAMP(`calcs`.`date2`)) / 86400.0) * 86400 AS INT)) AS TIMESTAMP) AS BIGINT) + ((UNIX_TIMESTAMP(`calcs`.`date3`) - UNIX_TIMESTAMP(`calcs`.`date0`)) / 86400.0 * 86400) AS BIGINT)) AS TIMESTAMP) AS `temp_test__268214076__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1975-11-23 00:00:00#
+#1995-11-02 00:00:00#
+#2024-09-27 00:00:00#","%null%
+#1975-11-23 00:00:00#
+#1995-11-02 00:00:00#
+#2024-09-27 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.B639952,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.B639952.txt,True,1,0,SUM(([date3]-400-[date0])+([date3]+500-[date2])),expression,,None,None,531.0,"
+      SELECT SUM(((UNIX_TIMESTAMP(CAST(DATE_ADD(`calcs`.`date3`, CAST(-(400) AS INT)) AS DATE)) - UNIX_TIMESTAMP(`calcs`.`date0`)) / 86400.0 + (UNIX_TIMESTAMP(CAST(DATE_ADD(`calcs`.`date3`, CAST(500 AS INT)) AS DATE)) - UNIX_TIMESTAMP(`calcs`.`date2`)) / 86400.0)) AS `temp_test__2422363430__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",1004.0,1004.0
+databricks,expression.standard.databricks,cast_calcs.databricks,date.B639952,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.B639952.txt,True,1,0,"SUM([date3]-1-(date(dateadd('month', 3, #2004-04-15# )))+1)",expression,,None,None,583.0,"
+      SELECT SUM(((UNIX_TIMESTAMP(CAST(DATE_ADD(`calcs`.`date3`, CAST(-(1) AS INT)) AS DATE)) - UNIX_TIMESTAMP(CAST(CAST(CAST(CONCAT(ADD_MONTHS(CAST('2004-04-15' AS DATE),3),SUBSTR(CAST(CAST('2004-04-15' AS DATE) AS TIMESTAMP),11)) AS TIMESTAMP) AS TIMESTAMP) AS DATE))) / 86400.0 + 1)) AS `temp_test__3637530074__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",-45223.0,-45223.0
+databricks,expression.standard.databricks,cast_calcs.databricks,date.cast.date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.cast.date.txt,True,0,0,DATE([date2]),expression,,None,None,545.0,"
+      SELECT CAST(CAST(`calcs`.`date2` AS TIMESTAMP) AS DATE) AS `temp_test__3817907367__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-12#
+#1974-03-17#
+#1974-05-03#
+#1976-09-09#
+#1977-02-08#
+#1977-04-20#
+#1980-07-26#
+#1980-11-07#
+#1988-01-05#
+#1994-04-20#
+#1995-06-04#
+#1995-09-03#
+#1997-05-30#
+#1997-09-19#
+#1998-08-12#
+#2001-02-04#
+#2002-04-27#","#1972-07-12#
+#1974-03-17#
+#1974-05-03#
+#1976-09-09#
+#1977-02-08#
+#1977-04-20#
+#1980-07-26#
+#1980-11-07#
+#1988-01-05#
+#1994-04-20#
+#1995-06-04#
+#1995-09-03#
+#1997-05-30#
+#1997-09-19#
+#1998-08-12#
+#2001-02-04#
+#2002-04-27#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.cast.datetime.630831,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.cast.datetime.630831.txt,True,0,0,Date('2017-01-01 12:12:12.0'),expression,,None,None,333.0,"
+      SELECT CAST(CAST('2017-01-01 12:12:12.0' AS TIMESTAMP) AS DATE) AS `temp_test__1641592311__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",#2017-01-01#,#2017-01-01#
+databricks,expression.standard.databricks,cast_calcs.databricks,date.cast.datetime,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.cast.datetime.txt,True,0,0,DATETIME([date2]),expression,,None,None,319.0,"
+      SELECT CAST(`calcs`.`date2` AS TIMESTAMP) AS `temp_test__1486024523__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.cast.float.extended,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.cast.float.extended.txt,True,0,0,float(#2050-01-01#),expression,,None,None,322.0,"
+      SELECT DATEDIFF(CAST(CAST('2050-01-01' AS DATE) AS DATE), CAST('1900-01-01' AS DATE)) AS `temp_test__3947742720__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",54787.0,54787.0
+databricks,expression.standard.databricks,cast_calcs.databricks,date.cast.float,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.cast.float.txt,True,0,0,FLOAT([date2]),expression,,None,None,308.0,"
+      SELECT DATEDIFF(CAST(`calcs`.`date2` AS DATE), CAST('1900-01-01' AS DATE)) AS `temp_test__2671902822__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","26490.0
+27103.0
+27150.0
+28010.0
+28162.0
+28233.0
+29426.0
+29530.0
+32145.0
+34442.0
+34852.0
+34943.0
+35578.0
+35690.0
+36017.0
+36924.0
+37371.0","26490.0
+27103.0
+27150.0
+28010.0
+28162.0
+28233.0
+29426.0
+29530.0
+32145.0
+34442.0
+34852.0
+34943.0
+35578.0
+35690.0
+36017.0
+36924.0
+37371.0"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.cast.int.extended,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.cast.int.extended.txt,True,0,0,int(#2050-01-01#),expression,,None,None,324.0,"
+      SELECT DATEDIFF(CAST(CAST('2050-01-01' AS DATE) AS DATE), CAST('1900-01-01' AS DATE)) AS `temp_test__1685825827__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",54787,54787
+databricks,expression.standard.databricks,cast_calcs.databricks,date.cast.num_to_date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.cast.num_to_date.txt,True,5,0,DATE([num4]),expression,,None,None,343.0,"
+      SELECT CAST(CAST(`calcs`.`num4` AS TIMESTAMP) AS DATE) AS `temp_test__158994214__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1969-12-31#
+#1970-01-01#","%null%
+#1969-12-31#
+#1970-01-01#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.cast.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.cast.str.txt,True,0,0,TRIM(STR([date2])),expression,,None,None,332.0,"
+      SELECT TRIM(CAST(`calcs`.`date2` AS STRING)) AS `temp_test__3929621149__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1972-07-12""
+""1974-03-17""
+""1974-05-03""
+""1976-09-09""
+""1977-02-08""
+""1977-04-20""
+""1980-07-26""
+""1980-11-07""
+""1988-01-05""
+""1994-04-20""
+""1995-06-04""
+""1995-09-03""
+""1997-05-30""
+""1997-09-19""
+""1998-08-12""
+""2001-02-04""
+""2002-04-27""","""1972-07-12""
+""1974-03-17""
+""1974-05-03""
+""1976-09-09""
+""1977-02-08""
+""1977-04-20""
+""1980-07-26""
+""1980-11-07""
+""1988-01-05""
+""1994-04-20""
+""1995-06-04""
+""1995-09-03""
+""1997-05-30""
+""1997-09-19""
+""1998-08-12""
+""2001-02-04""
+""2002-04-27"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.day.txt,True,0,0,"DATEADD('day', 1, [date2])",expression,,None,None,341.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(`calcs`.`date2` AS TIMESTAMP), CAST(1 AS INT)), SUBSTR(CAST(CAST(`calcs`.`date2` AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__670684053__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-13 00:00:00#
+#1974-03-18 00:00:00#
+#1974-05-04 00:00:00#
+#1976-09-10 00:00:00#
+#1977-02-09 00:00:00#
+#1977-04-21 00:00:00#
+#1980-07-27 00:00:00#
+#1980-11-08 00:00:00#
+#1988-01-06 00:00:00#
+#1994-04-21 00:00:00#
+#1995-06-05 00:00:00#
+#1995-09-04 00:00:00#
+#1997-05-31 00:00:00#
+#1997-09-20 00:00:00#
+#1998-08-13 00:00:00#
+#2001-02-05 00:00:00#
+#2002-04-28 00:00:00#","#1972-07-13 00:00:00#
+#1974-03-18 00:00:00#
+#1974-05-04 00:00:00#
+#1976-09-10 00:00:00#
+#1977-02-09 00:00:00#
+#1977-04-21 00:00:00#
+#1980-07-27 00:00:00#
+#1980-11-08 00:00:00#
+#1988-01-06 00:00:00#
+#1994-04-21 00:00:00#
+#1995-06-05 00:00:00#
+#1995-09-04 00:00:00#
+#1997-05-31 00:00:00#
+#1997-09-20 00:00:00#
+#1998-08-13 00:00:00#
+#2001-02-05 00:00:00#
+#2002-04-28 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.day.txt,True,0,0,"DATEADD('day', 1, [datetime0])",expression,,None,None,339.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(`calcs`.`datetime0` AS TIMESTAMP), CAST(1 AS INT)), SUBSTR(CAST(CAST(`calcs`.`datetime0` AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__2728495522__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-05 22:49:28#
+#2004-07-06 13:14:20#
+#2004-07-10 10:17:35#
+#2004-07-13 17:30:16#
+#2004-07-15 07:43:00#
+#2004-07-15 08:16:44#
+#2004-07-18 14:01:56#
+#2004-07-20 22:21:31#
+#2004-07-23 00:30:23#
+#2004-07-24 21:13:37#
+#2004-07-26 15:22:26#
+#2004-07-27 12:30:34#
+#2004-07-29 06:54:50#
+#2004-07-29 12:34:28#
+#2004-07-29 23:30:22#
+#2004-08-01 11:57:52#
+#2004-08-03 07:59:23#","#2004-07-05 22:49:28#
+#2004-07-06 13:14:20#
+#2004-07-10 10:17:35#
+#2004-07-13 17:30:16#
+#2004-07-15 07:43:00#
+#2004-07-15 08:16:44#
+#2004-07-18 14:01:56#
+#2004-07-20 22:21:31#
+#2004-07-23 00:30:23#
+#2004-07-24 21:13:37#
+#2004-07-26 15:22:26#
+#2004-07-27 12:30:34#
+#2004-07-29 06:54:50#
+#2004-07-29 12:34:28#
+#2004-07-29 23:30:22#
+#2004-08-01 11:57:52#
+#2004-08-03 07:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.dayofyear.txt,True,0,0,"DATEADD('dayofyear', 1, [date2])",expression,,None,None,302.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(`calcs`.`date2` AS TIMESTAMP), CAST(1 AS INT)), SUBSTR(CAST(CAST(`calcs`.`date2` AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__1139290352__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-13 00:00:00#
+#1974-03-18 00:00:00#
+#1974-05-04 00:00:00#
+#1976-09-10 00:00:00#
+#1977-02-09 00:00:00#
+#1977-04-21 00:00:00#
+#1980-07-27 00:00:00#
+#1980-11-08 00:00:00#
+#1988-01-06 00:00:00#
+#1994-04-21 00:00:00#
+#1995-06-05 00:00:00#
+#1995-09-04 00:00:00#
+#1997-05-31 00:00:00#
+#1997-09-20 00:00:00#
+#1998-08-13 00:00:00#
+#2001-02-05 00:00:00#
+#2002-04-28 00:00:00#","#1972-07-13 00:00:00#
+#1974-03-18 00:00:00#
+#1974-05-04 00:00:00#
+#1976-09-10 00:00:00#
+#1977-02-09 00:00:00#
+#1977-04-21 00:00:00#
+#1980-07-27 00:00:00#
+#1980-11-08 00:00:00#
+#1988-01-06 00:00:00#
+#1994-04-21 00:00:00#
+#1995-06-05 00:00:00#
+#1995-09-04 00:00:00#
+#1997-05-31 00:00:00#
+#1997-09-20 00:00:00#
+#1998-08-13 00:00:00#
+#2001-02-05 00:00:00#
+#2002-04-28 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.dayofyear.txt,True,0,0,"DATEADD('dayofyear', 1, [datetime0])",expression,,None,None,307.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(`calcs`.`datetime0` AS TIMESTAMP), CAST(1 AS INT)), SUBSTR(CAST(CAST(`calcs`.`datetime0` AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__748109579__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-05 22:49:28#
+#2004-07-06 13:14:20#
+#2004-07-10 10:17:35#
+#2004-07-13 17:30:16#
+#2004-07-15 07:43:00#
+#2004-07-15 08:16:44#
+#2004-07-18 14:01:56#
+#2004-07-20 22:21:31#
+#2004-07-23 00:30:23#
+#2004-07-24 21:13:37#
+#2004-07-26 15:22:26#
+#2004-07-27 12:30:34#
+#2004-07-29 06:54:50#
+#2004-07-29 12:34:28#
+#2004-07-29 23:30:22#
+#2004-08-01 11:57:52#
+#2004-08-03 07:59:23#","#2004-07-05 22:49:28#
+#2004-07-06 13:14:20#
+#2004-07-10 10:17:35#
+#2004-07-13 17:30:16#
+#2004-07-15 07:43:00#
+#2004-07-15 08:16:44#
+#2004-07-18 14:01:56#
+#2004-07-20 22:21:31#
+#2004-07-23 00:30:23#
+#2004-07-24 21:13:37#
+#2004-07-26 15:22:26#
+#2004-07-27 12:30:34#
+#2004-07-29 06:54:50#
+#2004-07-29 12:34:28#
+#2004-07-29 23:30:22#
+#2004-08-01 11:57:52#
+#2004-08-03 07:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.hour,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.hour.txt,True,0,0,"DATEADD('hour', 1, [datetime0])",expression,,None,None,348.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(`calcs`.`datetime0`) + 1*3600) AS TIMESTAMP) AS `temp_test__4261466899__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 23:49:28#
+#2004-07-05 14:14:20#
+#2004-07-09 11:17:35#
+#2004-07-12 18:30:16#
+#2004-07-14 08:43:00#
+#2004-07-14 09:16:44#
+#2004-07-17 15:01:56#
+#2004-07-19 23:21:31#
+#2004-07-22 01:30:23#
+#2004-07-23 22:13:37#
+#2004-07-25 16:22:26#
+#2004-07-26 13:30:34#
+#2004-07-28 07:54:50#
+#2004-07-28 13:34:28#
+#2004-07-29 00:30:22#
+#2004-07-31 12:57:52#
+#2004-08-02 08:59:23#","#2004-07-04 23:49:28#
+#2004-07-05 14:14:20#
+#2004-07-09 11:17:35#
+#2004-07-12 18:30:16#
+#2004-07-14 08:43:00#
+#2004-07-14 09:16:44#
+#2004-07-17 15:01:56#
+#2004-07-19 23:21:31#
+#2004-07-22 01:30:23#
+#2004-07-23 22:13:37#
+#2004-07-25 16:22:26#
+#2004-07-26 13:30:34#
+#2004-07-28 07:54:50#
+#2004-07-28 13:34:28#
+#2004-07-29 00:30:22#
+#2004-07-31 12:57:52#
+#2004-08-02 08:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.minute,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.minute.txt,True,0,0,"DATEADD('minute', 1, [datetime0])",expression,,None,None,331.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(`calcs`.`datetime0`) + 1*60) AS TIMESTAMP) AS `temp_test__2741755004__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 22:50:28#
+#2004-07-05 13:15:20#
+#2004-07-09 10:18:35#
+#2004-07-12 17:31:16#
+#2004-07-14 07:44:00#
+#2004-07-14 08:17:44#
+#2004-07-17 14:02:56#
+#2004-07-19 22:22:31#
+#2004-07-22 00:31:23#
+#2004-07-23 21:14:37#
+#2004-07-25 15:23:26#
+#2004-07-26 12:31:34#
+#2004-07-28 06:55:50#
+#2004-07-28 12:35:28#
+#2004-07-28 23:31:22#
+#2004-07-31 11:58:52#
+#2004-08-02 08:00:23#","#2004-07-04 22:50:28#
+#2004-07-05 13:15:20#
+#2004-07-09 10:18:35#
+#2004-07-12 17:31:16#
+#2004-07-14 07:44:00#
+#2004-07-14 08:17:44#
+#2004-07-17 14:02:56#
+#2004-07-19 22:22:31#
+#2004-07-22 00:31:23#
+#2004-07-23 21:14:37#
+#2004-07-25 15:23:26#
+#2004-07-26 12:31:34#
+#2004-07-28 06:55:50#
+#2004-07-28 12:35:28#
+#2004-07-28 23:31:22#
+#2004-07-31 11:58:52#
+#2004-08-02 08:00:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.month.txt,True,0,0,"DATEADD('month', 1, [date2])",expression,,None,None,342.0,"
+      SELECT CAST(CONCAT(ADD_MONTHS(`calcs`.`date2`,1),SUBSTR(CAST(`calcs`.`date2` AS TIMESTAMP),11)) AS TIMESTAMP) AS `temp_test__2799254343__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-08-12 00:00:00#
+#1974-04-17 00:00:00#
+#1974-06-03 00:00:00#
+#1976-10-09 00:00:00#
+#1977-03-08 00:00:00#
+#1977-05-20 00:00:00#
+#1980-08-26 00:00:00#
+#1980-12-07 00:00:00#
+#1988-02-05 00:00:00#
+#1994-05-20 00:00:00#
+#1995-07-04 00:00:00#
+#1995-10-03 00:00:00#
+#1997-06-30 00:00:00#
+#1997-10-19 00:00:00#
+#1998-09-12 00:00:00#
+#2001-03-04 00:00:00#
+#2002-05-27 00:00:00#","#1972-08-12 00:00:00#
+#1974-04-17 00:00:00#
+#1974-06-03 00:00:00#
+#1976-10-09 00:00:00#
+#1977-03-08 00:00:00#
+#1977-05-20 00:00:00#
+#1980-08-26 00:00:00#
+#1980-12-07 00:00:00#
+#1988-02-05 00:00:00#
+#1994-05-20 00:00:00#
+#1995-07-04 00:00:00#
+#1995-10-03 00:00:00#
+#1997-06-30 00:00:00#
+#1997-10-19 00:00:00#
+#1998-09-12 00:00:00#
+#2001-03-04 00:00:00#
+#2002-05-27 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.month.txt,True,0,0,"DATEADD('month', 1, [datetime0])",expression,,None,None,342.0,"
+      SELECT CAST(CONCAT(ADD_MONTHS(`calcs`.`datetime0`,1),SUBSTR(CAST(`calcs`.`datetime0` AS TIMESTAMP),11)) AS TIMESTAMP) AS `temp_test__1378354598__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-08-04 22:49:28#
+#2004-08-05 13:14:20#
+#2004-08-09 10:17:35#
+#2004-08-12 17:30:16#
+#2004-08-14 07:43:00#
+#2004-08-14 08:16:44#
+#2004-08-17 14:01:56#
+#2004-08-19 22:21:31#
+#2004-08-22 00:30:23#
+#2004-08-23 21:13:37#
+#2004-08-25 15:22:26#
+#2004-08-26 12:30:34#
+#2004-08-28 06:54:50#
+#2004-08-28 12:34:28#
+#2004-08-28 23:30:22#
+#2004-08-31 11:57:52#
+#2004-09-02 07:59:23#","#2004-08-04 22:49:28#
+#2004-08-05 13:14:20#
+#2004-08-09 10:17:35#
+#2004-08-12 17:30:16#
+#2004-08-14 07:43:00#
+#2004-08-14 08:16:44#
+#2004-08-17 14:01:56#
+#2004-08-19 22:21:31#
+#2004-08-22 00:30:23#
+#2004-08-23 21:13:37#
+#2004-08-25 15:22:26#
+#2004-08-26 12:30:34#
+#2004-08-28 06:54:50#
+#2004-08-28 12:34:28#
+#2004-08-28 23:30:22#
+#2004-08-31 11:57:52#
+#2004-09-02 07:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('year', 1, DATE(null))",expression,,None,None,332.0,"
+      SELECT CAST(CONCAT(YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))+1, SUBSTR(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS TIMESTAMP), 5)) AS TIMESTAMP) AS `temp_test__1053114602__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('year', 1, DATETIME(null))",expression,,None,None,317.0,"
+      SELECT CAST(CONCAT(YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP))+1, SUBSTR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS TIMESTAMP), 5)) AS TIMESTAMP) AS `temp_test__955333125__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('quarter', 1, DATE(null))",expression,,None,None,371.0,"
+      SELECT CAST(CONCAT(ADD_MONTHS(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),(1 * 3)),SUBSTR(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS TIMESTAMP),11)) AS TIMESTAMP) AS `temp_test__2396988690__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('quarter', 1, DATETIME(null))",expression,,None,None,326.0,"
+      SELECT CAST(CONCAT(ADD_MONTHS(CAST(CAST(NULL AS INT) AS TIMESTAMP),(1 * 3)),SUBSTR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS TIMESTAMP),11)) AS TIMESTAMP) AS `temp_test__2232502461__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('month', 1, DATE(null))",expression,,None,None,468.0,"
+      SELECT CAST(CONCAT(ADD_MONTHS(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),1),SUBSTR(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS TIMESTAMP),11)) AS TIMESTAMP) AS `temp_test__109946472__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('month', 1, DATETIME(null))",expression,,None,None,372.0,"
+      SELECT CAST(CONCAT(ADD_MONTHS(CAST(CAST(NULL AS INT) AS TIMESTAMP),1),SUBSTR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS TIMESTAMP),11)) AS TIMESTAMP) AS `temp_test__2095510626__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('week', 1, DATE(null))",expression,,None,None,319.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS TIMESTAMP), CAST(7 * 1 AS INT)), SUBSTR(CAST(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__359186020__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('week', 1, DATETIME(null))",expression,,None,None,302.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS TIMESTAMP), CAST(7 * 1 AS INT)), SUBSTR(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__3060670302__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('weekday', 1, DATE(null))",expression,,None,None,371.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS TIMESTAMP), CAST(1 AS INT)), SUBSTR(CAST(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__592740370__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('weekday', 1, DATETIME(null))",expression,,None,None,317.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS TIMESTAMP), CAST(1 AS INT)), SUBSTR(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__4169571243__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('dayofyear', 1, DATE(null))",expression,,None,None,328.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS TIMESTAMP), CAST(1 AS INT)), SUBSTR(CAST(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__2477057371__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('dayofyear', 1, DATETIME(null))",expression,,None,None,321.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS TIMESTAMP), CAST(1 AS INT)), SUBSTR(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__3817976182__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('day', 1, DATE(null))",expression,,None,None,309.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS TIMESTAMP), CAST(1 AS INT)), SUBSTR(CAST(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__2329360898__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('day', 1, DATETIME(null))",expression,,None,None,296.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS TIMESTAMP), CAST(1 AS INT)), SUBSTR(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__1469842605__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('hour', 1, DATETIME(null))",expression,,None,None,324.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(CAST(CAST(NULL AS INT) AS TIMESTAMP)) + 1*3600) AS TIMESTAMP) AS `temp_test__4189387493__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('minute', 1, DATETIME(null))",expression,,None,None,324.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(CAST(CAST(NULL AS INT) AS TIMESTAMP)) + 1*60) AS TIMESTAMP) AS `temp_test__3720439076__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.nulls.txt,True,0,0,"DATEADD('second', 1, DATETIME(null))",expression,,None,None,290.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(CAST(CAST(NULL AS INT) AS TIMESTAMP)) + 1) AS TIMESTAMP) AS `temp_test__2985757783__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.quarter.txt,True,0,0,"DATEADD('quarter', 1, [date2])",expression,,None,None,339.0,"
+      SELECT CAST(CONCAT(ADD_MONTHS(`calcs`.`date2`,(1 * 3)),SUBSTR(CAST(`calcs`.`date2` AS TIMESTAMP),11)) AS TIMESTAMP) AS `temp_test__893348878__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-10-12 00:00:00#
+#1974-06-17 00:00:00#
+#1974-08-03 00:00:00#
+#1976-12-09 00:00:00#
+#1977-05-08 00:00:00#
+#1977-07-20 00:00:00#
+#1980-10-26 00:00:00#
+#1981-02-07 00:00:00#
+#1988-04-05 00:00:00#
+#1994-07-20 00:00:00#
+#1995-09-04 00:00:00#
+#1995-12-03 00:00:00#
+#1997-08-30 00:00:00#
+#1997-12-19 00:00:00#
+#1998-11-12 00:00:00#
+#2001-05-04 00:00:00#
+#2002-07-27 00:00:00#","#1972-10-12 00:00:00#
+#1974-06-17 00:00:00#
+#1974-08-03 00:00:00#
+#1976-12-09 00:00:00#
+#1977-05-08 00:00:00#
+#1977-07-20 00:00:00#
+#1980-10-26 00:00:00#
+#1981-02-07 00:00:00#
+#1988-04-05 00:00:00#
+#1994-07-20 00:00:00#
+#1995-09-04 00:00:00#
+#1995-12-03 00:00:00#
+#1997-08-30 00:00:00#
+#1997-12-19 00:00:00#
+#1998-11-12 00:00:00#
+#2001-05-04 00:00:00#
+#2002-07-27 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.quarter.txt,True,0,0,"DATEADD('quarter', 1, [datetime0])",expression,,None,None,350.0,"
+      SELECT CAST(CONCAT(ADD_MONTHS(`calcs`.`datetime0`,(1 * 3)),SUBSTR(CAST(`calcs`.`datetime0` AS TIMESTAMP),11)) AS TIMESTAMP) AS `temp_test__454013980__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-10-04 22:49:28#
+#2004-10-05 13:14:20#
+#2004-10-09 10:17:35#
+#2004-10-12 17:30:16#
+#2004-10-14 07:43:00#
+#2004-10-14 08:16:44#
+#2004-10-17 14:01:56#
+#2004-10-19 22:21:31#
+#2004-10-22 00:30:23#
+#2004-10-23 21:13:37#
+#2004-10-25 15:22:26#
+#2004-10-26 12:30:34#
+#2004-10-28 06:54:50#
+#2004-10-28 12:34:28#
+#2004-10-28 23:30:22#
+#2004-10-31 11:57:52#
+#2004-11-02 07:59:23#","#2004-10-04 22:49:28#
+#2004-10-05 13:14:20#
+#2004-10-09 10:17:35#
+#2004-10-12 17:30:16#
+#2004-10-14 07:43:00#
+#2004-10-14 08:16:44#
+#2004-10-17 14:01:56#
+#2004-10-19 22:21:31#
+#2004-10-22 00:30:23#
+#2004-10-23 21:13:37#
+#2004-10-25 15:22:26#
+#2004-10-26 12:30:34#
+#2004-10-28 06:54:50#
+#2004-10-28 12:34:28#
+#2004-10-28 23:30:22#
+#2004-10-31 11:57:52#
+#2004-11-02 07:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.second,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.second.txt,True,0,0,"DATEADD('second', 1, [datetime0])",expression,,None,None,344.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(`calcs`.`datetime0`) + 1) AS TIMESTAMP) AS `temp_test__621896091__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 22:49:29#
+#2004-07-05 13:14:21#
+#2004-07-09 10:17:36#
+#2004-07-12 17:30:17#
+#2004-07-14 07:43:01#
+#2004-07-14 08:16:45#
+#2004-07-17 14:01:57#
+#2004-07-19 22:21:32#
+#2004-07-22 00:30:24#
+#2004-07-23 21:13:38#
+#2004-07-25 15:22:27#
+#2004-07-26 12:30:35#
+#2004-07-28 06:54:51#
+#2004-07-28 12:34:29#
+#2004-07-28 23:30:23#
+#2004-07-31 11:57:53#
+#2004-08-02 07:59:24#","#2004-07-04 22:49:29#
+#2004-07-05 13:14:21#
+#2004-07-09 10:17:36#
+#2004-07-12 17:30:17#
+#2004-07-14 07:43:01#
+#2004-07-14 08:16:45#
+#2004-07-17 14:01:57#
+#2004-07-19 22:21:32#
+#2004-07-22 00:30:24#
+#2004-07-23 21:13:38#
+#2004-07-25 15:22:27#
+#2004-07-26 12:30:35#
+#2004-07-28 06:54:51#
+#2004-07-28 12:34:29#
+#2004-07-28 23:30:23#
+#2004-07-31 11:57:53#
+#2004-08-02 07:59:24#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.week.txt,True,0,0,"DATEADD('week', 1, [date2])",expression,,None,None,368.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(`calcs`.`date2` AS TIMESTAMP), CAST(7 * 1 AS INT)), SUBSTR(CAST(CAST(`calcs`.`date2` AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__2748179160__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-19 00:00:00#
+#1974-03-24 00:00:00#
+#1974-05-10 00:00:00#
+#1976-09-16 00:00:00#
+#1977-02-15 00:00:00#
+#1977-04-27 00:00:00#
+#1980-08-02 00:00:00#
+#1980-11-14 00:00:00#
+#1988-01-12 00:00:00#
+#1994-04-27 00:00:00#
+#1995-06-11 00:00:00#
+#1995-09-10 00:00:00#
+#1997-06-06 00:00:00#
+#1997-09-26 00:00:00#
+#1998-08-19 00:00:00#
+#2001-02-11 00:00:00#
+#2002-05-04 00:00:00#","#1972-07-19 00:00:00#
+#1974-03-24 00:00:00#
+#1974-05-10 00:00:00#
+#1976-09-16 00:00:00#
+#1977-02-15 00:00:00#
+#1977-04-27 00:00:00#
+#1980-08-02 00:00:00#
+#1980-11-14 00:00:00#
+#1988-01-12 00:00:00#
+#1994-04-27 00:00:00#
+#1995-06-11 00:00:00#
+#1995-09-10 00:00:00#
+#1997-06-06 00:00:00#
+#1997-09-26 00:00:00#
+#1998-08-19 00:00:00#
+#2001-02-11 00:00:00#
+#2002-05-04 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.week.txt,True,0,0,"DATEADD('week', 1, [datetime0])",expression,,None,None,349.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(`calcs`.`datetime0` AS TIMESTAMP), CAST(7 * 1 AS INT)), SUBSTR(CAST(CAST(`calcs`.`datetime0` AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__3880453047__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-11 22:49:28#
+#2004-07-12 13:14:20#
+#2004-07-16 10:17:35#
+#2004-07-19 17:30:16#
+#2004-07-21 07:43:00#
+#2004-07-21 08:16:44#
+#2004-07-24 14:01:56#
+#2004-07-26 22:21:31#
+#2004-07-29 00:30:23#
+#2004-07-30 21:13:37#
+#2004-08-01 15:22:26#
+#2004-08-02 12:30:34#
+#2004-08-04 06:54:50#
+#2004-08-04 12:34:28#
+#2004-08-04 23:30:22#
+#2004-08-07 11:57:52#
+#2004-08-09 07:59:23#","#2004-07-11 22:49:28#
+#2004-07-12 13:14:20#
+#2004-07-16 10:17:35#
+#2004-07-19 17:30:16#
+#2004-07-21 07:43:00#
+#2004-07-21 08:16:44#
+#2004-07-24 14:01:56#
+#2004-07-26 22:21:31#
+#2004-07-29 00:30:23#
+#2004-07-30 21:13:37#
+#2004-08-01 15:22:26#
+#2004-08-02 12:30:34#
+#2004-08-04 06:54:50#
+#2004-08-04 12:34:28#
+#2004-08-04 23:30:22#
+#2004-08-07 11:57:52#
+#2004-08-09 07:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.weekday.txt,True,0,0,"DATEADD('weekday', 1, [date2])",expression,,None,None,326.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(`calcs`.`date2` AS TIMESTAMP), CAST(1 AS INT)), SUBSTR(CAST(CAST(`calcs`.`date2` AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__1743407296__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-13 00:00:00#
+#1974-03-18 00:00:00#
+#1974-05-04 00:00:00#
+#1976-09-10 00:00:00#
+#1977-02-09 00:00:00#
+#1977-04-21 00:00:00#
+#1980-07-27 00:00:00#
+#1980-11-08 00:00:00#
+#1988-01-06 00:00:00#
+#1994-04-21 00:00:00#
+#1995-06-05 00:00:00#
+#1995-09-04 00:00:00#
+#1997-05-31 00:00:00#
+#1997-09-20 00:00:00#
+#1998-08-13 00:00:00#
+#2001-02-05 00:00:00#
+#2002-04-28 00:00:00#","#1972-07-13 00:00:00#
+#1974-03-18 00:00:00#
+#1974-05-04 00:00:00#
+#1976-09-10 00:00:00#
+#1977-02-09 00:00:00#
+#1977-04-21 00:00:00#
+#1980-07-27 00:00:00#
+#1980-11-08 00:00:00#
+#1988-01-06 00:00:00#
+#1994-04-21 00:00:00#
+#1995-06-05 00:00:00#
+#1995-09-04 00:00:00#
+#1997-05-31 00:00:00#
+#1997-09-20 00:00:00#
+#1998-08-13 00:00:00#
+#2001-02-05 00:00:00#
+#2002-04-28 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.weekday.txt,True,0,0,"DATEADD('weekday', 1, [datetime0])",expression,,None,None,348.0,"
+      SELECT CAST(CONCAT(DATE_ADD(CAST(`calcs`.`datetime0` AS TIMESTAMP), CAST(1 AS INT)), SUBSTR(CAST(CAST(`calcs`.`datetime0` AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__2988076353__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-05 22:49:28#
+#2004-07-06 13:14:20#
+#2004-07-10 10:17:35#
+#2004-07-13 17:30:16#
+#2004-07-15 07:43:00#
+#2004-07-15 08:16:44#
+#2004-07-18 14:01:56#
+#2004-07-20 22:21:31#
+#2004-07-23 00:30:23#
+#2004-07-24 21:13:37#
+#2004-07-26 15:22:26#
+#2004-07-27 12:30:34#
+#2004-07-29 06:54:50#
+#2004-07-29 12:34:28#
+#2004-07-29 23:30:22#
+#2004-08-01 11:57:52#
+#2004-08-03 07:59:23#","#2004-07-05 22:49:28#
+#2004-07-06 13:14:20#
+#2004-07-10 10:17:35#
+#2004-07-13 17:30:16#
+#2004-07-15 07:43:00#
+#2004-07-15 08:16:44#
+#2004-07-18 14:01:56#
+#2004-07-20 22:21:31#
+#2004-07-23 00:30:23#
+#2004-07-24 21:13:37#
+#2004-07-26 15:22:26#
+#2004-07-27 12:30:34#
+#2004-07-29 06:54:50#
+#2004-07-29 12:34:28#
+#2004-07-29 23:30:22#
+#2004-08-01 11:57:52#
+#2004-08-03 07:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.year.txt,True,0,0,"DATEADD('year', 1, [date2])",expression,,None,None,336.0,"
+      SELECT CAST(CONCAT(YEAR(`calcs`.`date2`)+1, SUBSTR(CAST(`calcs`.`date2` AS TIMESTAMP), 5)) AS TIMESTAMP) AS `temp_test__858668231__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1973-07-12 00:00:00#
+#1975-03-17 00:00:00#
+#1975-05-03 00:00:00#
+#1977-09-09 00:00:00#
+#1978-02-08 00:00:00#
+#1978-04-20 00:00:00#
+#1981-07-26 00:00:00#
+#1981-11-07 00:00:00#
+#1989-01-05 00:00:00#
+#1995-04-20 00:00:00#
+#1996-06-04 00:00:00#
+#1996-09-03 00:00:00#
+#1998-05-30 00:00:00#
+#1998-09-19 00:00:00#
+#1999-08-12 00:00:00#
+#2002-02-04 00:00:00#
+#2003-04-27 00:00:00#","#1973-07-12 00:00:00#
+#1975-03-17 00:00:00#
+#1975-05-03 00:00:00#
+#1977-09-09 00:00:00#
+#1978-02-08 00:00:00#
+#1978-04-20 00:00:00#
+#1981-07-26 00:00:00#
+#1981-11-07 00:00:00#
+#1989-01-05 00:00:00#
+#1995-04-20 00:00:00#
+#1996-06-04 00:00:00#
+#1996-09-03 00:00:00#
+#1998-05-30 00:00:00#
+#1998-09-19 00:00:00#
+#1999-08-12 00:00:00#
+#2002-02-04 00:00:00#
+#2003-04-27 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.dateadd.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.dateadd.year.txt,True,0,0,"DATEADD('year', 1, [datetime0])",expression,,None,None,338.0,"
+      SELECT CAST(CONCAT(YEAR(`calcs`.`datetime0`)+1, SUBSTR(CAST(`calcs`.`datetime0` AS TIMESTAMP), 5)) AS TIMESTAMP) AS `temp_test__1314023193__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2005-07-04 22:49:28#
+#2005-07-05 13:14:20#
+#2005-07-09 10:17:35#
+#2005-07-12 17:30:16#
+#2005-07-14 07:43:00#
+#2005-07-14 08:16:44#
+#2005-07-17 14:01:56#
+#2005-07-19 22:21:31#
+#2005-07-22 00:30:23#
+#2005-07-23 21:13:37#
+#2005-07-25 15:22:26#
+#2005-07-26 12:30:34#
+#2005-07-28 06:54:50#
+#2005-07-28 12:34:28#
+#2005-07-28 23:30:22#
+#2005-07-31 11:57:52#
+#2005-08-02 07:59:23#","#2005-07-04 22:49:28#
+#2005-07-05 13:14:20#
+#2005-07-09 10:17:35#
+#2005-07-12 17:30:16#
+#2005-07-14 07:43:00#
+#2005-07-14 08:16:44#
+#2005-07-17 14:01:56#
+#2005-07-19 22:21:31#
+#2005-07-22 00:30:23#
+#2005-07-23 21:13:37#
+#2005-07-25 15:22:26#
+#2005-07-26 12:30:34#
+#2005-07-28 06:54:50#
+#2005-07-28 12:34:28#
+#2005-07-28 23:30:22#
+#2005-07-31 11:57:52#
+#2005-08-02 07:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.day.txt,True,0,0,"DATEDIFF('day', [date3], [date2])",expression,,None,None,314.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`date2`), TO_DATE(`calcs`.`date3`)) AS `temp_test__885008067__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.day.txt,True,0,0,"DATEDIFF('day', DATETIME([date2]), [datetime0])",expression,,None,None,330.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) AS `temp_test__3554344781__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.dayofyear.txt,True,0,0,"DATEDIFF('dayofyear', [date3], [date2])",expression,,None,None,301.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`date2`), TO_DATE(`calcs`.`date3`)) AS `temp_test__2016952657__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.dayofyear.txt,True,0,0,"DATEDIFF('dayofyear', DATETIME([date2]), [datetime0])",expression,,None,None,299.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) AS `temp_test__1256216982__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.hour,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.hour.txt,True,0,0,"DATEDIFF('hour', DATETIME([date2]), [datetime0])",expression,,None,None,415.0,"
+      SELECT CAST((DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) * 24 + COALESCE(CAST(SUBSTR(`calcs`.`datetime0`,12,2) AS INT), 0) - COALESCE(CAST(SUBSTR(CAST(`calcs`.`date2` AS TIMESTAMP),12,2) AS INT), 0)) AS BIGINT) AS `temp_test__289918985__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","19764
+30230
+52149
+60223
+62807
+77988
+79879
+89991
+144982
+207792
+209893
+238618
+240774
+243862
+264689
+265856
+280979","19764
+30230
+52149
+60223
+62807
+77988
+79879
+89991
+144982
+207792
+209893
+238618
+240774
+243862
+264689
+265856
+280979"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.minute,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.minute.txt,True,0,0,"DATEDIFF('minute', DATETIME([date2]), [datetime0])",expression,,None,None,376.0,"
+      SELECT CAST(((DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) * 24 + COALESCE(CAST(SUBSTR(`calcs`.`datetime0`,12,2) AS INT), 0) - COALESCE(CAST(SUBSTR(CAST(`calcs`.`date2` AS TIMESTAMP),12,2) AS INT), 0)) * 60 + COALESCE(MINUTE(`calcs`.`datetime0`), 0) - COALESCE(MINUTE(CAST(`calcs`.`date2` AS TIMESTAMP)), 0)) AS BIGINT) AS `temp_test__2180476504__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1185874
+1813801
+3128953
+3613439
+3768450
+4679310
+4792783
+5399482
+8698941
+12467550
+12593594
+14317097
+14446494
+14631769
+15881370
+15951376
+16858797","1185874
+1813801
+3128953
+3613439
+3768450
+4679310
+4792783
+5399482
+8698941
+12467550
+12593594
+14317097
+14446494
+14631769
+15881370
+15951376
+16858797"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.month.txt,True,0,0,"DATEDIFF('month', [date3], [date2])",expression,,None,None,356.0,"
+      SELECT CAST((12 * YEAR(`calcs`.`date2`) + MONTH(`calcs`.`date2`)) - (12 * YEAR(`calcs`.`date3`) + MONTH(`calcs`.`date3`)) AS BIGINT) AS `temp_test__381839689__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-305
+-172
+-107
+-100
+-80
+7
+14
+19
+123","%null%
+-305
+-172
+-107
+-100
+-80
+7
+14
+19
+123"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.month.txt,True,0,0,"DATEDIFF('month', DATETIME([date2]), [datetime0])",expression,,None,None,368.0,"
+      SELECT CAST((12 * YEAR(`calcs`.`datetime0`) + MONTH(`calcs`.`datetime0`)) - (12 * YEAR(CAST(`calcs`.`date2` AS TIMESTAMP)) + MONTH(CAST(`calcs`.`date2` AS TIMESTAMP))) AS BIGINT) AS `temp_test__2416406882__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","27
+41
+71
+83
+86
+106
+109
+123
+198
+284
+288
+327
+329
+334
+362
+364
+384","27
+41
+71
+83
+86
+106
+109
+123
+198
+284
+288
+327
+329
+334
+362
+364
+384"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('year',  DATE(null), DATE(null))",expression,,None,None,308.0,"
+      SELECT CAST(YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) - YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS BIGINT) AS `temp_test__1128710711__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('year', DATETIME(null), DATETIME(null))",expression,,None,None,312.0,"
+      SELECT CAST(YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) - YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS BIGINT) AS `temp_test__3816818712__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('quarter', DATE(null), DATE(null))",expression,,None,None,323.0,"
+      SELECT CAST((4 * YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) + CAST((MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) - 1) / 3 + 1 AS BIGINT)) - (4 * YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) + CAST((MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) - 1) / 3 + 1 AS BIGINT)) AS BIGINT) AS `temp_test__1220694026__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('quarter', DATETIME(null), DATETIME(null))",expression,,None,None,310.0,"
+      SELECT CAST((4 * YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) + CAST((MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP)) - 1) / 3 + 1 AS BIGINT)) - (4 * YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) + CAST((MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP)) - 1) / 3 + 1 AS BIGINT)) AS BIGINT) AS `temp_test__1878304808__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('month', DATE(null), DATE(null))",expression,,None,None,299.0,"
+      SELECT CAST((12 * YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) + MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))) - (12 * YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) + MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))) AS BIGINT) AS `temp_test__3201398499__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('month', DATETIME(null), DATETIME(null))",expression,,None,None,301.0,"
+      SELECT CAST((12 * YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) + MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP))) - (12 * YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) + MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP))) AS BIGINT) AS `temp_test__2380792894__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('week', DATE(null), DATE(null))",expression,,None,None,304.0,"
+      SELECT FLOOR(DATEDIFF(NEXT_DAY(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'SU'),NEXT_DAY(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'SU'))/7) AS `temp_test__1799303116__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('week', DATETIME(null), DATETIME(null))",expression,,None,None,294.0,"
+      SELECT FLOOR(DATEDIFF(NEXT_DAY(CAST(CAST(NULL AS INT) AS TIMESTAMP),'SU'),NEXT_DAY(CAST(CAST(NULL AS INT) AS TIMESTAMP),'SU'))/7) AS `temp_test__3424623419__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('weekday', DATE(null), DATE(null))",expression,,None,None,334.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)), TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))) AS `temp_test__496128354__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('weekday', DATETIME(null), DATETIME(null))",expression,,None,None,400.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP))) AS `temp_test__260207547__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('day', DATE(null), DATE(null))",expression,,None,None,312.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)), TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))) AS `temp_test__4282303505__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('day', DATETIME(null), DATETIME(null))",expression,,None,None,302.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP))) AS `temp_test__2339877044__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('dayofyear', DATE(null), DATE(null))",expression,,None,None,291.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)), TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))) AS `temp_test__3465754358__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('dayofyear', DATETIME(null), DATETIME(null))",expression,,None,None,289.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP))) AS `temp_test__2205674587__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('hour', DATETIME(null), DATETIME(null))",expression,,None,None,374.0,"
+      SELECT CAST((DATEDIFF(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP))) * 24 + COALESCE(CAST(SUBSTR(CAST(CAST(NULL AS INT) AS TIMESTAMP),12,2) AS INT), 0) - COALESCE(CAST(SUBSTR(CAST(CAST(NULL AS INT) AS TIMESTAMP),12,2) AS INT), 0)) AS BIGINT) AS `temp_test__4062119106__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('minute', DATETIME(null), DATETIME(null))",expression,,None,None,303.0,"
+      SELECT CAST(((DATEDIFF(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP))) * 24 + COALESCE(CAST(SUBSTR(CAST(CAST(NULL AS INT) AS TIMESTAMP),12,2) AS INT), 0) - COALESCE(CAST(SUBSTR(CAST(CAST(NULL AS INT) AS TIMESTAMP),12,2) AS INT), 0)) * 60 + COALESCE(MINUTE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 0) - COALESCE(MINUTE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 0)) AS BIGINT) AS `temp_test__2509274079__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.nulls.txt,True,0,0,"DATEDIFF('second', DATETIME(null), DATETIME(null))",expression,,None,None,311.0,"
+      SELECT CAST((((DATEDIFF(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP))) * 24 + COALESCE(CAST(SUBSTR(CAST(CAST(NULL AS INT) AS TIMESTAMP),12,2) AS INT), 0) - COALESCE(CAST(SUBSTR(CAST(CAST(NULL AS INT) AS TIMESTAMP),12,2) AS INT), 0)) * 60 + COALESCE(MINUTE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 0) - COALESCE(MINUTE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 0)) * 60 + COALESCE(SECOND(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 0) - COALESCE(SECOND(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 0)) AS BIGINT) AS `temp_test__508245917__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.quarter.txt,True,0,0,"DATEDIFF('quarter', [date3], [date2])",expression,,None,None,378.0,"
+      SELECT CAST((4 * YEAR(`calcs`.`date2`) + CAST((MONTH(`calcs`.`date2`) - 1) / 3 + 1 AS BIGINT)) - (4 * YEAR(`calcs`.`date3`) + CAST((MONTH(`calcs`.`date3`) - 1) / 3 + 1 AS BIGINT)) AS BIGINT) AS `temp_test__4144088821__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-102
+-57
+-35
+-33
+-27
+2
+5
+6
+41","%null%
+-102
+-57
+-35
+-33
+-27
+2
+5
+6
+41"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.quarter.txt,True,0,0,"DATEDIFF('quarter', DATETIME([date2]), [datetime0])",expression,,None,None,354.0,"
+      SELECT CAST((4 * YEAR(`calcs`.`datetime0`) + CAST((MONTH(`calcs`.`datetime0`) - 1) / 3 + 1 AS BIGINT)) - (4 * YEAR(CAST(`calcs`.`date2` AS TIMESTAMP)) + CAST((MONTH(CAST(`calcs`.`date2` AS TIMESTAMP)) - 1) / 3 + 1 AS BIGINT)) AS BIGINT) AS `temp_test__2035564840__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","9
+14
+24
+28
+29
+36
+37
+41
+66
+95
+96
+109
+110
+112
+121
+122
+128","9
+14
+24
+28
+29
+36
+37
+41
+66
+95
+96
+109
+110
+112
+121
+122
+128"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.second,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.second.txt,True,0,0,"DATEDIFF('second', DATETIME([date2]), [datetime0])",expression,,None,None,372.0,"
+      SELECT CAST((((DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) * 24 + COALESCE(CAST(SUBSTR(`calcs`.`datetime0`,12,2) AS INT), 0) - COALESCE(CAST(SUBSTR(CAST(`calcs`.`date2` AS TIMESTAMP),12,2) AS INT), 0)) * 60 + COALESCE(MINUTE(`calcs`.`datetime0`), 0) - COALESCE(MINUTE(CAST(`calcs`.`date2` AS TIMESTAMP)), 0)) * 60 + COALESCE(SECOND(`calcs`.`datetime0`), 0) - COALESCE(SECOND(CAST(`calcs`.`date2` AS TIMESTAMP)), 0)) AS BIGINT) AS `temp_test__3711433751__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","71152468
+108828116
+187737217
+216806363
+226107022
+280758634
+287566980
+323968946
+521936491
+748053023
+755615660
+859025855
+866789690
+877906168
+952882216
+957082604
+1011527872","71152468
+108828116
+187737217
+216806363
+226107022
+280758634
+287566980
+323968946
+521936491
+748053023
+755615660
+859025855
+866789690
+877906168
+952882216
+957082604
+1011527872"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.day.txt,True,0,0,"DATEDIFF('day', [date3], [date2], 'monday')",expression,,None,None,331.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`date2`), TO_DATE(`calcs`.`date3`)) AS `temp_test__838791689__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.day.txt,True,0,0,"DATEDIFF('day', [date3], [date2], 'sunday')",expression,,None,None,327.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`date2`), TO_DATE(`calcs`.`date3`)) AS `temp_test__1647283678__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.day.txt,True,0,0,"DATEDIFF('day', DATETIME([date2]), [datetime0], 'monday')",expression,,None,None,313.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) AS `temp_test__1719292105__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.day.txt,True,0,0,"DATEDIFF('day', DATETIME([date2]), [datetime0], 'sunday')",expression,,None,None,315.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) AS `temp_test__1567002572__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.dayofyear.txt,True,0,0,"DATEDIFF('dayofyear', [date3], [date2], 'monday')",expression,,None,None,311.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`date2`), TO_DATE(`calcs`.`date3`)) AS `temp_test__1590117682__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.dayofyear.txt,True,0,0,"DATEDIFF('dayofyear', [date3], [date2], 'sunday')",expression,,None,None,297.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`date2`), TO_DATE(`calcs`.`date3`)) AS `temp_test__4199707040__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.dayofyear.txt,True,0,0,"DATEDIFF('dayofyear', DATETIME([date2]), [datetime0], 'monday')",expression,,None,None,326.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) AS `temp_test__2589771434__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.dayofyear.txt,True,0,0,"DATEDIFF('dayofyear', DATETIME([date2]), [datetime0], 'sunday')",expression,,None,None,304.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) AS `temp_test__1875124737__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.hour,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.hour.txt,True,0,0,"DATEDIFF('hour', DATETIME([date2]), [datetime0], 'monday')",expression,,None,None,374.0,"
+      SELECT CAST((DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) * 24 + COALESCE(CAST(SUBSTR(`calcs`.`datetime0`,12,2) AS INT), 0) - COALESCE(CAST(SUBSTR(CAST(`calcs`.`date2` AS TIMESTAMP),12,2) AS INT), 0)) AS BIGINT) AS `temp_test__1898404202__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","19764
+30230
+52149
+60223
+62807
+77988
+79879
+89991
+144982
+207792
+209893
+238618
+240774
+243862
+264689
+265856
+280979","19764
+30230
+52149
+60223
+62807
+77988
+79879
+89991
+144982
+207792
+209893
+238618
+240774
+243862
+264689
+265856
+280979"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.hour,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.hour.txt,True,0,0,"DATEDIFF('hour', DATETIME([date2]), [datetime0], 'sunday')",expression,,None,None,348.0,"
+      SELECT CAST((DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) * 24 + COALESCE(CAST(SUBSTR(`calcs`.`datetime0`,12,2) AS INT), 0) - COALESCE(CAST(SUBSTR(CAST(`calcs`.`date2` AS TIMESTAMP),12,2) AS INT), 0)) AS BIGINT) AS `temp_test__4263325709__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","19764
+30230
+52149
+60223
+62807
+77988
+79879
+89991
+144982
+207792
+209893
+238618
+240774
+243862
+264689
+265856
+280979","19764
+30230
+52149
+60223
+62807
+77988
+79879
+89991
+144982
+207792
+209893
+238618
+240774
+243862
+264689
+265856
+280979"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.minute,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.minute.txt,True,0,0,"DATEDIFF('minute', DATETIME([date2]), [datetime0], 'monday')",expression,,None,None,369.0,"
+      SELECT CAST(((DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) * 24 + COALESCE(CAST(SUBSTR(`calcs`.`datetime0`,12,2) AS INT), 0) - COALESCE(CAST(SUBSTR(CAST(`calcs`.`date2` AS TIMESTAMP),12,2) AS INT), 0)) * 60 + COALESCE(MINUTE(`calcs`.`datetime0`), 0) - COALESCE(MINUTE(CAST(`calcs`.`date2` AS TIMESTAMP)), 0)) AS BIGINT) AS `temp_test__2300448284__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1185874
+1813801
+3128953
+3613439
+3768450
+4679310
+4792783
+5399482
+8698941
+12467550
+12593594
+14317097
+14446494
+14631769
+15881370
+15951376
+16858797","1185874
+1813801
+3128953
+3613439
+3768450
+4679310
+4792783
+5399482
+8698941
+12467550
+12593594
+14317097
+14446494
+14631769
+15881370
+15951376
+16858797"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.minute,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.minute.txt,True,0,0,"DATEDIFF('minute', DATETIME([date2]), [datetime0], 'sunday')",expression,,None,None,339.0,"
+      SELECT CAST(((DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) * 24 + COALESCE(CAST(SUBSTR(`calcs`.`datetime0`,12,2) AS INT), 0) - COALESCE(CAST(SUBSTR(CAST(`calcs`.`date2` AS TIMESTAMP),12,2) AS INT), 0)) * 60 + COALESCE(MINUTE(`calcs`.`datetime0`), 0) - COALESCE(MINUTE(CAST(`calcs`.`date2` AS TIMESTAMP)), 0)) AS BIGINT) AS `temp_test__2077207759__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1185874
+1813801
+3128953
+3613439
+3768450
+4679310
+4792783
+5399482
+8698941
+12467550
+12593594
+14317097
+14446494
+14631769
+15881370
+15951376
+16858797","1185874
+1813801
+3128953
+3613439
+3768450
+4679310
+4792783
+5399482
+8698941
+12467550
+12593594
+14317097
+14446494
+14631769
+15881370
+15951376
+16858797"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.month.txt,True,0,0,"DATEDIFF('month', [date3], [date2], 'monday')",expression,,None,None,336.0,"
+      SELECT CAST((12 * YEAR(`calcs`.`date2`) + MONTH(`calcs`.`date2`)) - (12 * YEAR(`calcs`.`date3`) + MONTH(`calcs`.`date3`)) AS BIGINT) AS `temp_test__2958462977__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-305
+-172
+-107
+-100
+-80
+7
+14
+19
+123","%null%
+-305
+-172
+-107
+-100
+-80
+7
+14
+19
+123"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.month.txt,True,0,0,"DATEDIFF('month', [date3], [date2], 'sunday')",expression,,None,None,319.0,"
+      SELECT CAST((12 * YEAR(`calcs`.`date2`) + MONTH(`calcs`.`date2`)) - (12 * YEAR(`calcs`.`date3`) + MONTH(`calcs`.`date3`)) AS BIGINT) AS `temp_test__667124691__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-305
+-172
+-107
+-100
+-80
+7
+14
+19
+123","%null%
+-305
+-172
+-107
+-100
+-80
+7
+14
+19
+123"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.month.txt,True,0,0,"DATEDIFF('month', DATETIME([date2]), [datetime0], 'monday')",expression,,None,None,331.0,"
+      SELECT CAST((12 * YEAR(`calcs`.`datetime0`) + MONTH(`calcs`.`datetime0`)) - (12 * YEAR(CAST(`calcs`.`date2` AS TIMESTAMP)) + MONTH(CAST(`calcs`.`date2` AS TIMESTAMP))) AS BIGINT) AS `temp_test__2463700949__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","27
+41
+71
+83
+86
+106
+109
+123
+198
+284
+288
+327
+329
+334
+362
+364
+384","27
+41
+71
+83
+86
+106
+109
+123
+198
+284
+288
+327
+329
+334
+362
+364
+384"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.month.txt,True,0,0,"DATEDIFF('month', DATETIME([date2]), [datetime0], 'sunday')",expression,,None,None,335.0,"
+      SELECT CAST((12 * YEAR(`calcs`.`datetime0`) + MONTH(`calcs`.`datetime0`)) - (12 * YEAR(CAST(`calcs`.`date2` AS TIMESTAMP)) + MONTH(CAST(`calcs`.`date2` AS TIMESTAMP))) AS BIGINT) AS `temp_test__3778274693__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","27
+41
+71
+83
+86
+106
+109
+123
+198
+284
+288
+327
+329
+334
+362
+364
+384","27
+41
+71
+83
+86
+106
+109
+123
+198
+284
+288
+327
+329
+334
+362
+364
+384"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('year',  DATE(null), DATE(null), 'sunday')",expression,,None,None,300.0,"
+      SELECT CAST(YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) - YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS BIGINT) AS `temp_test__523796786__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('year', DATETIME(null), DATETIME(null), 'sunday')",expression,,None,None,295.0,"
+      SELECT CAST(YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) - YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS BIGINT) AS `temp_test__1757347367__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('quarter', DATE(null), DATE(null), 'sunday')",expression,,None,None,297.0,"
+      SELECT CAST((4 * YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) + CAST((MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) - 1) / 3 + 1 AS BIGINT)) - (4 * YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) + CAST((MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) - 1) / 3 + 1 AS BIGINT)) AS BIGINT) AS `temp_test__2892653053__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('quarter', DATETIME(null), DATETIME(null), 'sunday')",expression,,None,None,326.0,"
+      SELECT CAST((4 * YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) + CAST((MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP)) - 1) / 3 + 1 AS BIGINT)) - (4 * YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) + CAST((MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP)) - 1) / 3 + 1 AS BIGINT)) AS BIGINT) AS `temp_test__208306356__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('month', DATETIME(null), DATETIME(null), 'sunday')",expression,,None,None,303.0,"
+      SELECT CAST((12 * YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) + MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP))) - (12 * YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) + MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP))) AS BIGINT) AS `temp_test__3602652935__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('month', DATE(null), DATE(null), 'sunday')",expression,,None,None,300.0,"
+      SELECT CAST((12 * YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) + MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))) - (12 * YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) + MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))) AS BIGINT) AS `temp_test__2736821__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('week', DATE(null), DATE(null), 'sunday')",expression,,None,None,315.0,"
+      SELECT FLOOR(DATEDIFF(NEXT_DAY(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'SU'),NEXT_DAY(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'SU'))/7) AS `temp_test__4175150207__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('week', DATETIME(null), DATETIME(null), 'sunday')",expression,,None,None,304.0,"
+      SELECT FLOOR(DATEDIFF(NEXT_DAY(CAST(CAST(NULL AS INT) AS TIMESTAMP),'SU'),NEXT_DAY(CAST(CAST(NULL AS INT) AS TIMESTAMP),'SU'))/7) AS `temp_test__573134401__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('weekday', DATE(null), DATE(null), 'sunday')",expression,,None,None,316.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)), TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))) AS `temp_test__4284829593__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('weekday', DATETIME(null), DATETIME(null), 'sunday')",expression,,None,None,350.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP))) AS `temp_test__2962792486__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('day', DATETIME(null), DATETIME(null), 'sunday')",expression,,None,None,294.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP))) AS `temp_test__2631483492__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('day', DATE(null), DATE(null), 'sunday')",expression,,None,None,304.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)), TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))) AS `temp_test__1607049625__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('dayofyear', DATETIME(null), DATETIME(null), 'sunday')",expression,,None,None,385.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP))) AS `temp_test__1299959868__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('dayofyear', DATE(null), DATE(null), 'sunday')",expression,,None,None,317.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)), TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))) AS `temp_test__1641185958__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('hour', DATETIME(null), DATETIME(null), 'sunday')",expression,,None,None,307.0,"
+      SELECT CAST((DATEDIFF(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP))) * 24 + COALESCE(CAST(SUBSTR(CAST(CAST(NULL AS INT) AS TIMESTAMP),12,2) AS INT), 0) - COALESCE(CAST(SUBSTR(CAST(CAST(NULL AS INT) AS TIMESTAMP),12,2) AS INT), 0)) AS BIGINT) AS `temp_test__1258940435__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('minute', DATETIME(null), DATETIME(null), 'sunday')",expression,,None,None,314.0,"
+      SELECT CAST(((DATEDIFF(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP))) * 24 + COALESCE(CAST(SUBSTR(CAST(CAST(NULL AS INT) AS TIMESTAMP),12,2) AS INT), 0) - COALESCE(CAST(SUBSTR(CAST(CAST(NULL AS INT) AS TIMESTAMP),12,2) AS INT), 0)) * 60 + COALESCE(MINUTE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 0) - COALESCE(MINUTE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 0)) AS BIGINT) AS `temp_test__401058515__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.nulls.txt,True,0,0,"DATEDIFF('second', DATETIME(null), DATETIME(null), 'sunday')",expression,,None,None,309.0,"
+      SELECT CAST((((DATEDIFF(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP))) * 24 + COALESCE(CAST(SUBSTR(CAST(CAST(NULL AS INT) AS TIMESTAMP),12,2) AS INT), 0) - COALESCE(CAST(SUBSTR(CAST(CAST(NULL AS INT) AS TIMESTAMP),12,2) AS INT), 0)) * 60 + COALESCE(MINUTE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 0) - COALESCE(MINUTE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 0)) * 60 + COALESCE(SECOND(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 0) - COALESCE(SECOND(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 0)) AS BIGINT) AS `temp_test__2833809390__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.quarter.txt,True,0,0,"DATEDIFF('quarter', [date3], [date2], 'monday')",expression,,None,None,361.0,"
+      SELECT CAST((4 * YEAR(`calcs`.`date2`) + CAST((MONTH(`calcs`.`date2`) - 1) / 3 + 1 AS BIGINT)) - (4 * YEAR(`calcs`.`date3`) + CAST((MONTH(`calcs`.`date3`) - 1) / 3 + 1 AS BIGINT)) AS BIGINT) AS `temp_test__3028875325__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-102
+-57
+-35
+-33
+-27
+2
+5
+6
+41","%null%
+-102
+-57
+-35
+-33
+-27
+2
+5
+6
+41"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.quarter.txt,True,0,0,"DATEDIFF('quarter', [date3], [date2], 'sunday')",expression,,None,None,344.0,"
+      SELECT CAST((4 * YEAR(`calcs`.`date2`) + CAST((MONTH(`calcs`.`date2`) - 1) / 3 + 1 AS BIGINT)) - (4 * YEAR(`calcs`.`date3`) + CAST((MONTH(`calcs`.`date3`) - 1) / 3 + 1 AS BIGINT)) AS BIGINT) AS `temp_test__3483942593__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-102
+-57
+-35
+-33
+-27
+2
+5
+6
+41","%null%
+-102
+-57
+-35
+-33
+-27
+2
+5
+6
+41"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.quarter.txt,True,0,0,"DATEDIFF('quarter', DATETIME([date2]), [datetime0], 'monday')",expression,,None,None,341.0,"
+      SELECT CAST((4 * YEAR(`calcs`.`datetime0`) + CAST((MONTH(`calcs`.`datetime0`) - 1) / 3 + 1 AS BIGINT)) - (4 * YEAR(CAST(`calcs`.`date2` AS TIMESTAMP)) + CAST((MONTH(CAST(`calcs`.`date2` AS TIMESTAMP)) - 1) / 3 + 1 AS BIGINT)) AS BIGINT) AS `temp_test__4196684004__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","9
+14
+24
+28
+29
+36
+37
+41
+66
+95
+96
+109
+110
+112
+121
+122
+128","9
+14
+24
+28
+29
+36
+37
+41
+66
+95
+96
+109
+110
+112
+121
+122
+128"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.quarter.txt,True,0,0,"DATEDIFF('quarter', DATETIME([date2]), [datetime0], 'sunday')",expression,,None,None,345.0,"
+      SELECT CAST((4 * YEAR(`calcs`.`datetime0`) + CAST((MONTH(`calcs`.`datetime0`) - 1) / 3 + 1 AS BIGINT)) - (4 * YEAR(CAST(`calcs`.`date2` AS TIMESTAMP)) + CAST((MONTH(CAST(`calcs`.`date2` AS TIMESTAMP)) - 1) / 3 + 1 AS BIGINT)) AS BIGINT) AS `temp_test__351668681__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","9
+14
+24
+28
+29
+36
+37
+41
+66
+95
+96
+109
+110
+112
+121
+122
+128","9
+14
+24
+28
+29
+36
+37
+41
+66
+95
+96
+109
+110
+112
+121
+122
+128"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.second,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.second.txt,True,0,0,"DATEDIFF('second', DATETIME([date2]), [datetime0], 'monday')",expression,,None,None,461.0,"
+      SELECT CAST((((DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) * 24 + COALESCE(CAST(SUBSTR(`calcs`.`datetime0`,12,2) AS INT), 0) - COALESCE(CAST(SUBSTR(CAST(`calcs`.`date2` AS TIMESTAMP),12,2) AS INT), 0)) * 60 + COALESCE(MINUTE(`calcs`.`datetime0`), 0) - COALESCE(MINUTE(CAST(`calcs`.`date2` AS TIMESTAMP)), 0)) * 60 + COALESCE(SECOND(`calcs`.`datetime0`), 0) - COALESCE(SECOND(CAST(`calcs`.`date2` AS TIMESTAMP)), 0)) AS BIGINT) AS `temp_test__3772571288__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","71152468
+108828116
+187737217
+216806363
+226107022
+280758634
+287566980
+323968946
+521936491
+748053023
+755615660
+859025855
+866789690
+877906168
+952882216
+957082604
+1011527872","71152468
+108828116
+187737217
+216806363
+226107022
+280758634
+287566980
+323968946
+521936491
+748053023
+755615660
+859025855
+866789690
+877906168
+952882216
+957082604
+1011527872"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.second,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.second.txt,True,0,0,"DATEDIFF('second', DATETIME([date2]), [datetime0], 'sunday')",expression,,None,None,348.0,"
+      SELECT CAST((((DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) * 24 + COALESCE(CAST(SUBSTR(`calcs`.`datetime0`,12,2) AS INT), 0) - COALESCE(CAST(SUBSTR(CAST(`calcs`.`date2` AS TIMESTAMP),12,2) AS INT), 0)) * 60 + COALESCE(MINUTE(`calcs`.`datetime0`), 0) - COALESCE(MINUTE(CAST(`calcs`.`date2` AS TIMESTAMP)), 0)) * 60 + COALESCE(SECOND(`calcs`.`datetime0`), 0) - COALESCE(SECOND(CAST(`calcs`.`date2` AS TIMESTAMP)), 0)) AS BIGINT) AS `temp_test__3405329770__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","71152468
+108828116
+187737217
+216806363
+226107022
+280758634
+287566980
+323968946
+521936491
+748053023
+755615660
+859025855
+866789690
+877906168
+952882216
+957082604
+1011527872","71152468
+108828116
+187737217
+216806363
+226107022
+280758634
+287566980
+323968946
+521936491
+748053023
+755615660
+859025855
+866789690
+877906168
+952882216
+957082604
+1011527872"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.week.txt,True,0,0,"DATEDIFF('week', [date3], [date2], 'monday')",expression,,None,None,358.0,"
+      SELECT FLOOR(DATEDIFF(NEXT_DAY(`calcs`.`date2`,'MO'),NEXT_DAY(`calcs`.`date3`,'MO'))/7) AS `temp_test__3550551924__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-1327
+-747
+-465
+-436
+-349
+33
+64
+84
+536","%null%
+-1327
+-747
+-465
+-436
+-349
+33
+64
+84
+536"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.week.txt,True,0,0,"DATEDIFF('week', [date3], [date2], 'sunday')",expression,,None,None,374.0,"
+      SELECT FLOOR(DATEDIFF(NEXT_DAY(`calcs`.`date2`,'SU'),NEXT_DAY(`calcs`.`date3`,'SU'))/7) AS `temp_test__2745903531__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-1326
+-747
+-465
+-436
+-350
+32
+64
+83
+536","%null%
+-1326
+-747
+-465
+-436
+-350
+32
+64
+83
+536"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.week.txt,True,0,0,"DATEDIFF('week', DATETIME([date2]), [datetime0], 'monday')",expression,,None,None,356.0,"
+      SELECT FLOOR(DATEDIFF(NEXT_DAY(`calcs`.`datetime0`,'MO'),NEXT_DAY(CAST(`calcs`.`date2` AS TIMESTAMP),'MO'))/7) AS `temp_test__1341534691__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","118
+180
+310
+359
+374
+465
+476
+535
+863
+1237
+1250
+1420
+1433
+1451
+1576
+1583
+1672","118
+180
+310
+359
+374
+465
+476
+535
+863
+1237
+1250
+1420
+1433
+1451
+1576
+1583
+1672"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.week.txt,True,0,0,"DATEDIFF('week', DATETIME([date2]), [datetime0], 'sunday')",expression,,None,None,368.0,"
+      SELECT FLOOR(DATEDIFF(NEXT_DAY(`calcs`.`datetime0`,'SU'),NEXT_DAY(CAST(`calcs`.`date2` AS TIMESTAMP),'SU'))/7) AS `temp_test__1157868287__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","118
+179
+310
+359
+374
+464
+475
+536
+863
+1237
+1250
+1420
+1433
+1452
+1576
+1582
+1672","118
+179
+310
+359
+374
+464
+475
+536
+863
+1237
+1250
+1420
+1433
+1452
+1576
+1582
+1672"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.weekday.txt,True,0,0,"DATEDIFF('weekday', [date3], [date2], 'monday')",expression,,None,None,349.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`date2`), TO_DATE(`calcs`.`date3`)) AS `temp_test__4265410721__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.weekday.txt,True,0,0,"DATEDIFF('weekday', [date3], [date2], 'sunday')",expression,,None,None,329.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`date2`), TO_DATE(`calcs`.`date3`)) AS `temp_test__1278698096__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.weekday.txt,True,0,0,"DATEDIFF('weekday', DATETIME([date2]), [datetime0], 'monday')",expression,,None,None,336.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) AS `temp_test__3729248905__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.weekday.txt,True,0,0,"DATEDIFF('weekday', DATETIME([date2]), [datetime0], 'sunday')",expression,,None,None,308.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) AS `temp_test__965356852__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.year.txt,True,0,0,"DATEDIFF('year', [date3], [date2], 'monday')",expression,,None,None,358.0,"
+      SELECT CAST(YEAR(`calcs`.`date2`) - YEAR(`calcs`.`date3`) AS BIGINT) AS `temp_test__427588088__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-25
+-14
+-9
+-8
+-7
+0
+1
+10","%null%
+-25
+-14
+-9
+-8
+-7
+0
+1
+10"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.year.txt,True,0,0,"DATEDIFF('year', [date3], [date2], 'sunday')",expression,,None,None,334.0,"
+      SELECT CAST(YEAR(`calcs`.`date2`) - YEAR(`calcs`.`date3`) AS BIGINT) AS `temp_test__2526313076__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-25
+-14
+-9
+-8
+-7
+0
+1
+10","%null%
+-25
+-14
+-9
+-8
+-7
+0
+1
+10"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.year.txt,True,0,0,"DATEDIFF('year', DATETIME([date2]), [datetime0], 'monday')",expression,,None,None,344.0,"
+      SELECT CAST(YEAR(`calcs`.`datetime0`) - YEAR(CAST(`calcs`.`date2` AS TIMESTAMP)) AS BIGINT) AS `temp_test__1540391660__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","2
+3
+6
+7
+9
+10
+16
+24
+27
+28
+30
+32","2
+3
+6
+7
+9
+10
+16
+24
+27
+28
+30
+32"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.sow.year.txt,True,0,0,"DATEDIFF('year', DATETIME([date2]), [datetime0], 'sunday')",expression,,None,None,312.0,"
+      SELECT CAST(YEAR(`calcs`.`datetime0`) - YEAR(CAST(`calcs`.`date2` AS TIMESTAMP)) AS BIGINT) AS `temp_test__3579576882__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","2
+3
+6
+7
+9
+10
+16
+24
+27
+28
+30
+32","2
+3
+6
+7
+9
+10
+16
+24
+27
+28
+30
+32"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.week.extended,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.week.extended.txt,True,0,0,"DATEDIFF('week', [date2], #2050-01-01#)",expression,,None,None,330.0,"
+      SELECT FLOOR(DATEDIFF(NEXT_DAY(CAST('2050-01-01' AS DATE),'SU'),NEXT_DAY(`calcs`.`date2`,'SU'))/7) AS `temp_test__2771060545__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","2488
+2551
+2681
+2728
+2744
+2834
+2847
+2906
+3234
+3608
+3623
+3793
+3803
+3825
+3948
+3954
+4042","2488
+2551
+2681
+2728
+2744
+2834
+2847
+2906
+3234
+3608
+3623
+3793
+3803
+3825
+3948
+3954
+4042"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.week.txt,True,0,0,"DATEDIFF('week', [date3], [date2])",expression,,None,None,317.0,"
+      SELECT FLOOR(DATEDIFF(NEXT_DAY(`calcs`.`date2`,'SU'),NEXT_DAY(`calcs`.`date3`,'SU'))/7) AS `temp_test__859582235__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-1326
+-747
+-465
+-436
+-350
+32
+64
+83
+536","%null%
+-1326
+-747
+-465
+-436
+-350
+32
+64
+83
+536"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.week.txt,True,0,0,"DATEDIFF('week', DATETIME([date2]), [datetime0])",expression,,None,None,334.0,"
+      SELECT FLOOR(DATEDIFF(NEXT_DAY(`calcs`.`datetime0`,'SU'),NEXT_DAY(CAST(`calcs`.`date2` AS TIMESTAMP),'SU'))/7) AS `temp_test__2079052241__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","118
+179
+310
+359
+374
+464
+475
+536
+863
+1237
+1250
+1420
+1433
+1452
+1576
+1582
+1672","118
+179
+310
+359
+374
+464
+475
+536
+863
+1237
+1250
+1420
+1433
+1452
+1576
+1582
+1672"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.weekday.txt,True,0,0,"DATEDIFF('weekday', [date3], [date2])",expression,,None,None,310.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`date2`), TO_DATE(`calcs`.`date3`)) AS `temp_test__3361088979__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752","%null%
+-9287
+-5232
+-3256
+-3051
+-2446
+229
+449
+586
+3752"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.weekday.txt,True,0,0,"DATEDIFF('weekday', DATETIME([date2]), [datetime0])",expression,,None,None,311.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(`calcs`.`date2` AS TIMESTAMP))) AS `temp_test__299717125__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707","823
+1259
+2172
+2509
+2616
+3249
+3328
+3749
+6040
+8658
+8745
+9942
+10032
+10160
+11028
+11077
+11707"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.year.txt,True,0,0,"DATEDIFF('year', [date3], [date2])",expression,,None,None,311.0,"
+      SELECT CAST(YEAR(`calcs`.`date2`) - YEAR(`calcs`.`date3`) AS BIGINT) AS `temp_test__3489013143__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-25
+-14
+-9
+-8
+-7
+0
+1
+10","%null%
+-25
+-14
+-9
+-8
+-7
+0
+1
+10"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datediff.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datediff.year.txt,True,0,0,"DATEDIFF('year', DATETIME([date2]), [datetime0])",expression,,None,None,323.0,"
+      SELECT CAST(YEAR(`calcs`.`datetime0`) - YEAR(CAST(`calcs`.`date2` AS TIMESTAMP)) AS BIGINT) AS `temp_test__3834106318__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","2
+3
+6
+7
+9
+10
+16
+24
+27
+28
+30
+32","2
+3
+6
+7
+9
+10
+16
+24
+27
+28
+30
+32"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.day.txt,True,0,0,"DATENAME('day', [date2])",expression,,None,None,343.0,"
+      SELECT CAST(DAY(`calcs`.`date2`) AS STRING) AS `temp_test__3471130809__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""12""
+""17""
+""19""
+""20""
+""26""
+""27""
+""3""
+""30""
+""4""
+""5""
+""7""
+""8""
+""9""","""12""
+""17""
+""19""
+""20""
+""26""
+""27""
+""3""
+""30""
+""4""
+""5""
+""7""
+""8""
+""9"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.day.txt,True,0,0,"DATENAME('day', [datetime0])",expression,,None,None,346.0,"
+      SELECT CAST(DAY(`calcs`.`datetime0`) AS STRING) AS `temp_test__482138814__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""12""
+""14""
+""17""
+""19""
+""2""
+""22""
+""23""
+""25""
+""26""
+""28""
+""31""
+""4""
+""5""
+""9""","""12""
+""14""
+""17""
+""19""
+""2""
+""22""
+""23""
+""25""
+""26""
+""28""
+""31""
+""4""
+""5""
+""9"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.dayofyear.txt,True,0,0,"DATENAME('dayofyear', [date2])",expression,,None,None,334.0,"
+      SELECT CAST(DAYOFYEAR(`calcs`.`date2`) AS STRING) AS `temp_test__1667583030__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""110""
+""117""
+""123""
+""150""
+""155""
+""194""
+""208""
+""224""
+""246""
+""253""
+""262""
+""312""
+""35""
+""39""
+""5""
+""76""","""110""
+""117""
+""123""
+""150""
+""155""
+""194""
+""208""
+""224""
+""246""
+""253""
+""262""
+""312""
+""35""
+""39""
+""5""
+""76"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.dayofyear.txt,True,0,0,"DATENAME('dayofyear', [datetime0])",expression,,None,None,343.0,"
+      SELECT CAST(DAYOFYEAR(`calcs`.`datetime0`) AS STRING) AS `temp_test__2537119552__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""186""
+""187""
+""191""
+""194""
+""196""
+""199""
+""201""
+""204""
+""205""
+""207""
+""208""
+""210""
+""213""
+""215""","""186""
+""187""
+""191""
+""194""
+""196""
+""199""
+""201""
+""204""
+""205""
+""207""
+""208""
+""210""
+""213""
+""215"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.hour,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.hour.txt,True,0,0,"DATENAME('hour', [datetime0])",expression,,None,None,339.0,"
+      SELECT CAST(HOUR(`calcs`.`datetime0`) AS STRING) AS `temp_test__3233853797__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""0""
+""10""
+""11""
+""12""
+""13""
+""14""
+""15""
+""17""
+""21""
+""22""
+""23""
+""6""
+""7""
+""8""","""0""
+""10""
+""11""
+""12""
+""13""
+""14""
+""15""
+""17""
+""21""
+""22""
+""23""
+""6""
+""7""
+""8"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.minute,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.minute.txt,True,0,0,"DATENAME('minute', [datetime0])",expression,,None,None,337.0,"
+      SELECT CAST(MINUTE(`calcs`.`datetime0`) AS STRING) AS `temp_test__3325657342__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1""
+""13""
+""14""
+""16""
+""17""
+""21""
+""22""
+""30""
+""34""
+""43""
+""49""
+""54""
+""57""
+""59""","""1""
+""13""
+""14""
+""16""
+""17""
+""21""
+""22""
+""30""
+""34""
+""43""
+""49""
+""54""
+""57""
+""59"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.month.txt,True,4,0,"DATENAME('month', [date2])",expression,,None,None,332.0,"
+      SELECT CAST(MONTH(`calcs`.`date2`) AS STRING) AS `temp_test__477986140__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1""
+""11""
+""2""
+""3""
+""4""
+""5""
+""6""
+""7""
+""8""
+""9""","""1""
+""11""
+""2""
+""3""
+""4""
+""5""
+""6""
+""7""
+""8""
+""9"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.month.txt,True,4,0,"DATENAME('month', [datetime0])",expression,,None,None,348.0,"
+      SELECT CAST(MONTH(`calcs`.`datetime0`) AS STRING) AS `temp_test__2224240773__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""7""
+""8""","""7""
+""8"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('year', DATE(null))",expression,,None,None,296.0,"
+      SELECT CAST(YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS STRING) AS `temp_test__3057229987__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('year', DATETIME(null))",expression,,None,None,401.0,"
+      SELECT CAST(YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__4063654893__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('quarter', DATE(null))",expression,,None,None,322.0,"
+      SELECT CAST(QUARTER(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS STRING) AS `temp_test__2102858309__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('quarter', DATETIME(null))",expression,,None,None,302.0,"
+      SELECT CAST(QUARTER(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__3270121971__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('month', DATE(null))",expression,,None,None,296.0,"
+      SELECT CAST(MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS STRING) AS `temp_test__2692233594__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('month', DATETIME(null))",expression,,None,None,304.0,"
+      SELECT CAST(MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__1772891037__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('week', DATE(null))",expression,,None,None,301.0,"
+      SELECT 
+            FORMAT_NUMBER(FLOOR((14 + DATEDIFF(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE), TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY')) + DATEDIFF(TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY'), NEXT_DAY(TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY'), 'SU')))/7), 0)
+         AS `temp_test__3926284460__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('week', DATETIME(null))",expression,,None,None,310.0,"
+      SELECT 
+            FORMAT_NUMBER(FLOOR((14 + DATEDIFF(CAST(CAST(NULL AS INT) AS TIMESTAMP), TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY')) + DATEDIFF(TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY'), NEXT_DAY(TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY'), 'SU')))/7), 0)
+         AS `temp_test__1415178918__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('weekday', DATE(null))",expression,,None,None,297.0,"
+      SELECT CAST(DAYOFWEEK(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS STRING) AS `temp_test__3608467423__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('weekday', DATETIME(null))",expression,,None,None,316.0,"
+      SELECT CAST(DAYOFWEEK(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__2920782836__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('day', DATE(null))",expression,,None,None,351.0,"
+      SELECT CAST(DAY(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS STRING) AS `temp_test__3132873078__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('day', DATETIME(null))",expression,,None,None,285.0,"
+      SELECT CAST(DAY(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__2450943592__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('dayofyear', DATE(null))",expression,,None,None,314.0,"
+      SELECT CAST(DAYOFYEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS STRING) AS `temp_test__3530921297__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('dayofyear', DATETIME(null))",expression,,None,None,310.0,"
+      SELECT CAST(DAYOFYEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__304383277__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('hour', DATETIME(null))",expression,,None,None,288.0,"
+      SELECT CAST(HOUR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__3871589708__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('minute', DATETIME(null))",expression,,None,None,290.0,"
+      SELECT CAST(MINUTE(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__2462406212__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.nulls.txt,True,0,0,"DATENAME('second', DATETIME(null))",expression,,None,None,308.0,"
+      SELECT CAST(SECOND(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__3443263072__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.quarter.txt,True,0,0,"DATENAME('quarter', [date2])",expression,,None,None,349.0,"
+      SELECT CAST(QUARTER(`calcs`.`date2`) AS STRING) AS `temp_test__653088523__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1""
+""2""
+""3""
+""4""","""1""
+""2""
+""3""
+""4"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.quarter.txt,True,0,0,"DATENAME('quarter', [datetime0])",expression,,None,None,328.0,"
+      SELECT CAST(QUARTER(`calcs`.`datetime0`) AS STRING) AS `temp_test__3134852500__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""3""","""3"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.second,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.second.txt,True,0,0,"DATENAME('second', [datetime0])",expression,,None,None,327.0,"
+      SELECT CAST(SECOND(`calcs`.`datetime0`) AS STRING) AS `temp_test__1235924899__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""0""
+""16""
+""20""
+""22""
+""23""
+""26""
+""28""
+""31""
+""34""
+""35""
+""37""
+""44""
+""50""
+""52""
+""56""","""0""
+""16""
+""20""
+""22""
+""23""
+""26""
+""28""
+""31""
+""34""
+""35""
+""37""
+""44""
+""50""
+""52""
+""56"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.day.txt,True,0,0,"DATENAME('day', [date2], 'monday')",expression,,None,None,330.0,"
+      SELECT CAST(DAY(`calcs`.`date2`) AS STRING) AS `temp_test__1699663235__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""12""
+""17""
+""19""
+""20""
+""26""
+""27""
+""3""
+""30""
+""4""
+""5""
+""7""
+""8""
+""9""","""12""
+""17""
+""19""
+""20""
+""26""
+""27""
+""3""
+""30""
+""4""
+""5""
+""7""
+""8""
+""9"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.day.txt,True,0,0,"DATENAME('day', [date2], 'sunday')",expression,,None,None,306.0,"
+      SELECT CAST(DAY(`calcs`.`date2`) AS STRING) AS `temp_test__1554256126__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""12""
+""17""
+""19""
+""20""
+""26""
+""27""
+""3""
+""30""
+""4""
+""5""
+""7""
+""8""
+""9""","""12""
+""17""
+""19""
+""20""
+""26""
+""27""
+""3""
+""30""
+""4""
+""5""
+""7""
+""8""
+""9"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.day.txt,True,0,0,"DATENAME('day', [datetime0], 'monday')",expression,,None,None,328.0,"
+      SELECT CAST(DAY(`calcs`.`datetime0`) AS STRING) AS `temp_test__2171721785__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""12""
+""14""
+""17""
+""19""
+""2""
+""22""
+""23""
+""25""
+""26""
+""28""
+""31""
+""4""
+""5""
+""9""","""12""
+""14""
+""17""
+""19""
+""2""
+""22""
+""23""
+""25""
+""26""
+""28""
+""31""
+""4""
+""5""
+""9"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.day.txt,True,0,0,"DATENAME('day', [datetime0], 'sunday')",expression,,None,None,297.0,"
+      SELECT CAST(DAY(`calcs`.`datetime0`) AS STRING) AS `temp_test__3941430330__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""12""
+""14""
+""17""
+""19""
+""2""
+""22""
+""23""
+""25""
+""26""
+""28""
+""31""
+""4""
+""5""
+""9""","""12""
+""14""
+""17""
+""19""
+""2""
+""22""
+""23""
+""25""
+""26""
+""28""
+""31""
+""4""
+""5""
+""9"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.dayofyear.txt,True,0,0,"DATENAME('dayofyear', [date2], 'monday')",expression,,None,None,323.0,"
+      SELECT CAST(DAYOFYEAR(`calcs`.`date2`) AS STRING) AS `temp_test__554447598__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""110""
+""117""
+""123""
+""150""
+""155""
+""194""
+""208""
+""224""
+""246""
+""253""
+""262""
+""312""
+""35""
+""39""
+""5""
+""76""","""110""
+""117""
+""123""
+""150""
+""155""
+""194""
+""208""
+""224""
+""246""
+""253""
+""262""
+""312""
+""35""
+""39""
+""5""
+""76"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.dayofyear.txt,True,0,0,"DATENAME('dayofyear', [date2], 'sunday')",expression,,None,None,352.0,"
+      SELECT CAST(DAYOFYEAR(`calcs`.`date2`) AS STRING) AS `temp_test__2130687817__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""110""
+""117""
+""123""
+""150""
+""155""
+""194""
+""208""
+""224""
+""246""
+""253""
+""262""
+""312""
+""35""
+""39""
+""5""
+""76""","""110""
+""117""
+""123""
+""150""
+""155""
+""194""
+""208""
+""224""
+""246""
+""253""
+""262""
+""312""
+""35""
+""39""
+""5""
+""76"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.dayofyear.txt,True,0,0,"DATENAME('dayofyear', [datetime0], 'monday')",expression,,None,None,363.0,"
+      SELECT CAST(DAYOFYEAR(`calcs`.`datetime0`) AS STRING) AS `temp_test__903794974__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""186""
+""187""
+""191""
+""194""
+""196""
+""199""
+""201""
+""204""
+""205""
+""207""
+""208""
+""210""
+""213""
+""215""","""186""
+""187""
+""191""
+""194""
+""196""
+""199""
+""201""
+""204""
+""205""
+""207""
+""208""
+""210""
+""213""
+""215"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.dayofyear.txt,True,0,0,"DATENAME('dayofyear', [datetime0], 'sunday')",expression,,None,None,323.0,"
+      SELECT CAST(DAYOFYEAR(`calcs`.`datetime0`) AS STRING) AS `temp_test__3917828147__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""186""
+""187""
+""191""
+""194""
+""196""
+""199""
+""201""
+""204""
+""205""
+""207""
+""208""
+""210""
+""213""
+""215""","""186""
+""187""
+""191""
+""194""
+""196""
+""199""
+""201""
+""204""
+""205""
+""207""
+""208""
+""210""
+""213""
+""215"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.hour,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.hour.txt,True,0,0,"DATENAME('hour', [datetime0], 'monday')",expression,,None,None,343.0,"
+      SELECT CAST(HOUR(`calcs`.`datetime0`) AS STRING) AS `temp_test__2997515538__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""0""
+""10""
+""11""
+""12""
+""13""
+""14""
+""15""
+""17""
+""21""
+""22""
+""23""
+""6""
+""7""
+""8""","""0""
+""10""
+""11""
+""12""
+""13""
+""14""
+""15""
+""17""
+""21""
+""22""
+""23""
+""6""
+""7""
+""8"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.hour,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.hour.txt,True,0,0,"DATENAME('hour', [datetime0], 'sunday')",expression,,None,None,321.0,"
+      SELECT CAST(HOUR(`calcs`.`datetime0`) AS STRING) AS `temp_test__4264664103__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""0""
+""10""
+""11""
+""12""
+""13""
+""14""
+""15""
+""17""
+""21""
+""22""
+""23""
+""6""
+""7""
+""8""","""0""
+""10""
+""11""
+""12""
+""13""
+""14""
+""15""
+""17""
+""21""
+""22""
+""23""
+""6""
+""7""
+""8"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.minute,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.minute.txt,True,0,0,"DATENAME('minute', [datetime0], 'monday')",expression,,None,None,355.0,"
+      SELECT CAST(MINUTE(`calcs`.`datetime0`) AS STRING) AS `temp_test__1695139533__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1""
+""13""
+""14""
+""16""
+""17""
+""21""
+""22""
+""30""
+""34""
+""43""
+""49""
+""54""
+""57""
+""59""","""1""
+""13""
+""14""
+""16""
+""17""
+""21""
+""22""
+""30""
+""34""
+""43""
+""49""
+""54""
+""57""
+""59"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.minute,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.minute.txt,True,0,0,"DATENAME('minute', [datetime0], 'sunday')",expression,,None,None,314.0,"
+      SELECT CAST(MINUTE(`calcs`.`datetime0`) AS STRING) AS `temp_test__1003104432__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1""
+""13""
+""14""
+""16""
+""17""
+""21""
+""22""
+""30""
+""34""
+""43""
+""49""
+""54""
+""57""
+""59""","""1""
+""13""
+""14""
+""16""
+""17""
+""21""
+""22""
+""30""
+""34""
+""43""
+""49""
+""54""
+""57""
+""59"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.month.txt,True,4,0,"DATENAME('month', [date2], 'monday')",expression,,None,None,324.0,"
+      SELECT CAST(MONTH(`calcs`.`date2`) AS STRING) AS `temp_test__1660803953__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1""
+""11""
+""2""
+""3""
+""4""
+""5""
+""6""
+""7""
+""8""
+""9""","""1""
+""11""
+""2""
+""3""
+""4""
+""5""
+""6""
+""7""
+""8""
+""9"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.month.txt,True,4,0,"DATENAME('month', [date2], 'sunday')",expression,,None,None,310.0,"
+      SELECT CAST(MONTH(`calcs`.`date2`) AS STRING) AS `temp_test__872696424__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1""
+""11""
+""2""
+""3""
+""4""
+""5""
+""6""
+""7""
+""8""
+""9""","""1""
+""11""
+""2""
+""3""
+""4""
+""5""
+""6""
+""7""
+""8""
+""9"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.month.txt,True,4,0,"DATENAME('month', [datetime0], 'monday')",expression,,None,None,310.0,"
+      SELECT CAST(MONTH(`calcs`.`datetime0`) AS STRING) AS `temp_test__732183378__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""7""
+""8""","""7""
+""8"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.month.txt,True,4,0,"DATENAME('month', [datetime0], 'sunday')",expression,,None,None,313.0,"
+      SELECT CAST(MONTH(`calcs`.`datetime0`) AS STRING) AS `temp_test__3816689092__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""7""
+""8""","""7""
+""8"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('year', DATETIME(null), 'sunday')",expression,,None,None,289.0,"
+      SELECT CAST(YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__2699142763__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('year', DATE(null), 'sunday')",expression,,None,None,317.0,"
+      SELECT CAST(YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS STRING) AS `temp_test__1634134069__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('quarter', DATETIME(null), 'sunday')",expression,,None,None,301.0,"
+      SELECT CAST(QUARTER(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__1949844743__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('quarter', DATE(null), 'sunday')",expression,,None,None,298.0,"
+      SELECT CAST(QUARTER(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS STRING) AS `temp_test__3376136658__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('month', DATETIME(null), 'sunday')",expression,,None,None,295.0,"
+      SELECT CAST(MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__3672267408__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('month', DATE(null), 'sunday')",expression,,None,None,429.0,"
+      SELECT CAST(MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS STRING) AS `temp_test__2406708804__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('week', DATETIME(null), 'sunday')",expression,,None,None,325.0,"
+      SELECT 
+            FORMAT_NUMBER(FLOOR((14 + DATEDIFF(CAST(CAST(NULL AS INT) AS TIMESTAMP), TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY')) + DATEDIFF(TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY'), NEXT_DAY(TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY'), 'SU')))/7), 0)
+         AS `temp_test__1073594909__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('week', DATE(null), 'sunday')",expression,,None,None,295.0,"
+      SELECT 
+            FORMAT_NUMBER(FLOOR((14 + DATEDIFF(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE), TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY')) + DATEDIFF(TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY'), NEXT_DAY(TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY'), 'SU')))/7), 0)
+         AS `temp_test__4016689999__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('weekday', DATETIME(null), 'sunday')",expression,,None,None,291.0,"
+      SELECT CAST(DAYOFWEEK(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__3405047399__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('weekday', DATE(null), 'sunday')",expression,,None,None,321.0,"
+      SELECT CAST(DAYOFWEEK(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS STRING) AS `temp_test__55506858__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('dayofyear', DATETIME(null), 'sunday')",expression,,None,None,314.0,"
+      SELECT CAST(DAYOFYEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__3460070750__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('dayofyear', DATE(null), 'sunday')",expression,,None,None,307.0,"
+      SELECT CAST(DAYOFYEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS STRING) AS `temp_test__1494289478__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('day', DATETIME(null), 'sunday')",expression,,None,None,307.0,"
+      SELECT CAST(DAY(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__3227046355__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('day', DATE(null), 'sunday')",expression,,None,None,283.0,"
+      SELECT CAST(DAY(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS STRING) AS `temp_test__1233941598__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('hour', DATETIME(null), 'sunday')",expression,,None,None,297.0,"
+      SELECT CAST(HOUR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__3874232094__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('minute', DATETIME(null), 'sunday')",expression,,None,None,348.0,"
+      SELECT CAST(MINUTE(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__1546814749__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.nulls.txt,True,0,0,"DATENAME('second', DATETIME(null), 'sunday')",expression,,None,None,309.0,"
+      SELECT CAST(SECOND(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS STRING) AS `temp_test__3692431276__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.quarter.txt,True,0,0,"DATENAME('quarter', [date2], 'monday')",expression,,None,None,338.0,"
+      SELECT CAST(QUARTER(`calcs`.`date2`) AS STRING) AS `temp_test__2643375604__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1""
+""2""
+""3""
+""4""","""1""
+""2""
+""3""
+""4"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.quarter.txt,True,0,0,"DATENAME('quarter', [date2], 'sunday')",expression,,None,None,346.0,"
+      SELECT CAST(QUARTER(`calcs`.`date2`) AS STRING) AS `temp_test__2986242609__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1""
+""2""
+""3""
+""4""","""1""
+""2""
+""3""
+""4"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.quarter.txt,True,0,0,"DATENAME('quarter', [datetime0], 'monday')",expression,,None,None,335.0,"
+      SELECT CAST(QUARTER(`calcs`.`datetime0`) AS STRING) AS `temp_test__1608337423__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""3""","""3"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.quarter.txt,True,0,0,"DATENAME('quarter', [datetime0], 'sunday')",expression,,None,None,320.0,"
+      SELECT CAST(QUARTER(`calcs`.`datetime0`) AS STRING) AS `temp_test__925465559__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""3""","""3"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.second,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.second.txt,True,0,0,"DATENAME('second', [datetime0], 'monday')",expression,,None,None,359.0,"
+      SELECT CAST(SECOND(`calcs`.`datetime0`) AS STRING) AS `temp_test__2740605400__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""0""
+""16""
+""20""
+""22""
+""23""
+""26""
+""28""
+""31""
+""34""
+""35""
+""37""
+""44""
+""50""
+""52""
+""56""","""0""
+""16""
+""20""
+""22""
+""23""
+""26""
+""28""
+""31""
+""34""
+""35""
+""37""
+""44""
+""50""
+""52""
+""56"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.second,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.second.txt,True,0,0,"DATENAME('second', [datetime0], 'sunday')",expression,,None,None,311.0,"
+      SELECT CAST(SECOND(`calcs`.`datetime0`) AS STRING) AS `temp_test__356589430__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""0""
+""16""
+""20""
+""22""
+""23""
+""26""
+""28""
+""31""
+""34""
+""35""
+""37""
+""44""
+""50""
+""52""
+""56""","""0""
+""16""
+""20""
+""22""
+""23""
+""26""
+""28""
+""31""
+""34""
+""35""
+""37""
+""44""
+""50""
+""52""
+""56"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.week.txt,True,0,0,"DATENAME('week', [date2], 'monday')",expression,,None,None,363.0,"
+      SELECT 
+            FORMAT_NUMBER(FLOOR((14 + DATEDIFF(`calcs`.`date2`, TRUNC(`calcs`.`date2`,'YY')) + DATEDIFF(TRUNC(`calcs`.`date2`,'YY'), NEXT_DAY(TRUNC(`calcs`.`date2`,'YY'), 'MO')))/7), 0)
+         AS `temp_test__499182808__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""11""
+""17""
+""18""
+""2""
+""22""
+""23""
+""29""
+""30""
+""33""
+""36""
+""37""
+""38""
+""45""
+""5""
+""7""","""11""
+""17""
+""18""
+""2""
+""22""
+""23""
+""29""
+""30""
+""33""
+""36""
+""37""
+""38""
+""45""
+""5""
+""7"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.week.txt,True,0,0,"DATENAME('week', [date2], 'sunday')",expression,,None,None,417.0,"
+      SELECT 
+            FORMAT_NUMBER(FLOOR((14 + DATEDIFF(`calcs`.`date2`, TRUNC(`calcs`.`date2`,'YY')) + DATEDIFF(TRUNC(`calcs`.`date2`,'YY'), NEXT_DAY(TRUNC(`calcs`.`date2`,'YY'), 'SU')))/7), 0)
+         AS `temp_test__2644944117__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""12""
+""17""
+""18""
+""2""
+""22""
+""23""
+""29""
+""30""
+""33""
+""36""
+""37""
+""38""
+""45""
+""6""
+""7""","""12""
+""17""
+""18""
+""2""
+""22""
+""23""
+""29""
+""30""
+""33""
+""36""
+""37""
+""38""
+""45""
+""6""
+""7"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.week.txt,True,0,0,"DATENAME('week', [datetime0], 'monday')",expression,,None,None,357.0,"
+      SELECT 
+            FORMAT_NUMBER(FLOOR((14 + DATEDIFF(`calcs`.`datetime0`, TRUNC(`calcs`.`datetime0`,'YY')) + DATEDIFF(TRUNC(`calcs`.`datetime0`,'YY'), NEXT_DAY(TRUNC(`calcs`.`datetime0`,'YY'), 'MO')))/7), 0)
+         AS `temp_test__3094931040__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""27""
+""28""
+""29""
+""30""
+""31""
+""32""","""27""
+""28""
+""29""
+""30""
+""31""
+""32"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.week.txt,True,0,0,"DATENAME('week', [datetime0], 'sunday')",expression,,None,None,357.0,"
+      SELECT 
+            FORMAT_NUMBER(FLOOR((14 + DATEDIFF(`calcs`.`datetime0`, TRUNC(`calcs`.`datetime0`,'YY')) + DATEDIFF(TRUNC(`calcs`.`datetime0`,'YY'), NEXT_DAY(TRUNC(`calcs`.`datetime0`,'YY'), 'SU')))/7), 0)
+         AS `temp_test__2831690081__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""28""
+""29""
+""30""
+""31""
+""32""","""28""
+""29""
+""30""
+""31""
+""32"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.weekday.txt,True,2,0,"DATENAME('weekday', [date2], 'monday')",expression,,None,None,329.0,"
+      SELECT CAST(DAYOFWEEK(`calcs`.`date2`) AS STRING) AS `temp_test__1706489238__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1""
+""3""
+""4""
+""5""
+""6""
+""7""","""1""
+""3""
+""4""
+""5""
+""6""
+""7"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.weekday.txt,True,2,0,"DATENAME('weekday', [date2], 'sunday')",expression,,None,None,307.0,"
+      SELECT CAST(DAYOFWEEK(`calcs`.`date2`) AS STRING) AS `temp_test__3326454598__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1""
+""3""
+""4""
+""5""
+""6""
+""7""","""1""
+""3""
+""4""
+""5""
+""6""
+""7"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.weekday.txt,True,2,0,"DATENAME('weekday', [datetime0], 'monday')",expression,,None,None,343.0,"
+      SELECT CAST(DAYOFWEEK(`calcs`.`datetime0`) AS STRING) AS `temp_test__1346443059__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1""
+""2""
+""4""
+""5""
+""6""
+""7""","""1""
+""2""
+""4""
+""5""
+""6""
+""7"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.weekday.txt,True,2,0,"DATENAME('weekday', [datetime0], 'sunday')",expression,,None,None,317.0,"
+      SELECT CAST(DAYOFWEEK(`calcs`.`datetime0`) AS STRING) AS `temp_test__2366796649__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1""
+""2""
+""4""
+""5""
+""6""
+""7""","""1""
+""2""
+""4""
+""5""
+""6""
+""7"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.year.txt,True,0,0,"DATENAME('year', [date2], 'monday')",expression,,None,None,334.0,"
+      SELECT CAST(YEAR(`calcs`.`date2`) AS STRING) AS `temp_test__1876737518__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1972""
+""1974""
+""1976""
+""1977""
+""1980""
+""1988""
+""1994""
+""1995""
+""1997""
+""1998""
+""2001""
+""2002""","""1972""
+""1974""
+""1976""
+""1977""
+""1980""
+""1988""
+""1994""
+""1995""
+""1997""
+""1998""
+""2001""
+""2002"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.year.txt,True,0,0,"DATENAME('year', [date2], 'sunday')",expression,,None,None,305.0,"
+      SELECT CAST(YEAR(`calcs`.`date2`) AS STRING) AS `temp_test__1437280163__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1972""
+""1974""
+""1976""
+""1977""
+""1980""
+""1988""
+""1994""
+""1995""
+""1997""
+""1998""
+""2001""
+""2002""","""1972""
+""1974""
+""1976""
+""1977""
+""1980""
+""1988""
+""1994""
+""1995""
+""1997""
+""1998""
+""2001""
+""2002"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.year.txt,True,0,0,"DATENAME('year', [datetime0], 'monday')",expression,,None,None,353.0,"
+      SELECT CAST(YEAR(`calcs`.`datetime0`) AS STRING) AS `temp_test__3178513645__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""2004""","""2004"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.sow.year.txt,True,0,0,"DATENAME('year', [datetime0], 'sunday')",expression,,None,None,295.0,"
+      SELECT CAST(YEAR(`calcs`.`datetime0`) AS STRING) AS `temp_test__3727444777__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""2004""","""2004"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.week.txt,True,0,0,"DATENAME('week', [date2])",expression,,None,None,325.0,"
+      SELECT 
+            FORMAT_NUMBER(FLOOR((14 + DATEDIFF(`calcs`.`date2`, TRUNC(`calcs`.`date2`,'YY')) + DATEDIFF(TRUNC(`calcs`.`date2`,'YY'), NEXT_DAY(TRUNC(`calcs`.`date2`,'YY'), 'SU')))/7), 0)
+         AS `temp_test__2524080111__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""12""
+""17""
+""18""
+""2""
+""22""
+""23""
+""29""
+""30""
+""33""
+""36""
+""37""
+""38""
+""45""
+""6""
+""7""","""12""
+""17""
+""18""
+""2""
+""22""
+""23""
+""29""
+""30""
+""33""
+""36""
+""37""
+""38""
+""45""
+""6""
+""7"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.week.txt,True,0,0,"DATENAME('week', [datetime0])",expression,,None,None,340.0,"
+      SELECT 
+            FORMAT_NUMBER(FLOOR((14 + DATEDIFF(`calcs`.`datetime0`, TRUNC(`calcs`.`datetime0`,'YY')) + DATEDIFF(TRUNC(`calcs`.`datetime0`,'YY'), NEXT_DAY(TRUNC(`calcs`.`datetime0`,'YY'), 'SU')))/7), 0)
+         AS `temp_test__1568799041__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""28""
+""29""
+""30""
+""31""
+""32""","""28""
+""29""
+""30""
+""31""
+""32"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.weekday.txt,True,2,0,"DATENAME('weekday', [date2])",expression,,None,None,295.0,"
+      SELECT CAST(DAYOFWEEK(`calcs`.`date2`) AS STRING) AS `temp_test__4107590482__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1""
+""3""
+""4""
+""5""
+""6""
+""7""","""1""
+""3""
+""4""
+""5""
+""6""
+""7"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.weekday.txt,True,2,0,"DATENAME('weekday', [datetime0])",expression,,None,None,305.0,"
+      SELECT CAST(DAYOFWEEK(`calcs`.`datetime0`) AS STRING) AS `temp_test__766794695__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1""
+""2""
+""4""
+""5""
+""6""
+""7""","""1""
+""2""
+""4""
+""5""
+""6""
+""7"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.year.txt,True,0,0,"DATENAME('year', [date2])",expression,,None,None,298.0,"
+      SELECT CAST(YEAR(`calcs`.`date2`) AS STRING) AS `temp_test__3529528921__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""1972""
+""1974""
+""1976""
+""1977""
+""1980""
+""1988""
+""1994""
+""1995""
+""1997""
+""1998""
+""2001""
+""2002""","""1972""
+""1974""
+""1976""
+""1977""
+""1980""
+""1988""
+""1994""
+""1995""
+""1997""
+""1998""
+""2001""
+""2002"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datename.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datename.year.txt,True,0,0,"DATENAME('year', [datetime0])",expression,,None,None,314.0,"
+      SELECT CAST(YEAR(`calcs`.`datetime0`) AS STRING) AS `temp_test__1066073186__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""2004""","""2004"""
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.dateadd.defect603107,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.dateadd.defect603107.txt,True,0,0,"DATEPART('year',DATEADD('day',-DATEPART('weekday',[date0])+1,[date0]))",expression,,None,None,371.0,"
+      SELECT YEAR(CAST(CONCAT(DATE_ADD(CAST(`calcs`.`date0` AS TIMESTAMP), CAST(((-(8 + DATEDIFF(`calcs`.`date0`,NEXT_DAY(CAST(`calcs`.`date0` AS DATE),'SU')))) + 1) AS INT)), SUBSTR(CAST(CAST(`calcs`.`date0` AS TIMESTAMP) AS TIMESTAMP), 11)) AS TIMESTAMP)) AS `temp_test__1308221269__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+1972
+1975
+2004","%null%
+1972
+1975
+2004"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.day.txt,True,0,0,"DATEPART('day', [date2])",expression,,None,None,342.0,"
+      SELECT DAY(`calcs`.`date2`) AS `temp_test__3076245501__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","3
+4
+5
+7
+8
+9
+12
+17
+19
+20
+26
+27
+30","3
+4
+5
+7
+8
+9
+12
+17
+19
+20
+26
+27
+30"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.day.txt,True,0,0,"DATEPART('day', [datetime0])",expression,,None,None,327.0,"
+      SELECT DAY(`calcs`.`datetime0`) AS `temp_test__148436784__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","2
+4
+5
+9
+12
+14
+17
+19
+22
+23
+25
+26
+28
+31","2
+4
+5
+9
+12
+14
+17
+19
+22
+23
+25
+26
+28
+31"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.dayofyear.txt,True,0,0,"DATEPART('dayofyear', [date2])",expression,,None,None,438.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`date2`), TO_DATE(CAST(TRUNC(`calcs`.`date2`,'YY') AS DATE))) + 1 AS `temp_test__877816921__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","5
+35
+39
+76
+110
+117
+123
+150
+155
+194
+208
+224
+246
+253
+262
+312","5
+35
+39
+76
+110
+117
+123
+150
+155
+194
+208
+224
+246
+253
+262
+312"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.dayofyear.txt,True,0,0,"DATEPART('dayofyear', [datetime0])",expression,,None,None,376.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(TRUNC(`calcs`.`datetime0`,'YY') AS DATE))) + 1 AS `temp_test__707037378__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","186
+187
+191
+194
+196
+199
+201
+204
+205
+207
+208
+210
+213
+215","186
+187
+191
+194
+196
+199
+201
+204
+205
+207
+208
+210
+213
+215"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.hour,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.hour.txt,True,0,0,"DATEPART('hour', [datetime0])",expression,,None,None,330.0,"
+      SELECT HOUR(`calcs`.`datetime0`) AS `temp_test__1298877827__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","0
+6
+7
+8
+10
+11
+12
+13
+14
+15
+17
+21
+22
+23","0
+6
+7
+8
+10
+11
+12
+13
+14
+15
+17
+21
+22
+23"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.minute,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.minute.txt,True,0,0,"DATEPART('minute', [datetime0])",expression,,None,None,328.0,"
+      SELECT MINUTE(`calcs`.`datetime0`) AS `temp_test__1256004566__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+13
+14
+16
+17
+21
+22
+30
+34
+43
+49
+54
+57
+59","1
+13
+14
+16
+17
+21
+22
+30
+34
+43
+49
+54
+57
+59"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.month.txt,True,0,0,"DATEPART('month', [date2])",expression,,None,None,328.0,"
+      SELECT MONTH(`calcs`.`date2`) AS `temp_test__2634030884__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+2
+3
+4
+5
+6
+7
+8
+9
+11","1
+2
+3
+4
+5
+6
+7
+8
+9
+11"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.month.txt,True,0,0,"DATEPART('month', [datetime0])",expression,,None,None,323.0,"
+      SELECT MONTH(`calcs`.`datetime0`) AS `temp_test__4000895377__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","7
+8","7
+8"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('year', DATE(null))",expression,,None,None,312.0,"
+      SELECT YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS `temp_test__2074921570__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('year', DATETIME(null))",expression,,None,None,321.0,"
+      SELECT YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS `temp_test__2348327946__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('quarter', DATE(null))",expression,,None,None,312.0,"
+      SELECT CAST((MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) - 1) / 3 + 1 AS BIGINT) AS `temp_test__3062347157__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('quarter', DATETIME(null))",expression,,None,None,339.0,"
+      SELECT CAST((MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP)) - 1) / 3 + 1 AS BIGINT) AS `temp_test__1236088422__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('month', DATE(null))",expression,,None,None,303.0,"
+      SELECT MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS `temp_test__1709161123__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('month', DATETIME(null))",expression,,None,None,297.0,"
+      SELECT MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS `temp_test__941741456__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('week', DATE(null))",expression,,None,None,299.0,"
+      SELECT FLOOR((14 + DATEDIFF(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE), TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY')) + DATEDIFF(TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY'),NEXT_DAY(TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY'),'SU')))/7) AS `temp_test__4070818381__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('week', DATETIME(null))",expression,,None,None,315.0,"
+      SELECT FLOOR((14 + DATEDIFF(CAST(CAST(NULL AS INT) AS TIMESTAMP), TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY')) + DATEDIFF(TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY'),NEXT_DAY(TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY'),'SU')))/7) AS `temp_test__1209329404__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('weekday', DATE(null))",expression,,None,None,298.0,"
+      SELECT (8 + DATEDIFF(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),NEXT_DAY(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS DATE),'SU'))) AS `temp_test__2284623665__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('weekday', DATETIME(null))",expression,,None,None,339.0,"
+      SELECT (8 + DATEDIFF(CAST(CAST(NULL AS INT) AS TIMESTAMP),NEXT_DAY(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'SU'))) AS `temp_test__3556637072__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('day', DATE(null))",expression,,None,None,307.0,"
+      SELECT DAY(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS `temp_test__20465857__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('day', DATETIME(null))",expression,,None,None,294.0,"
+      SELECT DAY(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS `temp_test__3365622206__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('dayofyear', DATE(null))",expression,,None,None,300.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)), TO_DATE(CAST(TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY') AS DATE))) + 1 AS `temp_test__1193407708__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('dayofyear', DATETIME(null))",expression,,None,None,288.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), TO_DATE(CAST(TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY') AS DATE))) + 1 AS `temp_test__3498421513__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('hour', DATETIME(null))",expression,,None,None,312.0,"
+      SELECT HOUR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS `temp_test__1756144708__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('minute', DATETIME(null))",expression,,None,None,300.0,"
+      SELECT MINUTE(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS `temp_test__2635020195__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.nulls.txt,True,0,0,"DATEPART('second', DATETIME(null))",expression,,None,None,285.0,"
+      SELECT SECOND(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS `temp_test__2744314424__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.quarter.txt,True,0,0,"DATEPART('quarter', [date2])",expression,,None,None,342.0,"
+      SELECT CAST((MONTH(`calcs`.`date2`) - 1) / 3 + 1 AS BIGINT) AS `temp_test__302607578__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+2
+3
+4","1
+2
+3
+4"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.quarter.txt,True,0,0,"DATEPART('quarter', [datetime0])",expression,,None,None,354.0,"
+      SELECT CAST((MONTH(`calcs`.`datetime0`) - 1) / 3 + 1 AS BIGINT) AS `temp_test__2001673842__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",3,3
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.second.ms,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.second.ms.txt,True,0,0,"DATEPART('second', DATETIME('2010-10-10 10:10:10.4'))",expression,,None,None,318.0,"
+      SELECT SECOND(CAST('2010-10-10 10:10:10.4' AS TIMESTAMP)) AS `temp_test__2143701310__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",10,10
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.second,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.second.txt,True,0,0,"DATEPART('second', [datetime0])",expression,,None,None,331.0,"
+      SELECT SECOND(`calcs`.`datetime0`) AS `temp_test__3191651815__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","0
+16
+20
+22
+23
+26
+28
+31
+34
+35
+37
+44
+50
+52
+56","0
+16
+20
+22
+23
+26
+28
+31
+34
+35
+37
+44
+50
+52
+56"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.day.txt,True,0,0,"DATEPART('day', [date2], 'monday')",expression,,None,None,315.0,"
+      SELECT DAY(`calcs`.`date2`) AS `temp_test__1438827077__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","3
+4
+5
+7
+8
+9
+12
+17
+19
+20
+26
+27
+30","3
+4
+5
+7
+8
+9
+12
+17
+19
+20
+26
+27
+30"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.day.txt,True,0,0,"DATEPART('day', [date2], 'sunday')",expression,,None,None,297.0,"
+      SELECT DAY(`calcs`.`date2`) AS `temp_test__331799714__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","3
+4
+5
+7
+8
+9
+12
+17
+19
+20
+26
+27
+30","3
+4
+5
+7
+8
+9
+12
+17
+19
+20
+26
+27
+30"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.day.txt,True,0,0,"DATEPART('day', [datetime0], 'monday')",expression,,None,None,309.0,"
+      SELECT DAY(`calcs`.`datetime0`) AS `temp_test__3561169943__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","2
+4
+5
+9
+12
+14
+17
+19
+22
+23
+25
+26
+28
+31","2
+4
+5
+9
+12
+14
+17
+19
+22
+23
+25
+26
+28
+31"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.day.txt,True,0,0,"DATEPART('day', [datetime0], 'sunday')",expression,,None,None,340.0,"
+      SELECT DAY(`calcs`.`datetime0`) AS `temp_test__2283476857__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","2
+4
+5
+9
+12
+14
+17
+19
+22
+23
+25
+26
+28
+31","2
+4
+5
+9
+12
+14
+17
+19
+22
+23
+25
+26
+28
+31"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.dayofyear.txt,True,0,0,"DATEPART('dayofyear', [date2], 'monday')",expression,,None,None,323.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`date2`), TO_DATE(CAST(TRUNC(`calcs`.`date2`,'YY') AS DATE))) + 1 AS `temp_test__3386714330__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","5
+35
+39
+76
+110
+117
+123
+150
+155
+194
+208
+224
+246
+253
+262
+312","5
+35
+39
+76
+110
+117
+123
+150
+155
+194
+208
+224
+246
+253
+262
+312"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.dayofyear.txt,True,0,0,"DATEPART('dayofyear', [date2], 'sunday')",expression,,None,None,314.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`date2`), TO_DATE(CAST(TRUNC(`calcs`.`date2`,'YY') AS DATE))) + 1 AS `temp_test__1554877814__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","5
+35
+39
+76
+110
+117
+123
+150
+155
+194
+208
+224
+246
+253
+262
+312","5
+35
+39
+76
+110
+117
+123
+150
+155
+194
+208
+224
+246
+253
+262
+312"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.dayofyear.txt,True,0,0,"DATEPART('dayofyear', [datetime0], 'monday')",expression,,None,None,323.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(TRUNC(`calcs`.`datetime0`,'YY') AS DATE))) + 1 AS `temp_test__680392169__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","186
+187
+191
+194
+196
+199
+201
+204
+205
+207
+208
+210
+213
+215","186
+187
+191
+194
+196
+199
+201
+204
+205
+207
+208
+210
+213
+215"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.dayofyear.txt,True,0,0,"DATEPART('dayofyear', [datetime0], 'sunday')",expression,,None,None,313.0,"
+      SELECT DATEDIFF(TO_DATE(`calcs`.`datetime0`), TO_DATE(CAST(TRUNC(`calcs`.`datetime0`,'YY') AS DATE))) + 1 AS `temp_test__792760981__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","186
+187
+191
+194
+196
+199
+201
+204
+205
+207
+208
+210
+213
+215","186
+187
+191
+194
+196
+199
+201
+204
+205
+207
+208
+210
+213
+215"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.hour,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.hour.txt,True,0,0,"DATEPART('hour', [datetime0], 'monday')",expression,,None,None,299.0,"
+      SELECT HOUR(`calcs`.`datetime0`) AS `temp_test__367110610__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","0
+6
+7
+8
+10
+11
+12
+13
+14
+15
+17
+21
+22
+23","0
+6
+7
+8
+10
+11
+12
+13
+14
+15
+17
+21
+22
+23"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.hour,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.hour.txt,True,0,0,"DATEPART('hour', [datetime0], 'sunday')",expression,,None,None,329.0,"
+      SELECT HOUR(`calcs`.`datetime0`) AS `temp_test__1785761163__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","0
+6
+7
+8
+10
+11
+12
+13
+14
+15
+17
+21
+22
+23","0
+6
+7
+8
+10
+11
+12
+13
+14
+15
+17
+21
+22
+23"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.minute,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.minute.txt,True,0,0,"DATEPART('minute', [datetime0], 'monday')",expression,,None,None,304.0,"
+      SELECT MINUTE(`calcs`.`datetime0`) AS `temp_test__232803726__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+13
+14
+16
+17
+21
+22
+30
+34
+43
+49
+54
+57
+59","1
+13
+14
+16
+17
+21
+22
+30
+34
+43
+49
+54
+57
+59"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.minute,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.minute.txt,True,0,0,"DATEPART('minute', [datetime0], 'sunday')",expression,,None,None,301.0,"
+      SELECT MINUTE(`calcs`.`datetime0`) AS `temp_test__2176505489__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+13
+14
+16
+17
+21
+22
+30
+34
+43
+49
+54
+57
+59","1
+13
+14
+16
+17
+21
+22
+30
+34
+43
+49
+54
+57
+59"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.month.txt,True,0,0,"DATEPART('month', [date2], 'monday')",expression,,None,None,318.0,"
+      SELECT MONTH(`calcs`.`date2`) AS `temp_test__1671202742__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+2
+3
+4
+5
+6
+7
+8
+9
+11","1
+2
+3
+4
+5
+6
+7
+8
+9
+11"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.month.txt,True,0,0,"DATEPART('month', [date2], 'sunday')",expression,,None,None,395.0,"
+      SELECT MONTH(`calcs`.`date2`) AS `temp_test__536615588__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+2
+3
+4
+5
+6
+7
+8
+9
+11","1
+2
+3
+4
+5
+6
+7
+8
+9
+11"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.month.txt,True,0,0,"DATEPART('month', [datetime0], 'monday')",expression,,None,None,317.0,"
+      SELECT MONTH(`calcs`.`datetime0`) AS `temp_test__1933085624__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","7
+8","7
+8"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.month.txt,True,0,0,"DATEPART('month', [datetime0], 'sunday')",expression,,None,None,313.0,"
+      SELECT MONTH(`calcs`.`datetime0`) AS `temp_test__2986113344__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","7
+8","7
+8"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('year', DATE(null), 'sunday')",expression,,None,None,329.0,"
+      SELECT YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS `temp_test__513464674__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('year', DATETIME(null), 'sunday')",expression,,None,None,290.0,"
+      SELECT YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS `temp_test__3512378422__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('quarter', DATETIME(null), 'sunday')",expression,,None,None,301.0,"
+      SELECT CAST((MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP)) - 1) / 3 + 1 AS BIGINT) AS `temp_test__3084524178__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('quarter', DATE(null), 'sunday')",expression,,None,None,319.0,"
+      SELECT CAST((MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) - 1) / 3 + 1 AS BIGINT) AS `temp_test__4202902840__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('month', DATETIME(null), 'sunday')",expression,,None,None,312.0,"
+      SELECT MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS `temp_test__2836269094__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('month', DATE(null), 'sunday')",expression,,None,None,303.0,"
+      SELECT MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS `temp_test__3924648662__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('week', DATE(null), 'sunday')",expression,,None,None,309.0,"
+      SELECT FLOOR((14 + DATEDIFF(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE), TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY')) + DATEDIFF(TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY'),NEXT_DAY(TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY'),'SU')))/7) AS `temp_test__1538264184__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('week', DATETIME(null), 'sunday')",expression,,None,None,303.0,"
+      SELECT FLOOR((14 + DATEDIFF(CAST(CAST(NULL AS INT) AS TIMESTAMP), TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY')) + DATEDIFF(TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY'),NEXT_DAY(TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY'),'SU')))/7) AS `temp_test__4042104093__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('weekday', DATE(null), 'sunday')",expression,,None,None,300.0,"
+      SELECT (8 + DATEDIFF(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),NEXT_DAY(CAST(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS DATE),'SU'))) AS `temp_test__4271712345__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('weekday', DATETIME(null), 'sunday')",expression,,None,None,322.0,"
+      SELECT (8 + DATEDIFF(CAST(CAST(NULL AS INT) AS TIMESTAMP),NEXT_DAY(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'SU'))) AS `temp_test__963247111__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('dayofyear', DATETIME(null), 'sunday')",expression,,None,None,312.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)), TO_DATE(CAST(TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY') AS DATE))) + 1 AS `temp_test__738426766__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('dayofyear', DATE(null), 'sunday')",expression,,None,None,296.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)), TO_DATE(CAST(TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY') AS DATE))) + 1 AS `temp_test__1202522493__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('day', DATETIME(null), 'sunday')",expression,,None,None,385.0,"
+      SELECT DAY(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS `temp_test__1255819744__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('day', DATE(null), 'sunday')",expression,,None,None,286.0,"
+      SELECT DAY(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS `temp_test__1639804515__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('hour', DATETIME(null), 'sunday')",expression,,None,None,297.0,"
+      SELECT HOUR(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS `temp_test__299943486__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('minute', DATETIME(null), 'sunday')",expression,,None,None,290.0,"
+      SELECT MINUTE(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS `temp_test__4177149407__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.nulls.txt,True,0,0,"DATEPART('second', DATETIME(null), 'sunday')",expression,,None,None,322.0,"
+      SELECT SECOND(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS `temp_test__1457324017__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.quarter.txt,True,0,0,"DATEPART('quarter', [date2], 'monday')",expression,,None,None,342.0,"
+      SELECT CAST((MONTH(`calcs`.`date2`) - 1) / 3 + 1 AS BIGINT) AS `temp_test__3044284514__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+2
+3
+4","1
+2
+3
+4"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.quarter.txt,True,0,0,"DATEPART('quarter', [date2], 'sunday')",expression,,None,None,297.0,"
+      SELECT CAST((MONTH(`calcs`.`date2`) - 1) / 3 + 1 AS BIGINT) AS `temp_test__2383411022__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+2
+3
+4","1
+2
+3
+4"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.quarter.txt,True,0,0,"DATEPART('quarter', [datetime0], 'monday')",expression,,None,None,333.0,"
+      SELECT CAST((MONTH(`calcs`.`datetime0`) - 1) / 3 + 1 AS BIGINT) AS `temp_test__3392256124__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",3,3
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.quarter.txt,True,0,0,"DATEPART('quarter', [datetime0], 'sunday')",expression,,None,None,305.0,"
+      SELECT CAST((MONTH(`calcs`.`datetime0`) - 1) / 3 + 1 AS BIGINT) AS `temp_test__1426463696__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",3,3
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.second,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.second.txt,True,0,0,"DATEPART('second', DATETIME([datetime0]), 'monday')",expression,,None,None,309.0,"
+      SELECT SECOND(CAST(`calcs`.`datetime0` as TIMESTAMP)) AS `temp_test__1770279206__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","0
+16
+20
+22
+23
+26
+28
+31
+34
+35
+37
+44
+50
+52
+56","0
+16
+20
+22
+23
+26
+28
+31
+34
+35
+37
+44
+50
+52
+56"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.second,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.second.txt,True,0,0,"DATEPART('second', DATETIME([datetime0]), 'sunday')",expression,,None,None,341.0,"
+      SELECT SECOND(CAST(`calcs`.`datetime0` as TIMESTAMP)) AS `temp_test__4279914489__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","0
+16
+20
+22
+23
+26
+28
+31
+34
+35
+37
+44
+50
+52
+56","0
+16
+20
+22
+23
+26
+28
+31
+34
+35
+37
+44
+50
+52
+56"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.week.txt,True,0,0,"DATEPART('week', [date2], 'monday')",expression,,None,None,344.0,"
+      SELECT FLOOR((14 + DATEDIFF(`calcs`.`date2`, TRUNC(`calcs`.`date2`,'YY')) + DATEDIFF(TRUNC(`calcs`.`date2`,'YY'),NEXT_DAY(TRUNC(`calcs`.`date2`,'YY'),'MO')))/7) AS `temp_test__3400925592__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","2
+5
+7
+11
+17
+18
+22
+23
+29
+30
+33
+36
+37
+38
+45","2
+5
+7
+11
+17
+18
+22
+23
+29
+30
+33
+36
+37
+38
+45"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.week.txt,True,0,0,"DATEPART('week', [date2], 'sunday')",expression,,None,None,356.0,"
+      SELECT FLOOR((14 + DATEDIFF(`calcs`.`date2`, TRUNC(`calcs`.`date2`,'YY')) + DATEDIFF(TRUNC(`calcs`.`date2`,'YY'),NEXT_DAY(TRUNC(`calcs`.`date2`,'YY'),'SU')))/7) AS `temp_test__1636919423__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","2
+6
+7
+12
+17
+18
+22
+23
+29
+30
+33
+36
+37
+38
+45","2
+6
+7
+12
+17
+18
+22
+23
+29
+30
+33
+36
+37
+38
+45"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.week.txt,True,0,0,"DATEPART('week', [datetime0], 'monday')",expression,,None,None,362.0,"
+      SELECT FLOOR((14 + DATEDIFF(`calcs`.`datetime0`, TRUNC(`calcs`.`datetime0`,'YY')) + DATEDIFF(TRUNC(`calcs`.`datetime0`,'YY'),NEXT_DAY(TRUNC(`calcs`.`datetime0`,'YY'),'MO')))/7) AS `temp_test__3595934100__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","27
+28
+29
+30
+31
+32","27
+28
+29
+30
+31
+32"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.week.txt,True,0,0,"DATEPART('week', [datetime0], 'sunday')",expression,,None,None,363.0,"
+      SELECT FLOOR((14 + DATEDIFF(`calcs`.`datetime0`, TRUNC(`calcs`.`datetime0`,'YY')) + DATEDIFF(TRUNC(`calcs`.`datetime0`,'YY'),NEXT_DAY(TRUNC(`calcs`.`datetime0`,'YY'),'SU')))/7) AS `temp_test__4171408365__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","28
+29
+30
+31
+32","28
+29
+30
+31
+32"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.weekday.txt,True,0,0,"DATEPART('weekday', [date2], 'monday')",expression,,None,None,614.0,"
+      SELECT (8 + DATEDIFF(`calcs`.`date2`,NEXT_DAY(CAST(`calcs`.`date2` AS DATE),'SU'))) AS `temp_test__3641022413__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+3
+4
+5
+6
+7","1
+3
+4
+5
+6
+7"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.weekday.txt,True,0,0,"DATEPART('weekday', [date2], 'sunday')",expression,,None,None,322.0,"
+      SELECT (8 + DATEDIFF(`calcs`.`date2`,NEXT_DAY(CAST(`calcs`.`date2` AS DATE),'SU'))) AS `temp_test__1193998601__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+3
+4
+5
+6
+7","1
+3
+4
+5
+6
+7"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.weekday.txt,True,0,0,"DATEPART('weekday', [datetime0], 'monday')",expression,,None,None,341.0,"
+      SELECT (8 + DATEDIFF(`calcs`.`datetime0`,NEXT_DAY(CAST(`calcs`.`datetime0` AS DATE),'SU'))) AS `temp_test__3800988289__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+2
+4
+5
+6
+7","1
+2
+4
+5
+6
+7"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.weekday.txt,True,0,0,"DATEPART('weekday', [datetime0], 'sunday')",expression,,None,None,315.0,"
+      SELECT (8 + DATEDIFF(`calcs`.`datetime0`,NEXT_DAY(CAST(`calcs`.`datetime0` AS DATE),'SU'))) AS `temp_test__779479971__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+2
+4
+5
+6
+7","1
+2
+4
+5
+6
+7"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.year.txt,True,0,0,"DATEPART('year', [date2], 'monday')",expression,,None,None,331.0,"
+      SELECT YEAR(`calcs`.`date2`) AS `temp_test__840463993__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1972
+1974
+1976
+1977
+1980
+1988
+1994
+1995
+1997
+1998
+2001
+2002","1972
+1974
+1976
+1977
+1980
+1988
+1994
+1995
+1997
+1998
+2001
+2002"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.year.txt,True,0,0,"DATEPART('year', [date2], 'sunday')",expression,,None,None,323.0,"
+      SELECT YEAR(`calcs`.`date2`) AS `temp_test__1720545932__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1972
+1974
+1976
+1977
+1980
+1988
+1994
+1995
+1997
+1998
+2001
+2002","1972
+1974
+1976
+1977
+1980
+1988
+1994
+1995
+1997
+1998
+2001
+2002"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.year.txt,True,0,0,"DATEPART('year', [datetime0], 'monday')",expression,,None,None,332.0,"
+      SELECT YEAR(`calcs`.`datetime0`) AS `temp_test__2707942807__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",2004,2004
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.sow.year.txt,True,0,0,"DATEPART('year', [datetime0], 'sunday')",expression,,None,None,306.0,"
+      SELECT YEAR(`calcs`.`datetime0`) AS `temp_test__3474280307__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",2004,2004
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.week.txt,True,0,0,"DATEPART('week', [date2])",expression,,None,None,316.0,"
+      SELECT FLOOR((14 + DATEDIFF(`calcs`.`date2`, TRUNC(`calcs`.`date2`,'YY')) + DATEDIFF(TRUNC(`calcs`.`date2`,'YY'),NEXT_DAY(TRUNC(`calcs`.`date2`,'YY'),'SU')))/7) AS `temp_test__3370976929__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","2
+6
+7
+12
+17
+18
+22
+23
+29
+30
+33
+36
+37
+38
+45","2
+6
+7
+12
+17
+18
+22
+23
+29
+30
+33
+36
+37
+38
+45"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.week.txt,True,0,0,"DATEPART('week', DATE([date3]))",expression,,None,None,434.0,"
+      SELECT FLOOR((14 + DATEDIFF(CAST(CAST(`calcs`.`date3` AS TIMESTAMP) AS DATE), TRUNC(CAST(CAST(`calcs`.`date3` AS TIMESTAMP) AS DATE),'YY')) + DATEDIFF(TRUNC(CAST(CAST(`calcs`.`date3` AS TIMESTAMP) AS DATE),'YY'),NEXT_DAY(TRUNC(CAST(CAST(`calcs`.`date3` AS TIMESTAMP) AS DATE),'YY'),'SU')))/7) AS `temp_test__2942029924__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+3
+6
+10
+12
+14
+20
+22
+34
+45","%null%
+3
+6
+10
+12
+14
+20
+22
+34
+45"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.week.txt,True,0,0,"DATEPART('week', [datetime0])",expression,,None,None,393.0,"
+      SELECT FLOOR((14 + DATEDIFF(`calcs`.`datetime0`, TRUNC(`calcs`.`datetime0`,'YY')) + DATEDIFF(TRUNC(`calcs`.`datetime0`,'YY'),NEXT_DAY(TRUNC(`calcs`.`datetime0`,'YY'),'SU')))/7) AS `temp_test__3904538922__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","28
+29
+30
+31
+32","28
+29
+30
+31
+32"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.weekday.txt,True,0,0,"DATEPART('weekday', [date2])",expression,,None,None,341.0,"
+      SELECT (8 + DATEDIFF(`calcs`.`date2`,NEXT_DAY(CAST(`calcs`.`date2` AS DATE),'SU'))) AS `temp_test__3854194266__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+3
+4
+5
+6
+7","1
+3
+4
+5
+6
+7"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.weekday.txt,True,0,0,"DATEPART('weekday', [datetime0])",expression,,None,None,339.0,"
+      SELECT (8 + DATEDIFF(`calcs`.`datetime0`,NEXT_DAY(CAST(`calcs`.`datetime0` AS DATE),'SU'))) AS `temp_test__621889678__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+2
+4
+5
+6
+7","1
+2
+4
+5
+6
+7"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.year.txt,True,0,0,"DATEPART('year', [date2])",expression,,None,None,327.0,"
+      SELECT YEAR(`calcs`.`date2`) AS `temp_test__3969685894__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1972
+1974
+1976
+1977
+1980
+1988
+1994
+1995
+1997
+1998
+2001
+2002","1972
+1974
+1976
+1977
+1980
+1988
+1994
+1995
+1997
+1998
+2001
+2002"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datepart.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datepart.year.txt,True,0,0,"DATEPART('year', [datetime0])",expression,,None,None,322.0,"
+      SELECT YEAR(`calcs`.`datetime0`) AS `temp_test__4179095987__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",2004,2004
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.day.txt,True,0,0,"DATETRUNC('day', [date2])",expression,,None,None,333.0,"
+      SELECT CAST(TO_DATE(`calcs`.`date2`) AS DATE) AS `temp_test__591126205__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.day.txt,True,0,0,"DATETRUNC('day', [datetime0])",expression,,None,None,324.0,"
+      SELECT CAST(TO_DATE(`calcs`.`datetime0`) AS DATE) AS `temp_test__3034828475__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.dayofyear.txt,True,0,0,"DATETRUNC('dayofyear', [date2])",expression,,None,None,342.0,"
+      SELECT CAST (`calcs`.`date2` AS DATE) AS `temp_test__402015915__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.dayofyear.txt,True,0,0,"DATETRUNC('dayofyear', [datetime0])",expression,,None,None,311.0,"
+      SELECT CAST (`calcs`.`datetime0` AS DATE) AS `temp_test__3033426574__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.hour,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.hour.txt,True,0,0,"DATETRUNC('hour', [datetime0])",expression,,None,None,337.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(`calcs`.`datetime0`), 'yyyy-MM-dd HH:00:00') AS TIMESTAMP) AS `temp_test__2456153780__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 22:00:00#
+#2004-07-05 13:00:00#
+#2004-07-09 10:00:00#
+#2004-07-12 17:00:00#
+#2004-07-14 07:00:00#
+#2004-07-14 08:00:00#
+#2004-07-17 14:00:00#
+#2004-07-19 22:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 21:00:00#
+#2004-07-25 15:00:00#
+#2004-07-26 12:00:00#
+#2004-07-28 06:00:00#
+#2004-07-28 12:00:00#
+#2004-07-28 23:00:00#
+#2004-07-31 11:00:00#
+#2004-08-02 07:00:00#","#2004-07-04 22:00:00#
+#2004-07-05 13:00:00#
+#2004-07-09 10:00:00#
+#2004-07-12 17:00:00#
+#2004-07-14 07:00:00#
+#2004-07-14 08:00:00#
+#2004-07-17 14:00:00#
+#2004-07-19 22:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 21:00:00#
+#2004-07-25 15:00:00#
+#2004-07-26 12:00:00#
+#2004-07-28 06:00:00#
+#2004-07-28 12:00:00#
+#2004-07-28 23:00:00#
+#2004-07-31 11:00:00#
+#2004-08-02 07:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.minute,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.minute.txt,True,0,0,"DATETRUNC('minute', [datetime0])",expression,,None,None,325.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(`calcs`.`datetime0`), 'yyyy-MM-dd HH:mm:00') AS TIMESTAMP) AS `temp_test__1224905293__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 22:49:00#
+#2004-07-05 13:14:00#
+#2004-07-09 10:17:00#
+#2004-07-12 17:30:00#
+#2004-07-14 07:43:00#
+#2004-07-14 08:16:00#
+#2004-07-17 14:01:00#
+#2004-07-19 22:21:00#
+#2004-07-22 00:30:00#
+#2004-07-23 21:13:00#
+#2004-07-25 15:22:00#
+#2004-07-26 12:30:00#
+#2004-07-28 06:54:00#
+#2004-07-28 12:34:00#
+#2004-07-28 23:30:00#
+#2004-07-31 11:57:00#
+#2004-08-02 07:59:00#","#2004-07-04 22:49:00#
+#2004-07-05 13:14:00#
+#2004-07-09 10:17:00#
+#2004-07-12 17:30:00#
+#2004-07-14 07:43:00#
+#2004-07-14 08:16:00#
+#2004-07-17 14:01:00#
+#2004-07-19 22:21:00#
+#2004-07-22 00:30:00#
+#2004-07-23 21:13:00#
+#2004-07-25 15:22:00#
+#2004-07-26 12:30:00#
+#2004-07-28 06:54:00#
+#2004-07-28 12:34:00#
+#2004-07-28 23:30:00#
+#2004-07-31 11:57:00#
+#2004-08-02 07:59:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.month.txt,True,0,0,"DATETRUNC('month', [date2])",expression,,None,None,350.0,"
+      SELECT CAST(TRUNC(`calcs`.`date2`,'MM') AS DATE) AS `temp_test__296025979__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-01 00:00:00#
+#1974-03-01 00:00:00#
+#1974-05-01 00:00:00#
+#1976-09-01 00:00:00#
+#1977-02-01 00:00:00#
+#1977-04-01 00:00:00#
+#1980-07-01 00:00:00#
+#1980-11-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-04-01 00:00:00#
+#1995-06-01 00:00:00#
+#1995-09-01 00:00:00#
+#1997-05-01 00:00:00#
+#1997-09-01 00:00:00#
+#1998-08-01 00:00:00#
+#2001-02-01 00:00:00#
+#2002-04-01 00:00:00#","#1972-07-01 00:00:00#
+#1974-03-01 00:00:00#
+#1974-05-01 00:00:00#
+#1976-09-01 00:00:00#
+#1977-02-01 00:00:00#
+#1977-04-01 00:00:00#
+#1980-07-01 00:00:00#
+#1980-11-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-04-01 00:00:00#
+#1995-06-01 00:00:00#
+#1995-09-01 00:00:00#
+#1997-05-01 00:00:00#
+#1997-09-01 00:00:00#
+#1998-08-01 00:00:00#
+#2001-02-01 00:00:00#
+#2002-04-01 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.month.txt,True,0,0,"DATETRUNC('month', [datetime0])",expression,,None,None,323.0,"
+      SELECT CAST(TRUNC(`calcs`.`datetime0`,'MM') AS DATE) AS `temp_test__595744937__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-01 00:00:00#
+#2004-08-01 00:00:00#","#2004-07-01 00:00:00#
+#2004-08-01 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('year', DATE(null))",expression,,None,None,307.0,"
+      SELECT CAST(TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY') AS DATE) AS `temp_test__1773778045__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('year', DATETIME(null))",expression,,None,None,296.0,"
+      SELECT CAST(TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY') AS DATE) AS `temp_test__382789366__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('month', DATE(null))",expression,,None,None,302.0,"
+      SELECT CAST(TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'MM') AS DATE) AS `temp_test__444902156__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('month', DATETIME(null))",expression,,None,None,299.0,"
+      SELECT CAST(TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'MM') AS DATE) AS `temp_test__581676997__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('quarter', DATE(null))",expression,,None,None,304.0,"
+      SELECT CAST(CONCAT(YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)), (CASE WHEN MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))<4 THEN '-01'  WHEN MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))<7 THEN '-04'  WHEN MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))<10 THEN '-07'  ELSE '-10' END), '-01 00:00:00') AS TIMESTAMP) AS `temp_test__1831450015__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('quarter', DATETIME(null))",expression,,None,None,311.0,"
+      SELECT CAST(CONCAT(YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)), (CASE WHEN MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP))<4 THEN '-01'  WHEN MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP))<7 THEN '-04'  WHEN MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP))<10 THEN '-07'  ELSE '-10' END), '-01 00:00:00') AS TIMESTAMP) AS `temp_test__360201683__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('week', DATE(null))",expression,,None,None,311.0,"
+      SELECT CAST(DATE_ADD(NEXT_DAY(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'SU'),-7) AS DATE) AS `temp_test__872678106__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('week', DATETIME(null))",expression,,None,None,305.0,"
+      SELECT CAST(DATE_ADD(NEXT_DAY(CAST(CAST(NULL AS INT) AS TIMESTAMP),'SU'),-7) AS DATE) AS `temp_test__3905701997__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('weekday', DATE(null))",expression,,None,None,301.0,"
+      SELECT CAST (CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS DATE) AS `temp_test__3359079369__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('weekday', DATETIME(null))",expression,,None,None,318.0,"
+      SELECT CAST (CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS `temp_test__1326289938__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('day', DATE(null))",expression,,None,None,352.0,"
+      SELECT CAST(TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS DATE) AS `temp_test__2763829899__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('day', DATETIME(null))",expression,,None,None,312.0,"
+      SELECT CAST(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS DATE) AS `temp_test__717997108__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('dayofyear', DATE(null))",expression,,None,None,323.0,"
+      SELECT CAST (CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS DATE) AS `temp_test__2963633898__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('dayofyear', DATETIME(null))",expression,,None,None,287.0,"
+      SELECT CAST (CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS `temp_test__3202209617__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('hour', DATETIME(null))",expression,,None,None,306.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 'yyyy-MM-dd HH:00:00') AS TIMESTAMP) AS `temp_test__4266496460__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('second', DATETIME(null))",expression,,None,None,297.0,"
+      SELECT CAST(CAST(NULL AS INT) AS TIMESTAMP) AS `temp_test__4131996060__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.nulls.txt,True,0,0,"DATETRUNC('minute', DATETIME(null))",expression,,None,None,302.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 'yyyy-MM-dd HH:mm:00') AS TIMESTAMP) AS `temp_test__2935754523__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.quarter.txt,True,0,0,"DATETRUNC('quarter', [date2])",expression,,None,None,357.0,"
+      SELECT CAST(CONCAT(YEAR(`calcs`.`date2`), (CASE WHEN MONTH(`calcs`.`date2`)<4 THEN '-01'  WHEN MONTH(`calcs`.`date2`)<7 THEN '-04'  WHEN MONTH(`calcs`.`date2`)<10 THEN '-07'  ELSE '-10' END), '-01 00:00:00') AS TIMESTAMP) AS `temp_test__1126788499__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-01 00:00:00#
+#1974-01-01 00:00:00#
+#1974-04-01 00:00:00#
+#1976-07-01 00:00:00#
+#1977-01-01 00:00:00#
+#1977-04-01 00:00:00#
+#1980-07-01 00:00:00#
+#1980-10-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-04-01 00:00:00#
+#1995-04-01 00:00:00#
+#1995-07-01 00:00:00#
+#1997-04-01 00:00:00#
+#1997-07-01 00:00:00#
+#1998-07-01 00:00:00#
+#2001-01-01 00:00:00#
+#2002-04-01 00:00:00#","#1972-07-01 00:00:00#
+#1974-01-01 00:00:00#
+#1974-04-01 00:00:00#
+#1976-07-01 00:00:00#
+#1977-01-01 00:00:00#
+#1977-04-01 00:00:00#
+#1980-07-01 00:00:00#
+#1980-10-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-04-01 00:00:00#
+#1995-04-01 00:00:00#
+#1995-07-01 00:00:00#
+#1997-04-01 00:00:00#
+#1997-07-01 00:00:00#
+#1998-07-01 00:00:00#
+#2001-01-01 00:00:00#
+#2002-04-01 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.quarter.txt,True,0,0,"DATETRUNC('quarter', [datetime0])",expression,,None,None,340.0,"
+      SELECT CAST(CONCAT(YEAR(`calcs`.`datetime0`), (CASE WHEN MONTH(`calcs`.`datetime0`)<4 THEN '-01'  WHEN MONTH(`calcs`.`datetime0`)<7 THEN '-04'  WHEN MONTH(`calcs`.`datetime0`)<10 THEN '-07'  ELSE '-10' END), '-01 00:00:00') AS TIMESTAMP) AS `temp_test__3855281255__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",#2004-07-01 00:00:00#,#2004-07-01 00:00:00#
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.second,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.second.txt,True,0,0,"DATETRUNC('second', [datetime0])",expression,,None,None,302.0,"
+      SELECT `calcs`.`datetime0` AS `temp_test__3300724379__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 22:49:28#
+#2004-07-05 13:14:20#
+#2004-07-09 10:17:35#
+#2004-07-12 17:30:16#
+#2004-07-14 07:43:00#
+#2004-07-14 08:16:44#
+#2004-07-17 14:01:56#
+#2004-07-19 22:21:31#
+#2004-07-22 00:30:23#
+#2004-07-23 21:13:37#
+#2004-07-25 15:22:26#
+#2004-07-26 12:30:34#
+#2004-07-28 06:54:50#
+#2004-07-28 12:34:28#
+#2004-07-28 23:30:22#
+#2004-07-31 11:57:52#
+#2004-08-02 07:59:23#","#2004-07-04 22:49:28#
+#2004-07-05 13:14:20#
+#2004-07-09 10:17:35#
+#2004-07-12 17:30:16#
+#2004-07-14 07:43:00#
+#2004-07-14 08:16:44#
+#2004-07-17 14:01:56#
+#2004-07-19 22:21:31#
+#2004-07-22 00:30:23#
+#2004-07-23 21:13:37#
+#2004-07-25 15:22:26#
+#2004-07-26 12:30:34#
+#2004-07-28 06:54:50#
+#2004-07-28 12:34:28#
+#2004-07-28 23:30:22#
+#2004-07-31 11:57:52#
+#2004-08-02 07:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.day.txt,True,0,0,"DATETRUNC('day', [date2], 'monday')",expression,,None,None,361.0,"
+      SELECT CAST(TO_DATE(`calcs`.`date2`) AS DATE) AS `temp_test__3738830082__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.day.txt,True,0,0,"DATETRUNC('day', [date2], 'sunday')",expression,,None,None,303.0,"
+      SELECT CAST(TO_DATE(`calcs`.`date2`) AS DATE) AS `temp_test__151653785__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.day.txt,True,0,0,"DATETRUNC('day', [datetime0], 'monday')",expression,,None,None,297.0,"
+      SELECT CAST(TO_DATE(`calcs`.`datetime0`) AS DATE) AS `temp_test__1373895161__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.day,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.day.txt,True,0,0,"DATETRUNC('day', [datetime0], 'sunday')",expression,,None,None,314.0,"
+      SELECT CAST(TO_DATE(`calcs`.`datetime0`) AS DATE) AS `temp_test__543203842__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.dayofyear.txt,True,0,0,"DATETRUNC('dayofyear', [date2], 'monday')",expression,,None,None,304.0,"
+      SELECT CAST (`calcs`.`date2` AS DATE) AS `temp_test__1942031084__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.dayofyear.txt,True,0,0,"DATETRUNC('dayofyear', [date2], 'sunday')",expression,,None,None,318.0,"
+      SELECT CAST (`calcs`.`date2` AS DATE) AS `temp_test__308042462__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.dayofyear.txt,True,0,0,"DATETRUNC('dayofyear', [datetime0], 'monday')",expression,,None,None,333.0,"
+      SELECT CAST (`calcs`.`datetime0` AS DATE) AS `temp_test__1290354772__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.dayofyear,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.dayofyear.txt,True,0,0,"DATETRUNC('dayofyear', [datetime0], 'sunday')",expression,,None,None,402.0,"
+      SELECT CAST (`calcs`.`datetime0` AS DATE) AS `temp_test__2022110629__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.hour,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.hour.txt,True,0,0,"DATETRUNC('hour', [datetime0], 'monday')",expression,,None,None,317.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(`calcs`.`datetime0`), 'yyyy-MM-dd HH:00:00') AS TIMESTAMP) AS `temp_test__2793013592__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 22:00:00#
+#2004-07-05 13:00:00#
+#2004-07-09 10:00:00#
+#2004-07-12 17:00:00#
+#2004-07-14 07:00:00#
+#2004-07-14 08:00:00#
+#2004-07-17 14:00:00#
+#2004-07-19 22:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 21:00:00#
+#2004-07-25 15:00:00#
+#2004-07-26 12:00:00#
+#2004-07-28 06:00:00#
+#2004-07-28 12:00:00#
+#2004-07-28 23:00:00#
+#2004-07-31 11:00:00#
+#2004-08-02 07:00:00#","#2004-07-04 22:00:00#
+#2004-07-05 13:00:00#
+#2004-07-09 10:00:00#
+#2004-07-12 17:00:00#
+#2004-07-14 07:00:00#
+#2004-07-14 08:00:00#
+#2004-07-17 14:00:00#
+#2004-07-19 22:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 21:00:00#
+#2004-07-25 15:00:00#
+#2004-07-26 12:00:00#
+#2004-07-28 06:00:00#
+#2004-07-28 12:00:00#
+#2004-07-28 23:00:00#
+#2004-07-31 11:00:00#
+#2004-08-02 07:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.hour,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.hour.txt,True,0,0,"DATETRUNC('hour', [datetime0], 'sunday')",expression,,None,None,336.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(`calcs`.`datetime0`), 'yyyy-MM-dd HH:00:00') AS TIMESTAMP) AS `temp_test__2980130610__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 22:00:00#
+#2004-07-05 13:00:00#
+#2004-07-09 10:00:00#
+#2004-07-12 17:00:00#
+#2004-07-14 07:00:00#
+#2004-07-14 08:00:00#
+#2004-07-17 14:00:00#
+#2004-07-19 22:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 21:00:00#
+#2004-07-25 15:00:00#
+#2004-07-26 12:00:00#
+#2004-07-28 06:00:00#
+#2004-07-28 12:00:00#
+#2004-07-28 23:00:00#
+#2004-07-31 11:00:00#
+#2004-08-02 07:00:00#","#2004-07-04 22:00:00#
+#2004-07-05 13:00:00#
+#2004-07-09 10:00:00#
+#2004-07-12 17:00:00#
+#2004-07-14 07:00:00#
+#2004-07-14 08:00:00#
+#2004-07-17 14:00:00#
+#2004-07-19 22:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 21:00:00#
+#2004-07-25 15:00:00#
+#2004-07-26 12:00:00#
+#2004-07-28 06:00:00#
+#2004-07-28 12:00:00#
+#2004-07-28 23:00:00#
+#2004-07-31 11:00:00#
+#2004-08-02 07:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.minute,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.minute.txt,True,0,0,"DATETRUNC('minute', [datetime0], 'monday')",expression,,None,None,295.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(`calcs`.`datetime0`), 'yyyy-MM-dd HH:mm:00') AS TIMESTAMP) AS `temp_test__1349416314__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 22:49:00#
+#2004-07-05 13:14:00#
+#2004-07-09 10:17:00#
+#2004-07-12 17:30:00#
+#2004-07-14 07:43:00#
+#2004-07-14 08:16:00#
+#2004-07-17 14:01:00#
+#2004-07-19 22:21:00#
+#2004-07-22 00:30:00#
+#2004-07-23 21:13:00#
+#2004-07-25 15:22:00#
+#2004-07-26 12:30:00#
+#2004-07-28 06:54:00#
+#2004-07-28 12:34:00#
+#2004-07-28 23:30:00#
+#2004-07-31 11:57:00#
+#2004-08-02 07:59:00#","#2004-07-04 22:49:00#
+#2004-07-05 13:14:00#
+#2004-07-09 10:17:00#
+#2004-07-12 17:30:00#
+#2004-07-14 07:43:00#
+#2004-07-14 08:16:00#
+#2004-07-17 14:01:00#
+#2004-07-19 22:21:00#
+#2004-07-22 00:30:00#
+#2004-07-23 21:13:00#
+#2004-07-25 15:22:00#
+#2004-07-26 12:30:00#
+#2004-07-28 06:54:00#
+#2004-07-28 12:34:00#
+#2004-07-28 23:30:00#
+#2004-07-31 11:57:00#
+#2004-08-02 07:59:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.minute,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.minute.txt,True,0,0,"DATETRUNC('minute', [datetime0], 'sunday')",expression,,None,None,298.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(`calcs`.`datetime0`), 'yyyy-MM-dd HH:mm:00') AS TIMESTAMP) AS `temp_test__3032747293__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 22:49:00#
+#2004-07-05 13:14:00#
+#2004-07-09 10:17:00#
+#2004-07-12 17:30:00#
+#2004-07-14 07:43:00#
+#2004-07-14 08:16:00#
+#2004-07-17 14:01:00#
+#2004-07-19 22:21:00#
+#2004-07-22 00:30:00#
+#2004-07-23 21:13:00#
+#2004-07-25 15:22:00#
+#2004-07-26 12:30:00#
+#2004-07-28 06:54:00#
+#2004-07-28 12:34:00#
+#2004-07-28 23:30:00#
+#2004-07-31 11:57:00#
+#2004-08-02 07:59:00#","#2004-07-04 22:49:00#
+#2004-07-05 13:14:00#
+#2004-07-09 10:17:00#
+#2004-07-12 17:30:00#
+#2004-07-14 07:43:00#
+#2004-07-14 08:16:00#
+#2004-07-17 14:01:00#
+#2004-07-19 22:21:00#
+#2004-07-22 00:30:00#
+#2004-07-23 21:13:00#
+#2004-07-25 15:22:00#
+#2004-07-26 12:30:00#
+#2004-07-28 06:54:00#
+#2004-07-28 12:34:00#
+#2004-07-28 23:30:00#
+#2004-07-31 11:57:00#
+#2004-08-02 07:59:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.month.txt,True,0,0,"DATETRUNC('month', [date2], 'monday')",expression,,None,None,357.0,"
+      SELECT CAST(TRUNC(`calcs`.`date2`,'MM') AS DATE) AS `temp_test__3415515666__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-01 00:00:00#
+#1974-03-01 00:00:00#
+#1974-05-01 00:00:00#
+#1976-09-01 00:00:00#
+#1977-02-01 00:00:00#
+#1977-04-01 00:00:00#
+#1980-07-01 00:00:00#
+#1980-11-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-04-01 00:00:00#
+#1995-06-01 00:00:00#
+#1995-09-01 00:00:00#
+#1997-05-01 00:00:00#
+#1997-09-01 00:00:00#
+#1998-08-01 00:00:00#
+#2001-02-01 00:00:00#
+#2002-04-01 00:00:00#","#1972-07-01 00:00:00#
+#1974-03-01 00:00:00#
+#1974-05-01 00:00:00#
+#1976-09-01 00:00:00#
+#1977-02-01 00:00:00#
+#1977-04-01 00:00:00#
+#1980-07-01 00:00:00#
+#1980-11-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-04-01 00:00:00#
+#1995-06-01 00:00:00#
+#1995-09-01 00:00:00#
+#1997-05-01 00:00:00#
+#1997-09-01 00:00:00#
+#1998-08-01 00:00:00#
+#2001-02-01 00:00:00#
+#2002-04-01 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.month.txt,True,0,0,"DATETRUNC('month', [date2], 'sunday')",expression,,None,None,297.0,"
+      SELECT CAST(TRUNC(`calcs`.`date2`,'MM') AS DATE) AS `temp_test__2048935536__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-01 00:00:00#
+#1974-03-01 00:00:00#
+#1974-05-01 00:00:00#
+#1976-09-01 00:00:00#
+#1977-02-01 00:00:00#
+#1977-04-01 00:00:00#
+#1980-07-01 00:00:00#
+#1980-11-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-04-01 00:00:00#
+#1995-06-01 00:00:00#
+#1995-09-01 00:00:00#
+#1997-05-01 00:00:00#
+#1997-09-01 00:00:00#
+#1998-08-01 00:00:00#
+#2001-02-01 00:00:00#
+#2002-04-01 00:00:00#","#1972-07-01 00:00:00#
+#1974-03-01 00:00:00#
+#1974-05-01 00:00:00#
+#1976-09-01 00:00:00#
+#1977-02-01 00:00:00#
+#1977-04-01 00:00:00#
+#1980-07-01 00:00:00#
+#1980-11-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-04-01 00:00:00#
+#1995-06-01 00:00:00#
+#1995-09-01 00:00:00#
+#1997-05-01 00:00:00#
+#1997-09-01 00:00:00#
+#1998-08-01 00:00:00#
+#2001-02-01 00:00:00#
+#2002-04-01 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.month.txt,True,0,0,"DATETRUNC('month', [datetime0], 'monday')",expression,,None,None,321.0,"
+      SELECT CAST(TRUNC(`calcs`.`datetime0`,'MM') AS DATE) AS `temp_test__2714077903__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-01 00:00:00#
+#2004-08-01 00:00:00#","#2004-07-01 00:00:00#
+#2004-08-01 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.month,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.month.txt,True,0,0,"DATETRUNC('month', [datetime0], 'sunday')",expression,,None,None,319.0,"
+      SELECT CAST(TRUNC(`calcs`.`datetime0`,'MM') AS DATE) AS `temp_test__1800100416__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-01 00:00:00#
+#2004-08-01 00:00:00#","#2004-07-01 00:00:00#
+#2004-08-01 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('year', DATE(null), 'sunday')",expression,,None,None,308.0,"
+      SELECT CAST(TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'YY') AS DATE) AS `temp_test__3311335472__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('year', DATETIME(null), 'sunday')",expression,,None,None,331.0,"
+      SELECT CAST(TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'YY') AS DATE) AS `temp_test__1982106892__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('quarter', DATE(null), 'sunday')",expression,,None,None,303.0,"
+      SELECT CAST(CONCAT(YEAR(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)), (CASE WHEN MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))<4 THEN '-01'  WHEN MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))<7 THEN '-04'  WHEN MONTH(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE))<10 THEN '-07'  ELSE '-10' END), '-01 00:00:00') AS TIMESTAMP) AS `temp_test__2616948526__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('quarter', DATETIME(null), 'sunday')",expression,,None,None,301.0,"
+      SELECT CAST(CONCAT(YEAR(CAST(CAST(NULL AS INT) AS TIMESTAMP)), (CASE WHEN MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP))<4 THEN '-01'  WHEN MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP))<7 THEN '-04'  WHEN MONTH(CAST(CAST(NULL AS INT) AS TIMESTAMP))<10 THEN '-07'  ELSE '-10' END), '-01 00:00:00') AS TIMESTAMP) AS `temp_test__4099405891__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('month', DATE(null), 'sunday')",expression,,None,None,342.0,"
+      SELECT CAST(TRUNC(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'MM') AS DATE) AS `temp_test__1303420554__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('month', DATETIME(null), 'sunday')",expression,,None,None,311.0,"
+      SELECT CAST(TRUNC(CAST(CAST(NULL AS INT) AS TIMESTAMP),'MM') AS DATE) AS `temp_test__1705284026__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('week', DATETIME(null), 'sunday')",expression,,None,None,311.0,"
+      SELECT CAST(DATE_ADD(NEXT_DAY(CAST(CAST(NULL AS INT) AS TIMESTAMP),'SU'),-7) AS DATE) AS `temp_test__2964540366__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('week', DATE(null), 'sunday')",expression,,None,None,332.0,"
+      SELECT CAST(DATE_ADD(NEXT_DAY(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE),'SU'),-7) AS DATE) AS `temp_test__3523871008__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('weekday', DATETIME(null), 'sunday')",expression,,None,None,288.0,"
+      SELECT CAST (CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS `temp_test__3587526928__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('weekday', DATE(null), 'sunday')",expression,,None,None,296.0,"
+      SELECT CAST (CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS DATE) AS `temp_test__2715649251__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('day', DATE(null), 'sunday')",expression,,None,None,291.0,"
+      SELECT CAST(TO_DATE(CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE)) AS DATE) AS `temp_test__3912893816__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('day', DATETIME(null), 'sunday')",expression,,None,None,298.0,"
+      SELECT CAST(TO_DATE(CAST(CAST(NULL AS INT) AS TIMESTAMP)) AS DATE) AS `temp_test__453060606__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('dayofyear', DATE(null), 'sunday')",expression,,None,None,302.0,"
+      SELECT CAST (CAST(CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS DATE) AS `temp_test__1466575961__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('dayofyear', DATETIME(null), 'sunday')",expression,,None,None,298.0,"
+      SELECT CAST (CAST(CAST(NULL AS INT) AS TIMESTAMP) AS DATE) AS `temp_test__265878863__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('hour', DATETIME(null), 'sunday')",expression,,None,None,298.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 'yyyy-MM-dd HH:00:00') AS TIMESTAMP) AS `temp_test__3877847632__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('minute', DATETIME(null), 'sunday')",expression,,None,None,284.0,"
+      SELECT CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(CAST(CAST(NULL AS INT) AS TIMESTAMP)), 'yyyy-MM-dd HH:mm:00') AS TIMESTAMP) AS `temp_test__263614731__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.nulls,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.nulls.txt,True,0,0,"DATETRUNC('second', DATETIME(null), 'sunday')",expression,,None,None,292.0,"
+      SELECT CAST(CAST(NULL AS INT) AS TIMESTAMP) AS `temp_test__864002214__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.quarter.txt,True,0,0,"DATETRUNC('quarter', [date2], 'monday')",expression,,None,None,331.0,"
+      SELECT CAST(CONCAT(YEAR(`calcs`.`date2`), (CASE WHEN MONTH(`calcs`.`date2`)<4 THEN '-01'  WHEN MONTH(`calcs`.`date2`)<7 THEN '-04'  WHEN MONTH(`calcs`.`date2`)<10 THEN '-07'  ELSE '-10' END), '-01 00:00:00') AS TIMESTAMP) AS `temp_test__4146692480__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-01 00:00:00#
+#1974-01-01 00:00:00#
+#1974-04-01 00:00:00#
+#1976-07-01 00:00:00#
+#1977-01-01 00:00:00#
+#1977-04-01 00:00:00#
+#1980-07-01 00:00:00#
+#1980-10-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-04-01 00:00:00#
+#1995-04-01 00:00:00#
+#1995-07-01 00:00:00#
+#1997-04-01 00:00:00#
+#1997-07-01 00:00:00#
+#1998-07-01 00:00:00#
+#2001-01-01 00:00:00#
+#2002-04-01 00:00:00#","#1972-07-01 00:00:00#
+#1974-01-01 00:00:00#
+#1974-04-01 00:00:00#
+#1976-07-01 00:00:00#
+#1977-01-01 00:00:00#
+#1977-04-01 00:00:00#
+#1980-07-01 00:00:00#
+#1980-10-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-04-01 00:00:00#
+#1995-04-01 00:00:00#
+#1995-07-01 00:00:00#
+#1997-04-01 00:00:00#
+#1997-07-01 00:00:00#
+#1998-07-01 00:00:00#
+#2001-01-01 00:00:00#
+#2002-04-01 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.quarter.txt,True,0,0,"DATETRUNC('quarter', [date2], 'sunday')",expression,,None,None,305.0,"
+      SELECT CAST(CONCAT(YEAR(`calcs`.`date2`), (CASE WHEN MONTH(`calcs`.`date2`)<4 THEN '-01'  WHEN MONTH(`calcs`.`date2`)<7 THEN '-04'  WHEN MONTH(`calcs`.`date2`)<10 THEN '-07'  ELSE '-10' END), '-01 00:00:00') AS TIMESTAMP) AS `temp_test__560528826__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-01 00:00:00#
+#1974-01-01 00:00:00#
+#1974-04-01 00:00:00#
+#1976-07-01 00:00:00#
+#1977-01-01 00:00:00#
+#1977-04-01 00:00:00#
+#1980-07-01 00:00:00#
+#1980-10-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-04-01 00:00:00#
+#1995-04-01 00:00:00#
+#1995-07-01 00:00:00#
+#1997-04-01 00:00:00#
+#1997-07-01 00:00:00#
+#1998-07-01 00:00:00#
+#2001-01-01 00:00:00#
+#2002-04-01 00:00:00#","#1972-07-01 00:00:00#
+#1974-01-01 00:00:00#
+#1974-04-01 00:00:00#
+#1976-07-01 00:00:00#
+#1977-01-01 00:00:00#
+#1977-04-01 00:00:00#
+#1980-07-01 00:00:00#
+#1980-10-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-04-01 00:00:00#
+#1995-04-01 00:00:00#
+#1995-07-01 00:00:00#
+#1997-04-01 00:00:00#
+#1997-07-01 00:00:00#
+#1998-07-01 00:00:00#
+#2001-01-01 00:00:00#
+#2002-04-01 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.quarter.txt,True,0,0,"DATETRUNC('quarter', [datetime0], 'monday')",expression,,None,None,374.0,"
+      SELECT CAST(CONCAT(YEAR(`calcs`.`datetime0`), (CASE WHEN MONTH(`calcs`.`datetime0`)<4 THEN '-01'  WHEN MONTH(`calcs`.`datetime0`)<7 THEN '-04'  WHEN MONTH(`calcs`.`datetime0`)<10 THEN '-07'  ELSE '-10' END), '-01 00:00:00') AS TIMESTAMP) AS `temp_test__105511240__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",#2004-07-01 00:00:00#,#2004-07-01 00:00:00#
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.quarter,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.quarter.txt,True,0,0,"DATETRUNC('quarter', [datetime0], 'sunday')",expression,,None,None,312.0,"
+      SELECT CAST(CONCAT(YEAR(`calcs`.`datetime0`), (CASE WHEN MONTH(`calcs`.`datetime0`)<4 THEN '-01'  WHEN MONTH(`calcs`.`datetime0`)<7 THEN '-04'  WHEN MONTH(`calcs`.`datetime0`)<10 THEN '-07'  ELSE '-10' END), '-01 00:00:00') AS TIMESTAMP) AS `temp_test__755301458__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",#2004-07-01 00:00:00#,#2004-07-01 00:00:00#
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.second,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.second.txt,True,0,0,"DATETRUNC('second', [datetime0], 'monday')",expression,,None,None,319.0,"
+      SELECT `calcs`.`datetime0` AS `temp_test__4192719501__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 22:49:28#
+#2004-07-05 13:14:20#
+#2004-07-09 10:17:35#
+#2004-07-12 17:30:16#
+#2004-07-14 07:43:00#
+#2004-07-14 08:16:44#
+#2004-07-17 14:01:56#
+#2004-07-19 22:21:31#
+#2004-07-22 00:30:23#
+#2004-07-23 21:13:37#
+#2004-07-25 15:22:26#
+#2004-07-26 12:30:34#
+#2004-07-28 06:54:50#
+#2004-07-28 12:34:28#
+#2004-07-28 23:30:22#
+#2004-07-31 11:57:52#
+#2004-08-02 07:59:23#","#2004-07-04 22:49:28#
+#2004-07-05 13:14:20#
+#2004-07-09 10:17:35#
+#2004-07-12 17:30:16#
+#2004-07-14 07:43:00#
+#2004-07-14 08:16:44#
+#2004-07-17 14:01:56#
+#2004-07-19 22:21:31#
+#2004-07-22 00:30:23#
+#2004-07-23 21:13:37#
+#2004-07-25 15:22:26#
+#2004-07-26 12:30:34#
+#2004-07-28 06:54:50#
+#2004-07-28 12:34:28#
+#2004-07-28 23:30:22#
+#2004-07-31 11:57:52#
+#2004-08-02 07:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.second,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.second.txt,True,0,0,"DATETRUNC('second', [datetime0], 'sunday')",expression,,None,None,310.0,"
+      SELECT `calcs`.`datetime0` AS `temp_test__2927274352__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 22:49:28#
+#2004-07-05 13:14:20#
+#2004-07-09 10:17:35#
+#2004-07-12 17:30:16#
+#2004-07-14 07:43:00#
+#2004-07-14 08:16:44#
+#2004-07-17 14:01:56#
+#2004-07-19 22:21:31#
+#2004-07-22 00:30:23#
+#2004-07-23 21:13:37#
+#2004-07-25 15:22:26#
+#2004-07-26 12:30:34#
+#2004-07-28 06:54:50#
+#2004-07-28 12:34:28#
+#2004-07-28 23:30:22#
+#2004-07-31 11:57:52#
+#2004-08-02 07:59:23#","#2004-07-04 22:49:28#
+#2004-07-05 13:14:20#
+#2004-07-09 10:17:35#
+#2004-07-12 17:30:16#
+#2004-07-14 07:43:00#
+#2004-07-14 08:16:44#
+#2004-07-17 14:01:56#
+#2004-07-19 22:21:31#
+#2004-07-22 00:30:23#
+#2004-07-23 21:13:37#
+#2004-07-25 15:22:26#
+#2004-07-26 12:30:34#
+#2004-07-28 06:54:50#
+#2004-07-28 12:34:28#
+#2004-07-28 23:30:22#
+#2004-07-31 11:57:52#
+#2004-08-02 07:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.week.txt,True,0,0,"DATETRUNC('week', [date2], 'monday')",expression,,None,None,351.0,"
+      SELECT CAST(DATE_ADD(NEXT_DAY(`calcs`.`date2`,'MO'),-7) AS DATE) AS `temp_test__1744581337__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-10 00:00:00#
+#1974-03-11 00:00:00#
+#1974-04-29 00:00:00#
+#1976-09-06 00:00:00#
+#1977-02-07 00:00:00#
+#1977-04-18 00:00:00#
+#1980-07-21 00:00:00#
+#1980-11-03 00:00:00#
+#1988-01-04 00:00:00#
+#1994-04-18 00:00:00#
+#1995-05-29 00:00:00#
+#1995-08-28 00:00:00#
+#1997-05-26 00:00:00#
+#1997-09-15 00:00:00#
+#1998-08-10 00:00:00#
+#2001-01-29 00:00:00#
+#2002-04-22 00:00:00#","#1972-07-10 00:00:00#
+#1974-03-11 00:00:00#
+#1974-04-29 00:00:00#
+#1976-09-06 00:00:00#
+#1977-02-07 00:00:00#
+#1977-04-18 00:00:00#
+#1980-07-21 00:00:00#
+#1980-11-03 00:00:00#
+#1988-01-04 00:00:00#
+#1994-04-18 00:00:00#
+#1995-05-29 00:00:00#
+#1995-08-28 00:00:00#
+#1997-05-26 00:00:00#
+#1997-09-15 00:00:00#
+#1998-08-10 00:00:00#
+#2001-01-29 00:00:00#
+#2002-04-22 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.week.txt,True,0,0,"DATETRUNC('week', [date2], 'sunday')",expression,,None,None,338.0,"
+      SELECT CAST(DATE_ADD(NEXT_DAY(`calcs`.`date2`,'SU'),-7) AS DATE) AS `temp_test__1635756518__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-09 00:00:00#
+#1974-03-17 00:00:00#
+#1974-04-28 00:00:00#
+#1976-09-05 00:00:00#
+#1977-02-06 00:00:00#
+#1977-04-17 00:00:00#
+#1980-07-20 00:00:00#
+#1980-11-02 00:00:00#
+#1988-01-03 00:00:00#
+#1994-04-17 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-25 00:00:00#
+#1997-09-14 00:00:00#
+#1998-08-09 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-21 00:00:00#","#1972-07-09 00:00:00#
+#1974-03-17 00:00:00#
+#1974-04-28 00:00:00#
+#1976-09-05 00:00:00#
+#1977-02-06 00:00:00#
+#1977-04-17 00:00:00#
+#1980-07-20 00:00:00#
+#1980-11-02 00:00:00#
+#1988-01-03 00:00:00#
+#1994-04-17 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-25 00:00:00#
+#1997-09-14 00:00:00#
+#1998-08-09 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-21 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.week.txt,True,0,0,"DATETRUNC('week', [datetime0], 'monday')",expression,,None,None,341.0,"
+      SELECT CAST(DATE_ADD(NEXT_DAY(`calcs`.`datetime0`,'MO'),-7) AS DATE) AS `temp_test__1985269479__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-06-28 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-26 00:00:00#
+#2004-08-02 00:00:00#","#2004-06-28 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-26 00:00:00#
+#2004-08-02 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.week.txt,True,0,0,"DATETRUNC('week', [datetime0], 'sunday')",expression,,None,None,333.0,"
+      SELECT CAST(DATE_ADD(NEXT_DAY(`calcs`.`datetime0`,'SU'),-7) AS DATE) AS `temp_test__3887385220__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 00:00:00#
+#2004-07-11 00:00:00#
+#2004-07-18 00:00:00#
+#2004-07-25 00:00:00#
+#2004-08-01 00:00:00#","#2004-07-04 00:00:00#
+#2004-07-11 00:00:00#
+#2004-07-18 00:00:00#
+#2004-07-25 00:00:00#
+#2004-08-01 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.weekday.txt,True,0,0,"DATETRUNC('weekday', [date2], 'monday')",expression,,None,None,351.0,"
+      SELECT CAST (`calcs`.`date2` AS DATE) AS `temp_test__2526477208__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.weekday.txt,True,0,0,"DATETRUNC('weekday', [date2], 'sunday')",expression,,None,None,310.0,"
+      SELECT CAST (`calcs`.`date2` AS DATE) AS `temp_test__2007354609__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.weekday.txt,True,0,0,"DATETRUNC('weekday', [datetime0], 'monday')",expression,,None,None,394.0,"
+      SELECT CAST (`calcs`.`datetime0` AS DATE) AS `temp_test__3928745396__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.weekday.txt,True,0,0,"DATETRUNC('weekday', [datetime0], 'sunday')",expression,,None,None,309.0,"
+      SELECT CAST (`calcs`.`datetime0` AS DATE) AS `temp_test__746880020__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.year.txt,True,0,0,"DATETRUNC('year', [date2], 'monday')",expression,,None,None,334.0,"
+      SELECT CAST(TRUNC(`calcs`.`date2`,'YY') AS DATE) AS `temp_test__433583207__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-01-01 00:00:00#
+#1974-01-01 00:00:00#
+#1976-01-01 00:00:00#
+#1977-01-01 00:00:00#
+#1980-01-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-01-01 00:00:00#
+#1995-01-01 00:00:00#
+#1997-01-01 00:00:00#
+#1998-01-01 00:00:00#
+#2001-01-01 00:00:00#
+#2002-01-01 00:00:00#","#1972-01-01 00:00:00#
+#1974-01-01 00:00:00#
+#1976-01-01 00:00:00#
+#1977-01-01 00:00:00#
+#1980-01-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-01-01 00:00:00#
+#1995-01-01 00:00:00#
+#1997-01-01 00:00:00#
+#1998-01-01 00:00:00#
+#2001-01-01 00:00:00#
+#2002-01-01 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.year.txt,True,0,0,"DATETRUNC('year', [date2], 'sunday')",expression,,None,None,413.0,"
+      SELECT CAST(TRUNC(`calcs`.`date2`,'YY') AS DATE) AS `temp_test__1289371916__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-01-01 00:00:00#
+#1974-01-01 00:00:00#
+#1976-01-01 00:00:00#
+#1977-01-01 00:00:00#
+#1980-01-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-01-01 00:00:00#
+#1995-01-01 00:00:00#
+#1997-01-01 00:00:00#
+#1998-01-01 00:00:00#
+#2001-01-01 00:00:00#
+#2002-01-01 00:00:00#","#1972-01-01 00:00:00#
+#1974-01-01 00:00:00#
+#1976-01-01 00:00:00#
+#1977-01-01 00:00:00#
+#1980-01-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-01-01 00:00:00#
+#1995-01-01 00:00:00#
+#1997-01-01 00:00:00#
+#1998-01-01 00:00:00#
+#2001-01-01 00:00:00#
+#2002-01-01 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.year.txt,True,0,0,"DATETRUNC('year', [datetime0], 'monday')",expression,,None,None,337.0,"
+      SELECT CAST(TRUNC(`calcs`.`datetime0`,'YY') AS DATE) AS `temp_test__3917841362__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",#2004-01-01 00:00:00#,#2004-01-01 00:00:00#
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.sow.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.sow.year.txt,True,0,0,"DATETRUNC('year', [datetime0], 'sunday')",expression,,None,None,304.0,"
+      SELECT CAST(TRUNC(`calcs`.`datetime0`,'YY') AS DATE) AS `temp_test__1921815362__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",#2004-01-01 00:00:00#,#2004-01-01 00:00:00#
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.week.txt,True,0,0,"DATETRUNC('week', [date2])",expression,,None,None,317.0,"
+      SELECT CAST(DATE_ADD(NEXT_DAY(`calcs`.`date2`,'SU'),-7) AS DATE) AS `temp_test__1630131013__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-09 00:00:00#
+#1974-03-17 00:00:00#
+#1974-04-28 00:00:00#
+#1976-09-05 00:00:00#
+#1977-02-06 00:00:00#
+#1977-04-17 00:00:00#
+#1980-07-20 00:00:00#
+#1980-11-02 00:00:00#
+#1988-01-03 00:00:00#
+#1994-04-17 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-25 00:00:00#
+#1997-09-14 00:00:00#
+#1998-08-09 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-21 00:00:00#","#1972-07-09 00:00:00#
+#1974-03-17 00:00:00#
+#1974-04-28 00:00:00#
+#1976-09-05 00:00:00#
+#1977-02-06 00:00:00#
+#1977-04-17 00:00:00#
+#1980-07-20 00:00:00#
+#1980-11-02 00:00:00#
+#1988-01-03 00:00:00#
+#1994-04-17 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-25 00:00:00#
+#1997-09-14 00:00:00#
+#1998-08-09 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-21 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.week,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.week.txt,True,0,0,"DATETRUNC('week', [datetime0])",expression,,None,None,336.0,"
+      SELECT CAST(DATE_ADD(NEXT_DAY(`calcs`.`datetime0`,'SU'),-7) AS DATE) AS `temp_test__3937478358__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 00:00:00#
+#2004-07-11 00:00:00#
+#2004-07-18 00:00:00#
+#2004-07-25 00:00:00#
+#2004-08-01 00:00:00#","#2004-07-04 00:00:00#
+#2004-07-11 00:00:00#
+#2004-07-18 00:00:00#
+#2004-07-25 00:00:00#
+#2004-08-01 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.weekday.txt,True,0,0,"DATETRUNC('weekday', [date2])",expression,,None,None,315.0,"
+      SELECT CAST (`calcs`.`date2` AS DATE) AS `temp_test__3715775174__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#","#1972-07-12 00:00:00#
+#1974-03-17 00:00:00#
+#1974-05-03 00:00:00#
+#1976-09-09 00:00:00#
+#1977-02-08 00:00:00#
+#1977-04-20 00:00:00#
+#1980-07-26 00:00:00#
+#1980-11-07 00:00:00#
+#1988-01-05 00:00:00#
+#1994-04-20 00:00:00#
+#1995-06-04 00:00:00#
+#1995-09-03 00:00:00#
+#1997-05-30 00:00:00#
+#1997-09-19 00:00:00#
+#1998-08-12 00:00:00#
+#2001-02-04 00:00:00#
+#2002-04-27 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.weekday,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.weekday.txt,True,0,0,"DATETRUNC('weekday', [datetime0])",expression,,None,None,322.0,"
+      SELECT CAST (`calcs`.`datetime0` AS DATE) AS `temp_test__2815480624__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#","#2004-07-04 00:00:00#
+#2004-07-05 00:00:00#
+#2004-07-09 00:00:00#
+#2004-07-12 00:00:00#
+#2004-07-14 00:00:00#
+#2004-07-17 00:00:00#
+#2004-07-19 00:00:00#
+#2004-07-22 00:00:00#
+#2004-07-23 00:00:00#
+#2004-07-25 00:00:00#
+#2004-07-26 00:00:00#
+#2004-07-28 00:00:00#
+#2004-07-31 00:00:00#
+#2004-08-02 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.year.txt,True,0,0,"DATETRUNC('year', [date2])",expression,,None,None,325.0,"
+      SELECT CAST(TRUNC(`calcs`.`date2`,'YY') AS DATE) AS `temp_test__3907469988__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-01-01 00:00:00#
+#1974-01-01 00:00:00#
+#1976-01-01 00:00:00#
+#1977-01-01 00:00:00#
+#1980-01-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-01-01 00:00:00#
+#1995-01-01 00:00:00#
+#1997-01-01 00:00:00#
+#1998-01-01 00:00:00#
+#2001-01-01 00:00:00#
+#2002-01-01 00:00:00#","#1972-01-01 00:00:00#
+#1974-01-01 00:00:00#
+#1976-01-01 00:00:00#
+#1977-01-01 00:00:00#
+#1980-01-01 00:00:00#
+#1988-01-01 00:00:00#
+#1994-01-01 00:00:00#
+#1995-01-01 00:00:00#
+#1997-01-01 00:00:00#
+#1998-01-01 00:00:00#
+#2001-01-01 00:00:00#
+#2002-01-01 00:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.datetrunc.year,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.datetrunc.year.txt,True,0,0,"DATETRUNC('year', [datetime0])",expression,,None,None,321.0,"
+      SELECT CAST(TRUNC(`calcs`.`datetime0`,'YY') AS DATE) AS `temp_test__1153873435__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",#2004-01-01 00:00:00#,#2004-01-01 00:00:00#
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math.date_minus_date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.date_minus_date.txt,True,0,0,[date2] - [date2],expression,,None,None,396.0,"
+      SELECT (UNIX_TIMESTAMP(`calcs`.`date2`) - UNIX_TIMESTAMP(`calcs`.`date2`)) / 86400.0 AS `temp_test__1152843842__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",0.0,0.0
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,"DATEDIFF('day', NOW(), NOW())",expression,,None,None,338.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(FROM_UNIXTIME(UNIX_TIMESTAMP()) AS TIMESTAMP)), TO_DATE(CAST(FROM_UNIXTIME(UNIX_TIMESTAMP()) AS TIMESTAMP))) AS `temp_test__3926981592__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",0,0
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,"DATEDIFF('day', TODAY(), TODAY())",expression,,None,None,320.0,"
+      SELECT DATEDIFF(TO_DATE(CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(), 'yyyy-MM-dd 00:00:00') AS TIMESTAMP)), TO_DATE(CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(), 'yyyy-MM-dd 00:00:00') AS TIMESTAMP))) AS `temp_test__1915846221__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",0,0
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] + 1,expression,,None,None,322.0,"
+      SELECT CAST(DATE_ADD(`calcs`.`date2`, CAST(1 AS INT)) AS DATE) AS `temp_test__715809068__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-13#
+#1974-03-18#
+#1974-05-04#
+#1976-09-10#
+#1977-02-09#
+#1977-04-21#
+#1980-07-27#
+#1980-11-08#
+#1988-01-06#
+#1994-04-21#
+#1995-06-05#
+#1995-09-04#
+#1997-05-31#
+#1997-09-20#
+#1998-08-13#
+#2001-02-05#
+#2002-04-28#","#1972-07-13#
+#1974-03-18#
+#1974-05-04#
+#1976-09-10#
+#1977-02-09#
+#1977-04-21#
+#1980-07-27#
+#1980-11-08#
+#1988-01-06#
+#1994-04-21#
+#1995-06-05#
+#1995-09-04#
+#1997-05-31#
+#1997-09-20#
+#1998-08-13#
+#2001-02-05#
+#2002-04-28#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] + 1.5,expression,,None,None,356.0,"
+      SELECT CAST(FROM_UNIXTIME(CAST(CAST(CAST(`calcs`.`date2` AS TIMESTAMP) AS BIGINT) + (1.5 * 86400) AS BIGINT)) AS TIMESTAMP) AS `temp_test__299505631__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-13 12:00:00#
+#1974-03-18 12:00:00#
+#1974-05-04 12:00:00#
+#1976-09-10 12:00:00#
+#1977-02-09 12:00:00#
+#1977-04-21 12:00:00#
+#1980-07-27 12:00:00#
+#1980-11-08 12:00:00#
+#1988-01-06 12:00:00#
+#1994-04-21 12:00:00#
+#1995-06-05 12:00:00#
+#1995-09-04 12:00:00#
+#1997-05-31 12:00:00#
+#1997-09-20 12:00:00#
+#1998-08-13 12:00:00#
+#2001-02-05 12:00:00#
+#2002-04-28 12:00:00#","#1972-07-13 12:00:00#
+#1974-03-18 12:00:00#
+#1974-05-04 12:00:00#
+#1976-09-10 12:00:00#
+#1977-02-09 12:00:00#
+#1977-04-21 12:00:00#
+#1980-07-27 12:00:00#
+#1980-11-08 12:00:00#
+#1988-01-06 12:00:00#
+#1994-04-21 12:00:00#
+#1995-06-05 12:00:00#
+#1995-09-04 12:00:00#
+#1997-05-31 12:00:00#
+#1997-09-20 12:00:00#
+#1998-08-13 12:00:00#
+#2001-02-05 12:00:00#
+#2002-04-28 12:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] - 1,expression,,None,None,346.0,"
+      SELECT CAST(DATE_ADD(`calcs`.`date2`, CAST(-(1) AS INT)) AS DATE) AS `temp_test__709470143__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-11#
+#1974-03-16#
+#1974-05-02#
+#1976-09-08#
+#1977-02-07#
+#1977-04-19#
+#1980-07-25#
+#1980-11-06#
+#1988-01-04#
+#1994-04-19#
+#1995-06-03#
+#1995-09-02#
+#1997-05-29#
+#1997-09-18#
+#1998-08-11#
+#2001-02-03#
+#2002-04-26#","#1972-07-11#
+#1974-03-16#
+#1974-05-02#
+#1976-09-08#
+#1977-02-07#
+#1977-04-19#
+#1980-07-25#
+#1980-11-06#
+#1988-01-04#
+#1994-04-19#
+#1995-06-03#
+#1995-09-02#
+#1997-05-29#
+#1997-09-18#
+#1998-08-11#
+#2001-02-03#
+#2002-04-26#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] - 1.5,expression,,None,None,336.0,"
+      SELECT CAST(FROM_UNIXTIME(CAST(CAST(`calcs`.`date2` AS TIMESTAMP) AS BIGINT) - CAST((1.5) * 86400 AS INT)) AS TIMESTAMP) AS `temp_test__1620718980__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-10 12:00:00#
+#1974-03-15 12:00:00#
+#1974-05-01 12:00:00#
+#1976-09-07 12:00:00#
+#1977-02-06 12:00:00#
+#1977-04-18 12:00:00#
+#1980-07-24 12:00:00#
+#1980-11-05 12:00:00#
+#1988-01-03 12:00:00#
+#1994-04-18 12:00:00#
+#1995-06-02 12:00:00#
+#1995-09-01 12:00:00#
+#1997-05-28 12:00:00#
+#1997-09-17 12:00:00#
+#1998-08-10 12:00:00#
+#2001-02-02 12:00:00#
+#2002-04-25 12:00:00#","#1972-07-10 12:00:00#
+#1974-03-15 12:00:00#
+#1974-05-01 12:00:00#
+#1976-09-07 12:00:00#
+#1977-02-06 12:00:00#
+#1977-04-18 12:00:00#
+#1980-07-24 12:00:00#
+#1980-11-05 12:00:00#
+#1988-01-03 12:00:00#
+#1994-04-18 12:00:00#
+#1995-06-02 12:00:00#
+#1995-09-01 12:00:00#
+#1997-05-28 12:00:00#
+#1997-09-17 12:00:00#
+#1998-08-10 12:00:00#
+#2001-02-02 12:00:00#
+#2002-04-25 12:00:00#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[datetime0] - [datetime0],expression,,None,None,344.0,"
+      SELECT (UNIX_TIMESTAMP(`calcs`.`datetime0`) - UNIX_TIMESTAMP(`calcs`.`datetime0`)) / 86400.0 AS `temp_test__2141740056__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",0.0,0.0
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[datetime0] - 1,expression,,None,None,399.0,"
+      SELECT CAST(FROM_UNIXTIME(CAST(`calcs`.`datetime0` AS BIGINT) - (1) * 86400) AS TIMESTAMP) AS `temp_test__1797652325__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-03 22:49:28#
+#2004-07-04 13:14:20#
+#2004-07-08 10:17:35#
+#2004-07-11 17:30:16#
+#2004-07-13 07:43:00#
+#2004-07-13 08:16:44#
+#2004-07-16 14:01:56#
+#2004-07-18 22:21:31#
+#2004-07-21 00:30:23#
+#2004-07-22 21:13:37#
+#2004-07-24 15:22:26#
+#2004-07-25 12:30:34#
+#2004-07-27 06:54:50#
+#2004-07-27 12:34:28#
+#2004-07-27 23:30:22#
+#2004-07-30 11:57:52#
+#2004-08-01 07:59:23#","#2004-07-03 22:49:28#
+#2004-07-04 13:14:20#
+#2004-07-08 10:17:35#
+#2004-07-11 17:30:16#
+#2004-07-13 07:43:00#
+#2004-07-13 08:16:44#
+#2004-07-16 14:01:56#
+#2004-07-18 22:21:31#
+#2004-07-21 00:30:23#
+#2004-07-22 21:13:37#
+#2004-07-24 15:22:26#
+#2004-07-25 12:30:34#
+#2004-07-27 06:54:50#
+#2004-07-27 12:34:28#
+#2004-07-27 23:30:22#
+#2004-07-30 11:57:52#
+#2004-08-01 07:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[datetime0] + 1,expression,,None,None,353.0,"
+      SELECT CAST(CONCAT(DATE_ADD(`calcs`.`datetime0`, CAST(1 AS INT)), SUBSTR(CAST(`calcs`.`datetime0` AS TIMESTAMP), 11)) AS TIMESTAMP) AS `temp_test__2686481578__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-05 22:49:28#
+#2004-07-06 13:14:20#
+#2004-07-10 10:17:35#
+#2004-07-13 17:30:16#
+#2004-07-15 07:43:00#
+#2004-07-15 08:16:44#
+#2004-07-18 14:01:56#
+#2004-07-20 22:21:31#
+#2004-07-23 00:30:23#
+#2004-07-24 21:13:37#
+#2004-07-26 15:22:26#
+#2004-07-27 12:30:34#
+#2004-07-29 06:54:50#
+#2004-07-29 12:34:28#
+#2004-07-29 23:30:22#
+#2004-08-01 11:57:52#
+#2004-08-03 07:59:23#","#2004-07-05 22:49:28#
+#2004-07-06 13:14:20#
+#2004-07-10 10:17:35#
+#2004-07-13 17:30:16#
+#2004-07-15 07:43:00#
+#2004-07-15 08:16:44#
+#2004-07-18 14:01:56#
+#2004-07-20 22:21:31#
+#2004-07-23 00:30:23#
+#2004-07-24 21:13:37#
+#2004-07-26 15:22:26#
+#2004-07-27 12:30:34#
+#2004-07-29 06:54:50#
+#2004-07-29 12:34:28#
+#2004-07-29 23:30:22#
+#2004-08-01 11:57:52#
+#2004-08-03 07:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[datetime0] - 1.5,expression,,None,None,334.0,"
+      SELECT CAST(FROM_UNIXTIME(CAST(`calcs`.`datetime0` AS BIGINT) - CAST((1.5) * 86400 AS INT)) AS TIMESTAMP) AS `temp_test__2341796372__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-03 10:49:28#
+#2004-07-04 01:14:20#
+#2004-07-07 22:17:35#
+#2004-07-11 05:30:16#
+#2004-07-12 19:43:00#
+#2004-07-12 20:16:44#
+#2004-07-16 02:01:56#
+#2004-07-18 10:21:31#
+#2004-07-20 12:30:23#
+#2004-07-22 09:13:37#
+#2004-07-24 03:22:26#
+#2004-07-25 00:30:34#
+#2004-07-26 18:54:50#
+#2004-07-27 00:34:28#
+#2004-07-27 11:30:22#
+#2004-07-29 23:57:52#
+#2004-07-31 19:59:23#","#2004-07-03 10:49:28#
+#2004-07-04 01:14:20#
+#2004-07-07 22:17:35#
+#2004-07-11 05:30:16#
+#2004-07-12 19:43:00#
+#2004-07-12 20:16:44#
+#2004-07-16 02:01:56#
+#2004-07-18 10:21:31#
+#2004-07-20 12:30:23#
+#2004-07-22 09:13:37#
+#2004-07-24 03:22:26#
+#2004-07-25 00:30:34#
+#2004-07-26 18:54:50#
+#2004-07-27 00:34:28#
+#2004-07-27 11:30:22#
+#2004-07-29 23:57:52#
+#2004-07-31 19:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[datetime0] + 1.5,expression,,None,None,357.0,"
+      SELECT CAST(FROM_UNIXTIME(CAST(CAST(`calcs`.`datetime0` AS BIGINT) + (1.5 * 86400) AS BIGINT)) AS TIMESTAMP) AS `temp_test__4017290474__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-06 10:49:28#
+#2004-07-07 01:14:20#
+#2004-07-10 22:17:35#
+#2004-07-14 05:30:16#
+#2004-07-15 19:43:00#
+#2004-07-15 20:16:44#
+#2004-07-19 02:01:56#
+#2004-07-21 10:21:31#
+#2004-07-23 12:30:23#
+#2004-07-25 09:13:37#
+#2004-07-27 03:22:26#
+#2004-07-28 00:30:34#
+#2004-07-29 18:54:50#
+#2004-07-30 00:34:28#
+#2004-07-30 11:30:22#
+#2004-08-01 23:57:52#
+#2004-08-03 19:59:23#","#2004-07-06 10:49:28#
+#2004-07-07 01:14:20#
+#2004-07-10 22:17:35#
+#2004-07-14 05:30:16#
+#2004-07-15 19:43:00#
+#2004-07-15 20:16:44#
+#2004-07-19 02:01:56#
+#2004-07-21 10:21:31#
+#2004-07-23 12:30:23#
+#2004-07-25 09:13:37#
+#2004-07-27 03:22:26#
+#2004-07-28 00:30:34#
+#2004-07-29 18:54:50#
+#2004-07-30 00:34:28#
+#2004-07-30 11:30:22#
+#2004-08-01 23:57:52#
+#2004-08-03 19:59:23#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[datetime0] = [datetime0],expression,,None,None,369.0,"
+      SELECT (`calcs`.`datetime0` = `calcs`.`datetime0`) AS `temp_test__3033382267__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[datetime0] > [datetime0],expression,,None,None,308.0,"
+      SELECT (`calcs`.`datetime0` > `calcs`.`datetime0`) AS `temp_test__4196472080__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",false,false
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[datetime0] >= [datetime0],expression,,None,None,309.0,"
+      SELECT (`calcs`.`datetime0` >= `calcs`.`datetime0`) AS `temp_test__1829388090__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[datetime0] < [datetime0],expression,,None,None,323.0,"
+      SELECT (`calcs`.`datetime0` < `calcs`.`datetime0`) AS `temp_test__2087345109__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",false,false
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[datetime0] <= [datetime0],expression,,None,None,305.0,"
+      SELECT (`calcs`.`datetime0` <= `calcs`.`datetime0`) AS `temp_test__3187080314__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[datetime0] <> [datetime0],expression,,None,None,319.0,"
+      SELECT (`calcs`.`datetime0` <> `calcs`.`datetime0`) AS `temp_test__436529008__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",false,false
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] = [datetime0],expression,,None,None,348.0,"
+      SELECT (CAST(`calcs`.`date2` AS TIMESTAMP) = `calcs`.`datetime0`) AS `temp_test__1122166960__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",false,false
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] > [datetime0],expression,,None,None,322.0,"
+      SELECT (CAST(`calcs`.`date2` AS TIMESTAMP) > `calcs`.`datetime0`) AS `temp_test__2476649334__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",false,false
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] >= [datetime0],expression,,None,None,350.0,"
+      SELECT (CAST(`calcs`.`date2` AS TIMESTAMP) >= `calcs`.`datetime0`) AS `temp_test__1267352367__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",false,false
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] < [datetime0],expression,,None,None,352.0,"
+      SELECT (CAST(`calcs`.`date2` AS TIMESTAMP) < `calcs`.`datetime0`) AS `temp_test__668774393__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] <= [datetime0],expression,,None,None,319.0,"
+      SELECT (CAST(`calcs`.`date2` AS TIMESTAMP) <= `calcs`.`datetime0`) AS `temp_test__2801366337__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] <> [datetime0],expression,,None,None,351.0,"
+      SELECT (CAST(`calcs`.`date2` AS TIMESTAMP) <> `calcs`.`datetime0`) AS `temp_test__6065346__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] =  [date2],expression,,None,None,316.0,"
+      SELECT (`calcs`.`date2` = `calcs`.`date2`) AS `temp_test__4213376628__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] >  [date2],expression,,None,None,306.0,"
+      SELECT (`calcs`.`date2` > `calcs`.`date2`) AS `temp_test__284925583__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",false,false
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] >= [date2],expression,,None,None,315.0,"
+      SELECT (`calcs`.`date2` >= `calcs`.`date2`) AS `temp_test__1365124261__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] <  [date2],expression,,None,None,296.0,"
+      SELECT (`calcs`.`date2` < `calcs`.`date2`) AS `temp_test__4277161941__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",false,false
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] <= [date2],expression,,None,None,306.0,"
+      SELECT (`calcs`.`date2` <= `calcs`.`date2`) AS `temp_test__932571096__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,date.math,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.math.txt,True,0,0,[date2] <> [date2],expression,,None,None,303.0,"
+      SELECT (`calcs`.`date2` <> `calcs`.`date2`) AS `temp_test__3666462064__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",false,false
+databricks,expression.standard.databricks,cast_calcs.databricks,date.max,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.max.txt,True,0,0,MAX([date2]),expression,,None,None,370.0,"
+      SELECT MAX(`calcs`.`date2`) AS `temp_test__3325074545__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",#2002-04-27#,#2002-04-27#
+databricks,expression.standard.databricks,cast_calcs.databricks,date.max,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.max.txt,True,0,0,"MAX([date2], [date3])",expression,,None,None,403.0,"
+      SELECT (CASE
+	WHEN (`calcs`.`date2` IS NULL) OR (`calcs`.`date3` IS NULL) THEN NULL
+	WHEN `calcs`.`date2` > `calcs`.`date3` THEN `calcs`.`date2`
+	ELSE `calcs`.`date3` END) AS `temp_test__1996265231__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1980-11-07#
+#1983-05-22#
+#1986-03-20#
+#1986-11-08#
+#1996-05-13#
+#1997-05-30#
+#1997-09-19#
+#1999-08-20#
+#2002-04-27#","%null%
+#1980-11-07#
+#1983-05-22#
+#1986-03-20#
+#1986-11-08#
+#1996-05-13#
+#1997-05-30#
+#1997-09-19#
+#1999-08-20#
+#2002-04-27#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.max,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.max.txt,True,0,0,MAX([datetime0]),expression,,None,None,386.0,"
+      SELECT MAX(`calcs`.`datetime0`) AS `temp_test__4035984656__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",#2004-08-02 07:59:23#,#2004-08-02 07:59:23#
+databricks,expression.standard.databricks,cast_calcs.databricks,date.min,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.min.txt,True,0,0,"MIN([date2], [date3])",expression,,None,None,375.0,"
+      SELECT (CASE
+	WHEN (`calcs`.`date2` IS NULL) OR (`calcs`.`date3` IS NULL) THEN NULL
+	WHEN `calcs`.`date2` < `calcs`.`date3` THEN `calcs`.`date2`
+	ELSE `calcs`.`date3` END) AS `temp_test__3951339438__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1972-07-12#
+#1974-03-17#
+#1976-09-09#
+#1977-04-20#
+#1979-04-01#
+#1988-01-05#
+#1992-01-18#
+#1996-03-07#
+#1997-02-02#","%null%
+#1972-07-12#
+#1974-03-17#
+#1976-09-09#
+#1977-04-20#
+#1979-04-01#
+#1988-01-05#
+#1992-01-18#
+#1996-03-07#
+#1997-02-02#"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.min,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.min.txt,True,0,0,MIN([date2]),expression,,None,None,364.0,"
+      SELECT MIN(`calcs`.`date2`) AS `temp_test__1465246653__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",#1972-07-12#,#1972-07-12#
+databricks,expression.standard.databricks,cast_calcs.databricks,date.min,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.min.txt,True,0,0,MIN([datetime0]),expression,,None,None,346.0,"
+      SELECT MIN(`calcs`.`datetime0`) AS `temp_test__2572329321__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",#2004-07-04 22:49:28#,#2004-07-04 22:49:28#
+databricks,expression.standard.databricks,cast_calcs.databricks,date.misc,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.misc.txt,True,0,0,DAY(DATE([date2])),expression,,None,None,336.0,"
+      SELECT DAY(CAST(CAST(`calcs`.`date2` AS TIMESTAMP) AS DATE)) AS `temp_test__2085924889__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","3
+4
+5
+7
+8
+9
+12
+17
+19
+20
+26
+27
+30","3
+4
+5
+7
+8
+9
+12
+17
+19
+20
+26
+27
+30"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.misc,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.misc.txt,True,0,0,DAY(DATETIME([datetime0])),expression,,None,None,323.0,"
+      SELECT DAY(CAST(`calcs`.`datetime0` as TIMESTAMP)) AS `temp_test__574618496__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","2
+4
+5
+9
+12
+14
+17
+19
+22
+23
+25
+26
+28
+31","2
+4
+5
+9
+12
+14
+17
+19
+22
+23
+25
+26
+28
+31"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.misc,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.misc.txt,True,0,0,MONTH(DATE([date2])),expression,,None,None,333.0,"
+      SELECT MONTH(CAST(CAST(`calcs`.`date2` AS TIMESTAMP) AS DATE)) AS `temp_test__1165289219__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1
+2
+3
+4
+5
+6
+7
+8
+9
+11","1
+2
+3
+4
+5
+6
+7
+8
+9
+11"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.misc,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.misc.txt,True,0,0,MONTH(DATETIME([datetime0])),expression,,None,None,324.0,"
+      SELECT MONTH(CAST(`calcs`.`datetime0` as TIMESTAMP)) AS `temp_test__3278952934__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","7
+8","7
+8"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.misc,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.misc.txt,True,0,0,YEAR(DATE([date2])),expression,,None,None,323.0,"
+      SELECT YEAR(CAST(CAST(`calcs`.`date2` AS TIMESTAMP) AS DATE)) AS `temp_test__3434755864__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1972
+1974
+1976
+1977
+1980
+1988
+1994
+1995
+1997
+1998
+2001
+2002","1972
+1974
+1976
+1977
+1980
+1988
+1994
+1995
+1997
+1998
+2001
+2002"
+databricks,expression.standard.databricks,cast_calcs.databricks,date.misc,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.misc.txt,True,0,0,YEAR(DATETIME([datetime0])),expression,,None,None,312.0,"
+      SELECT YEAR(CAST(`calcs`.`datetime0` as TIMESTAMP)) AS `temp_test__1819497289__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",2004,2004
+databricks,expression.standard.databricks,cast_calcs.databricks,date.now,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.now.txt,True,0,0,"datepart('year', now()) = datepart('year', now())",expression,,None,None,326.0,"
+      SELECT (YEAR(CAST(FROM_UNIXTIME(UNIX_TIMESTAMP()) AS TIMESTAMP)) = YEAR(CAST(FROM_UNIXTIME(UNIX_TIMESTAMP()) AS TIMESTAMP))) AS `temp_test__3241940546__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,date.now,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.now.txt,True,0,0,"datepart('second', now()) = datepart('second', now())",expression,,None,None,317.0,"
+      SELECT (SECOND(CAST(FROM_UNIXTIME(UNIX_TIMESTAMP()) AS TIMESTAMP)) = SECOND(CAST(FROM_UNIXTIME(UNIX_TIMESTAMP()) AS TIMESTAMP))) AS `temp_test__1432496731__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,date.today,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.today.txt,True,0,0,"datepart('year', today()) = datepart('year', today())",expression,,None,None,316.0,"
+      SELECT (YEAR(CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(), 'yyyy-MM-dd 00:00:00') AS TIMESTAMP)) = YEAR(CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(), 'yyyy-MM-dd 00:00:00') AS TIMESTAMP))) AS `temp_test__307093745__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,date.today,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.date.today.txt,True,0,0,"datepart('day', today()) = datepart('day', today())",expression,,None,None,309.0,"
+      SELECT (DAY(CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(), 'yyyy-MM-dd 00:00:00') AS TIMESTAMP)) = DAY(CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(), 'yyyy-MM-dd 00:00:00') AS TIMESTAMP))) AS `temp_test__3426973691__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,datetime.cast.date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.datetime.cast.date.txt,True,0,0,DATE([datetime0]),expression,,None,None,313.0,"
+      SELECT CAST(CAST(`calcs`.`datetime0` AS TIMESTAMP) AS DATE) AS `temp_test__1739373434__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#2004-07-04#
+#2004-07-05#
+#2004-07-09#
+#2004-07-12#
+#2004-07-14#
+#2004-07-17#
+#2004-07-19#
+#2004-07-22#
+#2004-07-23#
+#2004-07-25#
+#2004-07-26#
+#2004-07-28#
+#2004-07-31#
+#2004-08-02#","#2004-07-04#
+#2004-07-05#
+#2004-07-09#
+#2004-07-12#
+#2004-07-14#
+#2004-07-17#
+#2004-07-19#
+#2004-07-22#
+#2004-07-23#
+#2004-07-25#
+#2004-07-26#
+#2004-07-28#
+#2004-07-31#
+#2004-08-02#"
+databricks,expression.standard.databricks,cast_calcs.databricks,datetime.cast.float,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.datetime.cast.float.txt,True,4,0,FLOAT([datetime0]),expression,,None,None,379.0,"
+      SELECT CAST(`calcs`.`datetime0` AS DOUBLE) AS `temp_test__1573932322__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1.0889814e+09
+1.0890333e+09
+1.0893683e+09
+1.0896534e+09
+1.089791e+09
+1.089793e+09
+1.0900729e+09
+1.0902757e+09
+1.0904562e+09
+1.0906172e+09
+1.0907689e+09
+1.090845e+09
+1.0909977e+09
+1.0910181e+09
+1.0910574e+09
+1.0912751e+09
+1.0914336e+09","1.0889814e+09
+1.0890333e+09
+1.0893683e+09
+1.0896534e+09
+1.089791e+09
+1.089793e+09
+1.0900729e+09
+1.0902757e+09
+1.0904562e+09
+1.0906172e+09
+1.0907689e+09
+1.090845e+09
+1.0909977e+09
+1.0910181e+09
+1.0910574e+09
+1.0912751e+09
+1.0914336e+09"
+databricks,expression.standard.databricks,cast_calcs.databricks,datetime.cast.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.datetime.cast.str.txt,True,3,0,TRIM(STR([datetime0])),expression,,None,None,397.0,"
+      SELECT TRIM(CAST(`calcs`.`datetime0` AS STRING)) AS `temp_test__1103404331__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""2004-07-04 22:49:28""
+""2004-07-05 13:14:20""
+""2004-07-09 10:17:35""
+""2004-07-12 17:30:16""
+""2004-07-14 07:43:00""
+""2004-07-14 08:16:44""
+""2004-07-17 14:01:56""
+""2004-07-19 22:21:31""
+""2004-07-22 00:30:23""
+""2004-07-23 21:13:37""
+""2004-07-25 15:22:26""
+""2004-07-26 12:30:34""
+""2004-07-28 06:54:50""
+""2004-07-28 12:34:28""
+""2004-07-28 23:30:22""
+""2004-07-31 11:57:52""
+""2004-08-02 07:59:23""","""2004-07-04 22:49:28""
+""2004-07-05 13:14:20""
+""2004-07-09 10:17:35""
+""2004-07-12 17:30:16""
+""2004-07-14 07:43:00""
+""2004-07-14 08:16:44""
+""2004-07-17 14:01:56""
+""2004-07-19 22:21:31""
+""2004-07-22 00:30:23""
+""2004-07-23 21:13:37""
+""2004-07-25 15:22:26""
+""2004-07-26 12:30:34""
+""2004-07-28 06:54:50""
+""2004-07-28 12:34:28""
+""2004-07-28 23:30:22""
+""2004-07-31 11:57:52""
+""2004-08-02 07:59:23"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.bool.txt,True,2,0,"iif(bool0,date0,date1) ",expression,,None,None,333.0,"
+      SELECT (CASE WHEN `calcs`.`bool0` THEN `calcs`.`date0` WHEN NOT `calcs`.`bool0` THEN `calcs`.`date1` ELSE NULL END) AS `temp_test__3513628645__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#2004-04-02#
+#2004-04-05#
+#2004-04-08#
+#2004-04-12#
+#2004-04-15#
+#2004-04-16#
+#2004-06-04#","%null%
+#2004-04-02#
+#2004-04-05#
+#2004-04-08#
+#2004-04-12#
+#2004-04-15#
+#2004-04-16#
+#2004-06-04#"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.bool.txt,True,2,0,"iif(bool0,str2,str3,str0) ",expression,,None,None,327.0,"
+      SELECT (CASE WHEN `calcs`.`bool0` THEN `calcs`.`str2` WHEN NOT `calcs`.`bool0` THEN `calcs`.`str3` ELSE `calcs`.`str0` END) AS `temp_test__1007528555__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""OFFICE SUPPLIES""
+""TECHNOLOGY""
+""e""
+""eleven""
+""fifteen""
+""one""","%null%
+""OFFICE SUPPLIES""
+""TECHNOLOGY""
+""e""
+""eleven""
+""fifteen""
+""one"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.bool.txt,True,2,0,"iif(bool0,num0,num1,num2) ",expression,,None,None,324.0,"
+      SELECT (CASE WHEN `calcs`.`bool0` THEN `calcs`.`num0` WHEN NOT `calcs`.`bool0` THEN `calcs`.`num1` ELSE `calcs`.`num2` END) AS `temp_test__3428504110__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-15.7
+0.0
+2.47
+6.71
+7.87
+8.98
+9.05
+11.38
+11.5
+12.3
+13.04
+16.81","%null%
+-15.7
+0.0
+2.47
+6.71
+7.87
+8.98
+9.05
+11.38
+11.5
+12.3
+13.04
+16.81"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.bool.txt,True,2,0,"iif(bool0,date0,date1,date2) ",expression,,None,None,316.0,"
+      SELECT (CASE WHEN `calcs`.`bool0` THEN `calcs`.`date0` WHEN NOT `calcs`.`bool0` THEN `calcs`.`date1` ELSE `calcs`.`date2` END) AS `temp_test__1581504649__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1976-09-09#
+#1980-11-07#
+#1988-01-05#
+#1997-09-19#
+#1998-08-12#
+#2001-02-04#
+#2002-04-27#
+#2004-04-02#
+#2004-04-05#
+#2004-04-08#
+#2004-04-12#
+#2004-04-15#
+#2004-04-16#
+#2004-06-04#","%null%
+#1976-09-09#
+#1980-11-07#
+#1988-01-05#
+#1997-09-19#
+#1998-08-12#
+#2001-02-04#
+#2002-04-27#
+#2004-04-02#
+#2004-04-05#
+#2004-04-08#
+#2004-04-12#
+#2004-04-15#
+#2004-04-16#
+#2004-06-04#"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.bool.txt,True,2,0,"iif(bool0,num0,num1) ",expression,,None,None,344.0,"
+      SELECT (CASE WHEN `calcs`.`bool0` THEN CAST(`calcs`.`num0` AS DOUBLE) WHEN NOT `calcs`.`bool0` THEN CAST(`calcs`.`num1` AS DOUBLE) ELSE NULL END) AS `temp_test__750655768__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-15.7
+0.0
+2.47
+6.71
+9.05
+11.38
+12.3
+16.81","%null%
+-15.7
+0.0
+2.47
+6.71
+9.05
+11.38
+12.3
+16.81"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.bool.txt,True,2,0,"iif(bool0,bool1,bool2) ",expression,,None,None,331.0,"
+      SELECT ((`calcs`.`bool0` AND `calcs`.`bool1`) OR ((NOT `calcs`.`bool0`) AND `calcs`.`bool2`)) AS `temp_test__1656302737__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.bool.txt,True,2,0,isnull(bool0) ,expression,,None,None,359.0,"
+      SELECT (`calcs`.`bool0` IS NULL) AS `temp_test__4006206882__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","false
+true","false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.bool.txt,True,2,0,"iif(bool0,str2,str3) ",expression,,None,None,324.0,"
+      SELECT (CASE WHEN `calcs`.`bool0` THEN `calcs`.`str2` WHEN NOT `calcs`.`bool0` THEN `calcs`.`str3` ELSE NULL END) AS `temp_test__4173709053__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""e""
+""eleven""
+""fifteen""
+""one""","%null%
+""e""
+""eleven""
+""fifteen""
+""one"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.bool.txt,True,2,0, (if bool0 then int(bool1) else int(bool2) end) == int(true),expression,,None,None,360.0,"
+      SELECT ((CASE WHEN `calcs`.`bool0` THEN (CASE
+	WHEN `calcs`.`bool1` THEN 1
+	WHEN NOT `calcs`.`bool1` THEN 0
+	ELSE NULL END) ELSE (CASE
+	WHEN `calcs`.`bool2` THEN 1
+	WHEN NOT `calcs`.`bool2` THEN 0
+	ELSE NULL END) END) = (CASE
+	WHEN true THEN 1
+	WHEN NOT true THEN 0
+	ELSE NULL END)) AS `temp_test__1285160207__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.bool.txt,True,2,0, if bool0 then num0 else num1 end,expression,,None,None,354.0,"
+      SELECT (CASE WHEN `calcs`.`bool0` THEN `calcs`.`num0` ELSE `calcs`.`num1` END) AS `temp_test__898375479__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-15.7
+0.0
+2.47
+6.71
+7.12
+9.05
+9.38
+9.47
+9.78
+10.37
+11.38
+12.05
+12.3
+12.4
+16.81","%null%
+-15.7
+0.0
+2.47
+6.71
+7.12
+9.05
+9.38
+9.47
+9.78
+10.37
+11.38
+12.05
+12.3
+12.4
+16.81"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.bool.txt,True,2,0, if bool0 then date0 else date1 end,expression,,None,None,332.0,"
+      SELECT (CASE WHEN `calcs`.`bool0` THEN `calcs`.`date0` ELSE `calcs`.`date1` END) AS `temp_test__3012038505__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#2004-04-02#
+#2004-04-03#
+#2004-04-05#
+#2004-04-06#
+#2004-04-08#
+#2004-04-09#
+#2004-04-10#
+#2004-04-12#
+#2004-04-13#
+#2004-04-14#
+#2004-04-15#
+#2004-04-16#
+#2004-04-17#
+#2004-06-04#","%null%
+#2004-04-02#
+#2004-04-03#
+#2004-04-05#
+#2004-04-06#
+#2004-04-08#
+#2004-04-09#
+#2004-04-10#
+#2004-04-12#
+#2004-04-13#
+#2004-04-14#
+#2004-04-15#
+#2004-04-16#
+#2004-04-17#
+#2004-06-04#"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.bool.txt,True,2,0, if bool0 then str2 else str3 end,expression,,None,None,406.0,"
+      SELECT (CASE WHEN `calcs`.`bool0` THEN `calcs`.`str2` ELSE `calcs`.`str3` END) AS `temp_test__490796425__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""e""
+""eleven""
+""fifteen""
+""one""","%null%
+""e""
+""eleven""
+""fifteen""
+""one"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical.case.null,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.case.null.txt,True,0,0,"case datepart('weekday',date1) when 7 then null when 1 then null else date1 end",expression,,None,None,335.0,"
+      SELECT (CASE WHEN ((8 + DATEDIFF(`calcs`.`date1`,NEXT_DAY(CAST(`calcs`.`date1` AS DATE),'SU'))) IN (7, 1)) THEN CAST(NULL AS TIMESTAMP) ELSE `calcs`.`date1` END) AS `temp_test__4257957843__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#2004-04-01#
+#2004-04-02#
+#2004-04-05#
+#2004-04-06#
+#2004-04-07#
+#2004-04-08#
+#2004-04-09#
+#2004-04-12#
+#2004-04-13#
+#2004-04-14#
+#2004-04-15#
+#2004-04-16#","%null%
+#2004-04-01#
+#2004-04-02#
+#2004-04-05#
+#2004-04-06#
+#2004-04-07#
+#2004-04-08#
+#2004-04-09#
+#2004-04-12#
+#2004-04-13#
+#2004-04-14#
+#2004-04-15#
+#2004-04-16#"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical.case.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.case.str.txt,True,0,0,case [str0] when 'TECHNOLOGY' then '*Anonymous*'  else [str0] end,expression,,None,None,322.0,"
+      SELECT IF((`calcs`.`str0` = 'TECHNOLOGY'),'*Anonymous*',`calcs`.`str0`) AS `temp_test__1797172313__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""*Anonymous*""
+""FURNITURE""
+""OFFICE SUPPLIES""","""*Anonymous*""
+""FURNITURE""
+""OFFICE SUPPLIES"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical.ifnull,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.ifnull.txt,True,0,0,"IFNULL(COUNTD(num2), 0)",expression,,None,None,667.0,"
+      SELECT COUNT(DISTINCT `calcs`.`num2`) AS `temp_test__957319405__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",13,13
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,IF TRUE AND TRUE THEN TRUE END,expression,,None,None,303.0,"
+      SELECT true AS `temp_test__2106812187__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,CASE [int0] WHEN 1 THEN 'test1' WHEN 3 THEN 'test3' ELSE 'testelse' END,expression,,None,None,349.0,"
+      SELECT IF((`calcs`.`int0` = 1),'test1',IF((`calcs`.`int0` = 3),'test3','testelse')) AS `temp_test__4155671032__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""test1""
+""test3""
+""testelse""","""test1""
+""test3""
+""testelse"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,IF [int0] = 1 THEN 'yes' ELSE 'no' END,expression,,None,None,329.0,"
+      SELECT (CASE WHEN (`calcs`.`int0` = 1) THEN 'yes' ELSE 'no' END) AS `temp_test__344883989__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""no""
+""yes""","""no""
+""yes"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,IF [int0] = 1 THEN 'yes' ELSEIF [int0] = 3 THEN 'yes3' ELSE 'no' END,expression,,None,None,630.0,"
+      SELECT (CASE WHEN (`calcs`.`int0` = 1) THEN 'yes' WHEN (`calcs`.`int0` = 3) THEN 'yes3' ELSE 'no' END) AS `temp_test__1470681487__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""no""
+""yes""
+""yes3""","""no""
+""yes""
+""yes3"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,"IFNULL([int0], 0)",expression,,None,None,362.0,"
+      SELECT COALESCE(CAST(`calcs`.`int0` AS BIGINT), CAST(0 AS BIGINT)) AS `temp_test__404394451__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","0
+1
+3
+4
+7
+8
+10
+11","0
+1
+3
+4
+7
+8
+10
+11"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,"IIF([int0] > 3, 'yes', 'no')",expression,,None,None,363.0,"
+      SELECT (CASE WHEN (`calcs`.`int0` > 3) THEN 'yes' WHEN NOT (`calcs`.`int0` > 3) THEN 'no' ELSE NULL END) AS `temp_test__2582407534__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""no""
+""yes""","%null%
+""no""
+""yes"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,"IIF([int0] > 3, 'yes', 'no', 'I dont know')",expression,,None,None,317.0,"
+      SELECT (CASE WHEN (`calcs`.`int0` > 3) THEN 'yes' WHEN NOT (`calcs`.`int0` > 3) THEN 'no' ELSE 'I dont know' END) AS `temp_test__485230187__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""I dont know""
+""no""
+""yes""","""I dont know""
+""no""
+""yes"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,ISNULL([int0]),expression,,None,None,424.0,"
+      SELECT (`calcs`.`int0` IS NULL) AS `temp_test__3944872634__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","false
+true","false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,IF NOT FALSE THEN 'yes' END,expression,,None,None,368.0,"
+      SELECT 'yes' AS `temp_test__1030668643__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ","""yes""","""yes"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,IF NOT [int0] = 1 THEN 'yes' ELSE 'no' END,expression,,None,None,352.0,"
+      SELECT (CASE WHEN (`calcs`.`int0` <> 1) THEN 'yes' ELSE 'no' END) AS `temp_test__1548476355__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""no""
+""yes""","""no""
+""yes"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,"iif(num0>num1,num0,num1) ",expression,,None,None,947.0,"
+      SELECT (CASE WHEN (`calcs`.`num0` > `calcs`.`num1`) THEN CAST(`calcs`.`num0` AS DOUBLE) WHEN NOT (`calcs`.`num0` > `calcs`.`num1`) THEN CAST(`calcs`.`num1` AS DOUBLE) ELSE NULL END) AS `temp_test__2733626226__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+6.71
+7.43
+9.05
+9.38
+10.0
+12.3
+15.7
+16.42","%null%
+6.71
+7.43
+9.05
+9.38
+10.0
+12.3
+15.7
+16.42"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,isnull(num4) ,expression,,None,None,318.0,"
+      SELECT (`calcs`.`num4` IS NULL) AS `temp_test__746449830__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","false
+true","false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,isnull(str2) ,expression,,None,None,374.0,"
+      SELECT (`calcs`.`str2` IS NULL) AS `temp_test__4153117630__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","false
+true","false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,"iif(str0>str1,str2,str3) ",expression,,None,None,431.0,"
+      SELECT (CASE WHEN (`calcs`.`str0` > `calcs`.`str1`) THEN `calcs`.`str2` WHEN NOT (`calcs`.`str0` > `calcs`.`str1`) THEN `calcs`.`str3` ELSE NULL END) AS `temp_test__661341884__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two""","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,"min(date0,date1) ",expression,,None,None,404.0,"
+      SELECT (CASE
+	WHEN (`calcs`.`date0` IS NULL) OR (`calcs`.`date1` IS NULL) THEN NULL
+	WHEN `calcs`.`date0` < `calcs`.`date1` THEN `calcs`.`date0`
+	ELSE `calcs`.`date1` END) AS `temp_test__1970381992__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1972-07-04#
+#1975-11-12#
+#2004-04-01#
+#2004-04-04#
+#2004-04-05#","%null%
+#1972-07-04#
+#1975-11-12#
+#2004-04-01#
+#2004-04-04#
+#2004-04-05#"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,"iif(num0>num1,date0,date1,date2) ",expression,,None,None,335.0,"
+      SELECT (CASE WHEN (`calcs`.`num0` > `calcs`.`num1`) THEN `calcs`.`date0` WHEN NOT (`calcs`.`num0` > `calcs`.`num1`) THEN `calcs`.`date1` ELSE `calcs`.`date2` END) AS `temp_test__2049518482__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1972-07-12#
+#1974-03-17#
+#1974-05-03#
+#1975-11-12#
+#1988-01-05#
+#1994-04-20#
+#1995-06-04#
+#1998-08-12#
+#2001-02-04#
+#2002-04-27#
+#2004-04-02#
+#2004-04-04#
+#2004-04-05#
+#2004-04-06#
+#2004-04-07#
+#2004-04-15#","%null%
+#1972-07-12#
+#1974-03-17#
+#1974-05-03#
+#1975-11-12#
+#1988-01-05#
+#1994-04-20#
+#1995-06-04#
+#1998-08-12#
+#2001-02-04#
+#2002-04-27#
+#2004-04-02#
+#2004-04-04#
+#2004-04-05#
+#2004-04-06#
+#2004-04-07#
+#2004-04-15#"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,lower(str0) ,expression,,None,None,317.0,"
+      SELECT LOWER(`calcs`.`str0`) AS `temp_test__157987442__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""furniture""
+""office supplies""
+""technology""","""furniture""
+""office supplies""
+""technology"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,"iif(num0>num1,str2,str3,str0) ",expression,,None,None,343.0,"
+      SELECT (CASE WHEN (`calcs`.`num0` > `calcs`.`num1`) THEN `calcs`.`str2` WHEN NOT (`calcs`.`num0` > `calcs`.`num1`) THEN `calcs`.`str3` ELSE `calcs`.`str0` END) AS `temp_test__3250337019__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""OFFICE SUPPLIES""
+""TECHNOLOGY""
+""e""
+""nine""
+""one""
+""three""","%null%
+""OFFICE SUPPLIES""
+""TECHNOLOGY""
+""e""
+""nine""
+""one""
+""three"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,"iif(num0>num1,date0,date1) ",expression,,None,None,322.0,"
+      SELECT (CASE WHEN (`calcs`.`num0` > `calcs`.`num1`) THEN `calcs`.`date0` WHEN NOT (`calcs`.`num0` > `calcs`.`num1`) THEN `calcs`.`date1` ELSE NULL END) AS `temp_test__1454773621__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1975-11-12#
+#2004-04-02#
+#2004-04-04#
+#2004-04-05#
+#2004-04-06#
+#2004-04-07#
+#2004-04-15#","%null%
+#1975-11-12#
+#2004-04-02#
+#2004-04-04#
+#2004-04-05#
+#2004-04-06#
+#2004-04-07#
+#2004-04-15#"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,"iif(num0>num1,num0,num1,num2) ",expression,,None,None,330.0,"
+      SELECT (CASE WHEN (`calcs`.`num0` > `calcs`.`num1`) THEN `calcs`.`num0` WHEN NOT (`calcs`.`num0` > `calcs`.`num1`) THEN `calcs`.`num1` ELSE `calcs`.`num2` END) AS `temp_test__1162317302__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+3.79
+6.71
+6.8
+7.43
+7.87
+9.05
+9.38
+10.0
+10.98
+11.5
+12.3
+13.04
+15.7
+16.42
+17.25","%null%
+3.79
+6.71
+6.8
+7.43
+7.87
+9.05
+9.38
+10.0
+10.98
+11.5
+12.3
+13.04
+15.7
+16.42
+17.25"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,"min(lower(str0),str2) ",expression,,None,None,331.0,"
+      SELECT (CASE
+	WHEN (LOWER(`calcs`.`str0`) IS NULL) OR (`calcs`.`str2` IS NULL) THEN NULL
+	WHEN LOWER(`calcs`.`str0`) < `calcs`.`str2` THEN LOWER(`calcs`.`str0`)
+	ELSE `calcs`.`str2` END) AS `temp_test__1389344980__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""furniture""
+""nine""
+""office supplies""
+""sixteen""
+""technology""","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""furniture""
+""nine""
+""office supplies""
+""sixteen""
+""technology"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,"IFNULL(date0, #4/12/2010#) ",expression,,None,None,335.0,"
+      SELECT COALESCE(`calcs`.`date0`, CAST('2010-04-12' AS DATE)) AS `temp_test__1229425804__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","#1972-07-04#
+#1975-11-12#
+#2004-04-15#
+#2004-06-04#
+#2004-06-19#
+#2010-04-12#","#1972-07-04#
+#1975-11-12#
+#2004-04-15#
+#2004-06-04#
+#2004-06-19#
+#2010-04-12#"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,"IFNULL(num4, -1) ",expression,,None,None,379.0,"
+      SELECT COALESCE(CAST(`calcs`.`num4` AS DOUBLE), CAST(-1 AS DOUBLE)) AS `temp_test__4224438892__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-14.21
+-13.47
+-10.24
+-6.05
+-1.0
+3.38
+3.82
+4.77
+6.75
+8.32
+10.71
+10.85
+19.39","-14.21
+-13.47
+-10.24
+-6.05
+-1.0
+3.38
+3.82
+4.77
+6.75
+8.32
+10.71
+10.85
+19.39"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,"IFNULL(str2, ""i'm null"") ",expression,,None,None,332.0,"
+      SELECT COALESCE(`calcs`.`str2`, 'i\'m null') AS `temp_test__3314993157__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""i'm null""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two""","""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""i'm null""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,isnull(date0) ,expression,,None,None,297.0,"
+      SELECT (`calcs`.`date0` IS NULL) AS `temp_test__2842042984__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","false
+true","false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0, (if num0>num1 then int(bool1) else int(bool2) end) == int(true),expression,,None,None,357.0,"
+      SELECT ((CASE WHEN (`calcs`.`num0` > `calcs`.`num1`) THEN (CASE
+	WHEN `calcs`.`bool1` THEN 1
+	WHEN NOT `calcs`.`bool1` THEN 0
+	ELSE NULL END) ELSE (CASE
+	WHEN `calcs`.`bool2` THEN 1
+	WHEN NOT `calcs`.`bool2` THEN 0
+	ELSE NULL END) END) = (CASE
+	WHEN true THEN 1
+	WHEN NOT true THEN 0
+	ELSE NULL END)) AS `temp_test__4227881224__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0, if num0>num1 then num0 else num1 end,expression,,None,None,337.0,"
+      SELECT (CASE WHEN (`calcs`.`num0` > `calcs`.`num1`) THEN `calcs`.`num0` ELSE `calcs`.`num1` END) AS `temp_test__709594122__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","2.47
+6.71
+7.1
+7.12
+7.43
+9.05
+9.38
+10.0
+10.32
+10.37
+11.38
+12.05
+12.3
+12.4
+15.7
+16.42
+16.81","2.47
+6.71
+7.1
+7.12
+7.43
+9.05
+9.38
+10.0
+10.32
+10.37
+11.38
+12.05
+12.3
+12.4
+15.7
+16.42
+16.81"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0, if num0>num1 then date0 else date1 end,expression,,None,None,363.0,"
+      SELECT (CASE WHEN (`calcs`.`num0` > `calcs`.`num1`) THEN `calcs`.`date0` ELSE `calcs`.`date1` END) AS `temp_test__467266194__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1975-11-12#
+#2004-04-02#
+#2004-04-04#
+#2004-04-05#
+#2004-04-06#
+#2004-04-07#
+#2004-04-08#
+#2004-04-10#
+#2004-04-11#
+#2004-04-12#
+#2004-04-13#
+#2004-04-14#
+#2004-04-15#
+#2004-04-16#
+#2004-04-17#","%null%
+#1975-11-12#
+#2004-04-02#
+#2004-04-04#
+#2004-04-05#
+#2004-04-06#
+#2004-04-07#
+#2004-04-08#
+#2004-04-10#
+#2004-04-11#
+#2004-04-12#
+#2004-04-13#
+#2004-04-14#
+#2004-04-15#
+#2004-04-16#
+#2004-04-17#"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0, if str0>str1 then str2 else str3 end,expression,,None,None,378.0,"
+      SELECT (CASE WHEN (`calcs`.`str0` > `calcs`.`str1`) THEN `calcs`.`str2` ELSE `calcs`.`str3` END) AS `temp_test__2963734906__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two""","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0, case int(num0>num1) when int(true) then num0 when int(false) then num1 else num2 end,expression,,None,None,371.0,"
+      SELECT IF(((CASE
+	WHEN (`calcs`.`num0` > `calcs`.`num1`) THEN 1
+	WHEN NOT (`calcs`.`num0` > `calcs`.`num1`) THEN 0
+	ELSE NULL END) = (CASE
+	WHEN true THEN 1
+	WHEN NOT true THEN 0
+	ELSE NULL END)),`calcs`.`num0`,IF(((CASE
+	WHEN (`calcs`.`num0` > `calcs`.`num1`) THEN 1
+	WHEN NOT (`calcs`.`num0` > `calcs`.`num1`) THEN 0
+	ELSE NULL END) = (CASE
+	WHEN false THEN 1
+	WHEN NOT false THEN 0
+	ELSE NULL END)),`calcs`.`num1`,`calcs`.`num2`)) AS `temp_test__4143049742__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+3.79
+6.71
+6.8
+7.43
+7.87
+9.05
+9.38
+10.0
+10.98
+11.5
+12.3
+13.04
+15.7
+16.42
+17.25","%null%
+3.79
+6.71
+6.8
+7.43
+7.87
+9.05
+9.38
+10.0
+10.98
+11.5
+12.3
+13.04
+15.7
+16.42
+17.25"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0, case int(num0>num1) when int(true) then date0 when int(false) then date1 else date2 end,expression,,None,None,379.0,"
+      SELECT IF(((CASE
+	WHEN (`calcs`.`num0` > `calcs`.`num1`) THEN 1
+	WHEN NOT (`calcs`.`num0` > `calcs`.`num1`) THEN 0
+	ELSE NULL END) = (CASE
+	WHEN true THEN 1
+	WHEN NOT true THEN 0
+	ELSE NULL END)),`calcs`.`date0`,IF(((CASE
+	WHEN (`calcs`.`num0` > `calcs`.`num1`) THEN 1
+	WHEN NOT (`calcs`.`num0` > `calcs`.`num1`) THEN 0
+	ELSE NULL END) = (CASE
+	WHEN false THEN 1
+	WHEN NOT false THEN 0
+	ELSE NULL END)),`calcs`.`date1`,`calcs`.`date2`)) AS `temp_test__1171954805__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1972-07-12#
+#1974-03-17#
+#1974-05-03#
+#1975-11-12#
+#1988-01-05#
+#1994-04-20#
+#1995-06-04#
+#1998-08-12#
+#2001-02-04#
+#2002-04-27#
+#2004-04-02#
+#2004-04-04#
+#2004-04-05#
+#2004-04-06#
+#2004-04-07#
+#2004-04-15#","%null%
+#1972-07-12#
+#1974-03-17#
+#1974-05-03#
+#1975-11-12#
+#1988-01-05#
+#1994-04-20#
+#1995-06-04#
+#1998-08-12#
+#2001-02-04#
+#2002-04-27#
+#2004-04-02#
+#2004-04-04#
+#2004-04-05#
+#2004-04-06#
+#2004-04-07#
+#2004-04-15#"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0, case int(num0>num1) when int(true) then str2 when int(false) then str3 else str0 end,expression,,None,None,366.0,"
+      SELECT IF(((CASE
+	WHEN (`calcs`.`num0` > `calcs`.`num1`) THEN 1
+	WHEN NOT (`calcs`.`num0` > `calcs`.`num1`) THEN 0
+	ELSE NULL END) = (CASE
+	WHEN true THEN 1
+	WHEN NOT true THEN 0
+	ELSE NULL END)),`calcs`.`str2`,IF(((CASE
+	WHEN (`calcs`.`num0` > `calcs`.`num1`) THEN 1
+	WHEN NOT (`calcs`.`num0` > `calcs`.`num1`) THEN 0
+	ELSE NULL END) = (CASE
+	WHEN false THEN 1
+	WHEN NOT false THEN 0
+	ELSE NULL END)),`calcs`.`str3`,`calcs`.`str0`)) AS `temp_test__2451799140__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""OFFICE SUPPLIES""
+""TECHNOLOGY""
+""e""
+""nine""
+""one""
+""three""","%null%
+""OFFICE SUPPLIES""
+""TECHNOLOGY""
+""e""
+""nine""
+""one""
+""three"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0, case int(bool0) when int(true) then num0 when int(false) then num1 else num2 end,expression,,None,None,350.0,"
+      SELECT IF(((CASE
+	WHEN `calcs`.`bool0` THEN 1
+	WHEN NOT `calcs`.`bool0` THEN 0
+	ELSE NULL END) = (CASE
+	WHEN true THEN 1
+	WHEN NOT true THEN 0
+	ELSE NULL END)),`calcs`.`num0`,IF(((CASE
+	WHEN `calcs`.`bool0` THEN 1
+	WHEN NOT `calcs`.`bool0` THEN 0
+	ELSE NULL END) = (CASE
+	WHEN false THEN 1
+	WHEN NOT false THEN 0
+	ELSE NULL END)),`calcs`.`num1`,`calcs`.`num2`)) AS `temp_test__1574830296__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-15.7
+0.0
+2.47
+6.71
+7.87
+8.98
+9.05
+11.38
+11.5
+12.3
+13.04
+16.81","%null%
+-15.7
+0.0
+2.47
+6.71
+7.87
+8.98
+9.05
+11.38
+11.5
+12.3
+13.04
+16.81"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0, case int(bool0) when int(true) then date0 when int(false) then date1 else date2 end,expression,,None,None,342.0,"
+      SELECT IF(((CASE
+	WHEN `calcs`.`bool0` THEN 1
+	WHEN NOT `calcs`.`bool0` THEN 0
+	ELSE NULL END) = (CASE
+	WHEN true THEN 1
+	WHEN NOT true THEN 0
+	ELSE NULL END)),`calcs`.`date0`,IF(((CASE
+	WHEN `calcs`.`bool0` THEN 1
+	WHEN NOT `calcs`.`bool0` THEN 0
+	ELSE NULL END) = (CASE
+	WHEN false THEN 1
+	WHEN NOT false THEN 0
+	ELSE NULL END)),`calcs`.`date1`,`calcs`.`date2`)) AS `temp_test__49931887__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1976-09-09#
+#1980-11-07#
+#1988-01-05#
+#1997-09-19#
+#1998-08-12#
+#2001-02-04#
+#2002-04-27#
+#2004-04-02#
+#2004-04-05#
+#2004-04-08#
+#2004-04-12#
+#2004-04-15#
+#2004-04-16#
+#2004-06-04#","%null%
+#1976-09-09#
+#1980-11-07#
+#1988-01-05#
+#1997-09-19#
+#1998-08-12#
+#2001-02-04#
+#2002-04-27#
+#2004-04-02#
+#2004-04-05#
+#2004-04-08#
+#2004-04-12#
+#2004-04-15#
+#2004-04-16#
+#2004-06-04#"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0," case datepart('weekday',date1) when 7 then null when 1 then null else date1 end",expression,,None,None,336.0,"
+      SELECT (CASE WHEN ((8 + DATEDIFF(`calcs`.`date1`,NEXT_DAY(CAST(`calcs`.`date1` AS DATE),'SU'))) IN (7, 1)) THEN CAST(NULL AS TIMESTAMP) ELSE `calcs`.`date1` END) AS `temp_test__1471931871__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#2004-04-01#
+#2004-04-02#
+#2004-04-05#
+#2004-04-06#
+#2004-04-07#
+#2004-04-08#
+#2004-04-09#
+#2004-04-12#
+#2004-04-13#
+#2004-04-14#
+#2004-04-15#
+#2004-04-16#","%null%
+#2004-04-01#
+#2004-04-02#
+#2004-04-05#
+#2004-04-06#
+#2004-04-07#
+#2004-04-08#
+#2004-04-09#
+#2004-04-12#
+#2004-04-13#
+#2004-04-14#
+#2004-04-15#
+#2004-04-16#"
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0, case int(bool0) when int(true) then str2 when int(false) then str3 else str0 end,expression,,None,None,367.0,"
+      SELECT IF(((CASE
+	WHEN `calcs`.`bool0` THEN 1
+	WHEN NOT `calcs`.`bool0` THEN 0
+	ELSE NULL END) = (CASE
+	WHEN true THEN 1
+	WHEN NOT true THEN 0
+	ELSE NULL END)),`calcs`.`str2`,IF(((CASE
+	WHEN `calcs`.`bool0` THEN 1
+	WHEN NOT `calcs`.`bool0` THEN 0
+	ELSE NULL END) = (CASE
+	WHEN false THEN 1
+	WHEN NOT false THEN 0
+	ELSE NULL END)),`calcs`.`str3`,`calcs`.`str0`)) AS `temp_test__166894492__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""OFFICE SUPPLIES""
+""TECHNOLOGY""
+""e""
+""eleven""
+""fifteen""
+""one""","%null%
+""OFFICE SUPPLIES""
+""TECHNOLOGY""
+""e""
+""eleven""
+""fifteen""
+""one"""
+databricks,expression.standard.databricks,cast_calcs.databricks,logical,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.logical.txt,True,8,0,"if [str1] = ""CLOCKS"" then ""*Anonymous*"" elseif [str1] = ""DVD"" then ""*Public*"" else [str1] end",expression,,None,None,351.0,"
+      SELECT (CASE WHEN (`calcs`.`str1` = 'CLOCKS') THEN '*Anonymous*' WHEN (`calcs`.`str1` = 'DVD') THEN '*Public*' ELSE `calcs`.`str1` END) AS `temp_test__899461877__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""*Anonymous*""
+""*Public*""
+""AIR PURIFIERS""
+""ANSWERING MACHINES""
+""BINDER ACCESSORIES""
+""BINDER CLIPS""
+""BINDING MACHINES""
+""BINDING SUPPLIES""
+""BUSINESS COPIERS""
+""BUSINESS ENVELOPES""
+""CD-R MEDIA""
+""CLAMP ON LAMPS""
+""CONFERENCE PHONES""
+""CORDED KEYBOARDS""
+""CORDLESS KEYBOARDS""
+""DOT MATRIX PRINTERS""
+""ERICSSON""","""*Anonymous*""
+""*Public*""
+""AIR PURIFIERS""
+""ANSWERING MACHINES""
+""BINDER ACCESSORIES""
+""BINDER CLIPS""
+""BINDING MACHINES""
+""BINDING SUPPLIES""
+""BUSINESS COPIERS""
+""BUSINESS ENVELOPES""
+""CD-R MEDIA""
+""CLAMP ON LAMPS""
+""CONFERENCE PHONES""
+""CORDED KEYBOARDS""
+""CORDLESS KEYBOARDS""
+""DOT MATRIX PRINTERS""
+""ERICSSON"""
+databricks,expression.standard.databricks,cast_calcs.databricks,math.abs,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.abs.txt,True,0,0,ABS([int2]),expression,,None,None,322.0,"
+      SELECT ABS(`calcs`.`int2`) AS `temp_test__2102582873__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","0
+2
+3
+4
+5
+6
+8
+9","0
+2
+3
+4
+5
+6
+8
+9"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.abs,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.abs.txt,True,0,0,abs(num0),expression,,None,None,341.0,"
+      SELECT ABS(`calcs`.`num0`) AS `temp_test__3816473022__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0.0
+3.5
+10.0
+12.3
+15.7","%null%
+0.0
+3.5
+10.0
+12.3
+15.7"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.acos,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.acos.txt,True,0,0,acos(num0/20),expression,,None,None,332.0,"
+      SELECT ACOS((CASE WHEN 20 = 0 THEN NULL ELSE `calcs`.`num0` / 20 END)) AS `temp_test__4196263986__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0.6681002
+0.90841036
+1.0471976
+1.3948906
+1.5707963
+1.7467021
+2.2331823
+2.4734925","%null%
+0.6681002
+0.90841036
+1.0471976
+1.3948906
+1.5707963
+1.7467021
+2.2331823
+2.4734925"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.asin,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.asin.txt,True,0,0,asin(num0/20),expression,,None,None,338.0,"
+      SELECT ASIN((CASE WHEN 20 = 0 THEN NULL ELSE `calcs`.`num0` / 20 END)) AS `temp_test__1317198372__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-0.90269613
+-0.66238597
+-0.17590577
+0.0
+0.17590577
+0.52359878
+0.66238597
+0.90269613","%null%
+-0.90269613
+-0.66238597
+-0.17590577
+0.0
+0.17590577
+0.52359878
+0.66238597
+0.90269613"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.atan,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.atan.txt,True,0,0,ATAN([int2]),expression,,None,None,326.0,"
+      SELECT ATAN(`calcs`.`int2`) AS `temp_test__3655856496__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-1.4601391
+-1.4464413
+-1.4056476
+-1.3734008
+-1.3258177
+-1.2490458
+0.0
+1.1071487
+1.2490458
+1.3258177
+1.3734008
+1.4056476
+1.4601391","-1.4601391
+-1.4464413
+-1.4056476
+-1.3734008
+-1.3258177
+-1.2490458
+0.0
+1.1071487
+1.2490458
+1.3258177
+1.3734008
+1.4056476
+1.4601391"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.atan,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.atan.txt,True,0,0,atan(num0),expression,,None,None,342.0,"
+      SELECT ATAN(`calcs`.`num0`) AS `temp_test__4053915117__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-1.507188
+-1.4896739
+-1.2924967
+0.0
+1.2924967
+1.4711277
+1.4896739
+1.507188","%null%
+-1.507188
+-1.4896739
+-1.2924967
+0.0
+1.2924967
+1.4711277
+1.4896739
+1.507188"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.atan2,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.atan2.txt,True,0,0,"ATAN2([int2],1)",expression,,None,None,334.0,"
+      SELECT ATAN2(`calcs`.`int2`, 1) AS `temp_test__2745915023__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-1.4601391
+-1.4464413
+-1.4056476
+-1.3734008
+-1.3258177
+-1.2490458
+0.0
+1.1071487
+1.2490458
+1.3258177
+1.3734008
+1.4056476
+1.4601391","-1.4601391
+-1.4464413
+-1.4056476
+-1.3734008
+-1.3258177
+-1.2490458
+0.0
+1.1071487
+1.2490458
+1.3258177
+1.3734008
+1.4056476
+1.4601391"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.atan2,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.atan2.txt,True,0,0,"atan2(num0,num1)",expression,,None,None,326.0,"
+      SELECT ATAN2(`calcs`.`num0`, `calcs`.`num1`) AS `temp_test__3341395046__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-1.1287781
+-1.0713926
+-0.35713401
+0.0
+0.36902363
+0.81261281
+0.97051299
+1.013687","%null%
+-1.1287781
+-1.0713926
+-0.35713401
+0.0
+0.36902363
+0.81261281
+0.97051299
+1.013687"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.ceilfloor,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.ceilfloor.txt,True,0,0,CEILING([num0]),expression,,None,None,331.0,"
+      SELECT CAST(CEILING(`calcs`.`num0`) AS BIGINT) AS `temp_test__739736782__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-15
+-12
+-3
+0
+4
+10
+13
+16","%null%
+-15
+-12
+-3
+0
+4
+10
+13
+16"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.ceilfloor,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.ceilfloor.txt,True,0,0,CEILING([num1]),expression,,None,None,297.0,"
+      SELECT CAST(CEILING(`calcs`.`num1`) AS BIGINT) AS `temp_test__408310354__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","3
+7
+8
+9
+10
+11
+12
+13
+17","3
+7
+8
+9
+10
+11
+12
+13
+17"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.ceilfloor,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.ceilfloor.txt,True,0,0,CEILING([num3]+[num4]),expression,,None,None,334.0,"
+      SELECT CAST(CEILING((`calcs`.`num3` + `calcs`.`num4`)) AS BIGINT) AS `temp_test__645239290__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-25
+-13
+-9
+-8
+-7
+-6
+-4
+-3
+2
+15
+22","%null%
+-25
+-13
+-9
+-8
+-7
+-6
+-4
+-3
+2
+15
+22"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.ceilfloor,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.ceilfloor.txt,True,0,0,FLOOR([num0]),expression,,None,None,397.0,"
+      SELECT CAST(FLOOR(`calcs`.`num0`) AS BIGINT) AS `temp_test__965933154__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-16
+-13
+-4
+0
+3
+10
+12
+15","%null%
+-16
+-13
+-4
+0
+3
+10
+12
+15"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.ceilfloor,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.ceilfloor.txt,True,0,0,FLOOR([num1]),expression,,None,None,337.0,"
+      SELECT CAST(FLOOR(`calcs`.`num1`) AS BIGINT) AS `temp_test__3363679606__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","2
+6
+7
+8
+9
+10
+11
+12
+16","2
+6
+7
+8
+9
+10
+11
+12
+16"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.ceilfloor,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.ceilfloor.txt,True,0,0,FLOOR([num3]+[num4]),expression,,None,None,344.0,"
+      SELECT CAST(FLOOR((`calcs`.`num3` + `calcs`.`num4`)) AS BIGINT) AS `temp_test__4164962185__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-26
+-14
+-10
+-9
+-8
+-7
+-5
+-4
+1
+14
+21","%null%
+-26
+-14
+-10
+-9
+-8
+-7
+-5
+-4
+1
+14
+21"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.cos,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.cos.txt,True,0,0,COS([int2]),expression,,None,None,327.0,"
+      SELECT COS(`calcs`.`int2`) AS `temp_test__344207442__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-0.9899925
+-0.91113026
+-0.65364362
+-0.41614684
+-0.14550003
+0.28366219
+0.96017029
+1.0","-0.9899925
+-0.91113026
+-0.65364362
+-0.41614684
+-0.14550003
+0.28366219
+0.96017029
+1.0"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.cos,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.cos.txt,True,0,0,cos(num0),expression,,None,None,311.0,"
+      SELECT COS(`calcs`.`num0`) AS `temp_test__1355320598__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-0.99996829
+-0.93645669
+-0.83907153
+0.96473262
+1.0","%null%
+-0.99996829
+-0.93645669
+-0.83907153
+0.96473262
+1.0"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.cot,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.cot.txt,True,0,0,COT([int2]),expression,,None,None,356.0,"
+      SELECT IF(`calcs`.`int2` != 0, COS(`calcs`.`int2`)/SIN(`calcs`.`int2`), NULL) AS `temp_test__2415226193__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-7.0152526
+-3.436353
+-2.2108454
+-0.86369115
+-0.45765755
+-0.29581292
+0.14706506
+0.29581292
+0.86369115
+2.2108454
+3.436353
+7.0152526","%null%
+-7.0152526
+-3.436353
+-2.2108454
+-0.86369115
+-0.45765755
+-0.29581292
+0.14706506
+0.29581292
+0.86369115
+2.2108454
+3.436353
+7.0152526"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.cot,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.cot.txt,True,0,0,cot(num0),expression,,None,None,342.0,"
+      SELECT IF(`calcs`.`num0` != 0, COS(`calcs`.`num0`)/SIN(`calcs`.`num0`), NULL) AS `temp_test__2834009176__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-125.57393
+-3.6649548
+-2.6696165
+1.542351
+2.6696165
+3.6649548
+125.57393","%null%
+-125.57393
+-3.6649548
+-2.6696165
+1.542351
+2.6696165
+3.6649548
+125.57393"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.degree,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.degree.txt,True,0,0,DEGREES([int2]),expression,,None,None,323.0,"
+      SELECT DEGREES(`calcs`.`int2`) AS `temp_test__2688244734__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-515.66202
+-458.36624
+-343.77468
+-286.4789
+-229.18312
+-171.88734
+0.0
+114.59156
+171.88734
+229.18312
+286.4789
+343.77468
+515.66202","-515.66202
+-458.36624
+-343.77468
+-286.4789
+-229.18312
+-171.88734
+0.0
+114.59156
+171.88734
+229.18312
+286.4789
+343.77468
+515.66202"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.degree,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.degree.txt,True,0,0,degrees(num0),expression,,None,None,334.0,"
+      SELECT DEGREES(`calcs`.`num0`) AS `temp_test__583539797__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-899.54374
+-704.73809
+-200.53523
+0.0
+200.53523
+572.9578
+704.73809
+899.54374","%null%
+-899.54374
+-704.73809
+-200.53523
+0.0
+200.53523
+572.9578
+704.73809
+899.54374"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.div,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.div.txt,True,1,0,"DIV([int2],2)",expression,,None,None,335.0,"
+      SELECT CASE WHEN 2 = 0 THEN NULL ELSE ( `calcs`.`int2` / 2 ) END AS `temp_test__266359676__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-4
+-4
+-3
+-2
+-2
+-1
+0
+1
+1
+2
+2
+3
+4","-4
+-4
+-3
+-2
+-2
+-1
+0
+1
+1
+2
+2
+3
+4"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.div,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.div.txt,True,1,0,"div(int0,int1)",expression,,None,None,324.0,"
+      SELECT CASE WHEN `calcs`.`int1` = 0 THEN NULL ELSE ( `calcs`.`int0` / `calcs`.`int1` ) END AS `temp_test__2600727600__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-1
+0
+0
+2","%null%
+-1
+0
+0
+2"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.div,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.div.txt,True,1,0,"div(int3,int2)",expression,,None,None,343.0,"
+      SELECT CASE WHEN `calcs`.`int2` = 0 THEN NULL ELSE ( `calcs`.`int3` / `calcs`.`int2` ) END AS `temp_test__3955107424__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-3
+-3
+-2
+-2
+-1
+-1
+0
+0
+0
+0
+1
+2
+3
+3
+4","%null%
+-3
+-3
+-2
+-2
+-1
+-1
+0
+0
+0
+0
+1
+2
+3
+3
+4"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.exp,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.exp.txt,True,0,0,exp(0.1*num0),expression,,None,None,328.0,"
+      SELECT EXP((0.10000000000000001 * `calcs`.`num0`)) AS `temp_test__526466750__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0.20804518
+0.29229258
+0.70468809
+1.0
+1.4190675
+2.7182818
+3.4212295
+4.8066482","%null%
+0.20804518
+0.29229258
+0.70468809
+1.0
+1.4190675
+2.7182818
+3.4212295
+4.8066482"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.exp,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.exp.txt,True,0,0,EXP([int2]),expression,,None,None,376.0,"
+      SELECT EXP(`calcs`.`int2`) AS `temp_test__2988208579__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","0.0001234098
+0.00033546263
+0.0024787522
+0.006737947
+0.018315639
+0.049787068
+1.0
+7.3890561
+20.085537
+54.59815
+148.41316
+403.42879
+8103.0839","0.0001234098
+0.00033546263
+0.0024787522
+0.006737947
+0.018315639
+0.049787068
+1.0
+7.3890561
+20.085537
+54.59815
+148.41316
+403.42879
+8103.0839"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.hexbin,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.hexbin.txt,True,0,0,"HEXBINX([int2],2)",expression,,None,None,502.0,"
+      SELECT (((CASE WHEN (ABS((2) - (CAST( ( (2) / SQRT(3.0) ) AS DECIMAL(18, 0) ) * SQRT(3.0)))) + SQRT(3.0) * ((ABS((`calcs`.`int2`) - (CAST( ( (`calcs`.`int2`) / 3.0 ) AS DECIMAL(18, 0) ) * 3.0))) - 1.0) > 0.0 THEN 1.5 ELSE 0.0 END) - (CASE WHEN ((`calcs`.`int2`) - (CAST( ( (`calcs`.`int2`) / 3.0 ) AS DECIMAL(18, 0) ) * 3.0) < 0.0) AND ((CASE WHEN (ABS((2) - (CAST( ( (2) / SQRT(3.0) ) AS DECIMAL(18, 0) ) * SQRT(3.0)))) + SQRT(3.0) * ((ABS((`calcs`.`int2`) - (CAST( ( (`calcs`.`int2`) / 3.0 ) AS DECIMAL(18, 0) ) * 3.0))) - 1.0) > 0.0 THEN 1.5 ELSE 0.0 END) > 0.0) THEN 3.0 ELSE 0.0 END)) + (CAST( ( (`calcs`.`int2`) / 3.0 ) AS DECIMAL(18, 0) ) * 3.0)) AS `temp_test__2503102272__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-9.0
+-7.5
+-6.0
+-4.5
+-3.0
+0.0
+1.5
+3.0
+4.5
+6.0
+9.0","-9.0
+-7.5
+-6.0
+-4.5
+-3.0
+0.0
+1.5
+3.0
+4.5
+6.0
+9.0"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.hexbin,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.hexbin.txt,True,0,0,"HEXBINY([int2],2)",expression,,None,None,398.0,"
+      SELECT ROUND(((CASE WHEN (ABS((2) - (CAST( ( (2) / SQRT(3.0) ) AS DECIMAL(18, 0) ) * SQRT(3.0)))) + SQRT(3.0) * ((ABS((`calcs`.`int2`) - (CAST( ( (`calcs`.`int2`) / 3.0 ) AS DECIMAL(18, 0) ) * 3.0))) - 1.0) > 0.0 THEN SQRT(3.0) / 2.0 ELSE 0.0 END) - (CASE WHEN ((2) - (CAST( ( (2) / SQRT(3.0) ) AS DECIMAL(18, 0) ) * SQRT(3.0)) < 0.0) AND ((CASE WHEN (ABS((2) - (CAST( ( (2) / SQRT(3.0) ) AS DECIMAL(18, 0) ) * SQRT(3.0)))) + SQRT(3.0) * ((ABS((`calcs`.`int2`) - (CAST( ( (`calcs`.`int2`) / 3.0 ) AS DECIMAL(18, 0) ) * 3.0))) - 1.0) > 0.0 THEN SQRT(3.0) / 2.0 ELSE 0.0 END) > 0.0) THEN SQRT(3.0) ELSE 0.0 END)) + (CAST( ( (2) / SQRT(3.0) ) AS DECIMAL(18, 0) ) * SQRT(3.0)),3) AS `temp_test__2977666156__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","1.732
+2.598","1.732
+2.598"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.ln,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.ln.txt,True,0,0,LN([int2]),expression,,None,None,341.0,"
+      SELECT (CASE WHEN `calcs`.`int2` > 0 THEN LN(`calcs`.`int2`) ELSE CAST(NULL AS DOUBLE) END) AS `temp_test__2832324438__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0.69314718
+1.0986123
+1.3862944
+1.6094379
+1.7917595
+2.1972246","%null%
+0.69314718
+1.0986123
+1.3862944
+1.6094379
+1.7917595
+2.1972246"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.ln,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.ln.txt,True,0,0,ln(num0),expression,,None,None,335.0,"
+      SELECT (CASE WHEN `calcs`.`num0` > 0 THEN LN(`calcs`.`num0`) ELSE CAST(NULL AS DOUBLE) END) AS `temp_test__1125921255__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+1.252763
+2.3025851
+2.5095993
+2.7536607","%null%
+1.252763
+2.3025851
+2.5095993
+2.7536607"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.log,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.log.txt,True,0,0,LOG([int2]),expression,,None,None,323.0,"
+      SELECT (CASE WHEN `calcs`.`int2` > 0 THEN LOG10(`calcs`.`int2`) ELSE CAST(NULL AS DOUBLE) END) AS `temp_test__114283928__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0.30103
+0.47712125
+0.60205999
+0.69897
+0.77815125
+0.95424251","%null%
+0.30103
+0.47712125
+0.60205999
+0.69897
+0.77815125
+0.95424251"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.log,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.log.txt,True,0,0,"LOG([int2],2)",expression,,None,None,361.0,"
+      SELECT (CASE WHEN `calcs`.`int2` > 0 THEN LOG10(`calcs`.`int2`) / LOG10(2) ELSE NULL END) AS `temp_test__3322085183__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+1.0
+1.5849625
+2.0
+2.3219281
+2.5849625
+3.169925","%null%
+1.0
+1.5849625
+2.0
+2.3219281
+2.5849625
+3.169925"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.log,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.log.txt,True,0,0,log(num0),expression,,None,None,314.0,"
+      SELECT (CASE WHEN `calcs`.`num0` > 0 THEN LOG10(`calcs`.`num0`) ELSE CAST(NULL AS DOUBLE) END) AS `temp_test__1814892178__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0.54406804
+1.0
+1.0899051
+1.1958997","%null%
+0.54406804
+1.0
+1.0899051
+1.1958997"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.log,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.log.txt,True,0,0,"log(num0,2)",expression,,None,None,322.0,"
+      SELECT (CASE WHEN `calcs`.`num0` > 0 THEN LOG10(`calcs`.`num0`) / LOG10(2) ELSE NULL END) AS `temp_test__3081102343__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+1.8073549
+3.3219281
+3.6205864
+3.9726927","%null%
+1.8073549
+3.3219281
+3.6205864
+3.9726927"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.max,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.max.txt,True,0,0,MAX([int0]),expression,,None,None,6.0,"
+      SELECT MAX(`calcs`.`int0`) AS `temp_test__56370746__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",11,11
+databricks,expression.standard.databricks,cast_calcs.databricks,math.max,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.max.txt,True,0,0,"MAX([int1],[int2] )",expression,,None,None,348.0,"
+      SELECT (CASE
+	WHEN (`calcs`.`int1` IS NULL) OR (`calcs`.`int2` IS NULL) THEN NULL
+	WHEN `calcs`.`int1` > `calcs`.`int2` THEN `calcs`.`int1`
+	ELSE `calcs`.`int2` END) AS `temp_test__2763474205__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-4
+2
+3
+5
+6","%null%
+-4
+2
+3
+5
+6"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.min,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.min.txt,True,0,0,MIN([int0]),expression,,None,None,6.0,"
+      SELECT MIN(`calcs`.`int0`) AS `temp_test__4016644369__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",1,1
+databricks,expression.standard.databricks,cast_calcs.databricks,math.min,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.min.txt,True,0,0,"MIN([int1], [int2])",expression,,None,None,330.0,"
+      SELECT (CASE
+	WHEN (`calcs`.`int1` IS NULL) OR (`calcs`.`int2` IS NULL) THEN NULL
+	WHEN `calcs`.`int1` < `calcs`.`int2` THEN `calcs`.`int1`
+	ELSE `calcs`.`int2` END) AS `temp_test__1701645592__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-9
+-8
+-6
+-5
+-3
+0","%null%
+-9
+-8
+-6
+-5
+-3
+0"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.pi,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.pi.txt,True,0,0,PI(),expression,,None,None,313.0,"
+      SELECT PI() AS `temp_test__356598120__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",3.1415927,3.1415927
+databricks,expression.standard.databricks,cast_calcs.databricks,math.pi,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.pi.txt,True,0,0,pi()*num0,expression,,None,None,336.0,"
+      SELECT (PI() * `calcs`.`num0`) AS `temp_test__1299212312__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-49.323005
+-38.64159
+-10.995574
+0.0
+10.995574
+31.415927
+38.64159
+49.323005","%null%
+-49.323005
+-38.64159
+-10.995574
+0.0
+10.995574
+31.415927
+38.64159
+49.323005"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.power.real,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.power.real.txt,True,0,0,"power(int0,0.5)",expression,,None,None,333.0,"
+      SELECT (CASE WHEN `calcs`.`int0` < 0 AND FLOOR(0.5) <> 0.5 THEN NULL ELSE POW(`calcs`.`int0`,0.5) END) AS `temp_test__3264960529__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+1.0
+1.7320508
+2.0
+2.6457513
+2.8284271
+3.1622777
+3.3166248","%null%
+1.0
+1.7320508
+2.0
+2.6457513
+2.8284271
+3.1622777
+3.3166248"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.power.real,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.power.real.txt,True,0,0,"power(num1,0.1*num0)",expression,,None,None,353.0,"
+      SELECT (CASE WHEN `calcs`.`num1` < 0 AND FLOOR((0.10000000000000001 * `calcs`.`num0`)) <> (0.10000000000000001 * `calcs`.`num0`) THEN NULL ELSE POW(`calcs`.`num1`,(0.10000000000000001 * `calcs`.`num0`)) END) AS `temp_test__2631457506__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0.042908918
+0.096190305
+0.45680306
+1.0
+2.1618572
+9.47
+13.744656
+35.878312","%null%
+0.042908918
+0.096190305
+0.45680306
+1.0
+2.1618572
+9.47
+13.744656
+35.878312"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.power,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.power.txt,True,0,0,"POWER([int2], 2)",expression,,None,None,341.0,"
+      SELECT POW(CAST(`calcs`.`int2` AS DOUBLE),2) AS `temp_test__3037854782__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","0.0
+4.0
+9.0
+16.0
+25.0
+36.0
+64.0
+81.0","0.0
+4.0
+9.0
+16.0
+25.0
+36.0
+64.0
+81.0"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.radians,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.radians.txt,True,0,0,RADIANS([int2]),expression,,None,None,331.0,"
+      SELECT RADIANS(`calcs`.`int2`) AS `temp_test__1973795369__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-0.15707963
+-0.13962634
+-0.10471976
+-0.087266463
+-0.06981317
+-0.052359878
+0.0
+0.034906585
+0.052359878
+0.06981317
+0.087266463
+0.10471976
+0.15707963","-0.15707963
+-0.13962634
+-0.10471976
+-0.087266463
+-0.06981317
+-0.052359878
+0.0
+0.034906585
+0.052359878
+0.06981317
+0.087266463
+0.10471976
+0.15707963"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.radians,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.radians.txt,True,0,0,radians(num0),expression,,None,None,314.0,"
+      SELECT RADIANS(`calcs`.`num0`) AS `temp_test__2823743498__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-0.27401669
+-0.2146755
+-0.061086524
+0.0
+0.061086524
+0.17453293
+0.2146755
+0.27401669","%null%
+-0.27401669
+-0.2146755
+-0.061086524
+0.0
+0.061086524
+0.17453293
+0.2146755
+0.27401669"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.round.B584401,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.round.B584401.txt,True,0,0,"ROUND([num3],0)",expression,,None,None,584.0,"
+      SELECT ROUND(`calcs`.`num3`,0) AS `temp_test__3830326670__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-20.0
+-18.0
+-13.0
+-12.0
+-11.0
+-9.0
+-7.0
+-5.0
+-3.0
+4.0
+7.0
+11.0
+13.0","-20.0
+-18.0
+-13.0
+-12.0
+-11.0
+-9.0
+-7.0
+-5.0
+-3.0
+4.0
+7.0
+11.0
+13.0"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.round.B584401,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.round.B584401.txt,True,0,0,ROUND([num3]),expression,,None,None,309.0,"
+      SELECT ROUND(`calcs`.`num3`) AS `temp_test__4174655436__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-20.0
+-18.0
+-13.0
+-12.0
+-11.0
+-9.0
+-7.0
+-5.0
+-3.0
+4.0
+7.0
+11.0
+13.0","-20.0
+-18.0
+-13.0
+-12.0
+-11.0
+-9.0
+-7.0
+-5.0
+-3.0
+4.0
+7.0
+11.0
+13.0"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.round,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.round.txt,True,0,0,ROUND([int2]),expression,,None,None,339.0,"
+      SELECT ROUND(`calcs`.`int2`) AS `temp_test__366741644__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-9.0
+-8.0
+-6.0
+-5.0
+-4.0
+-3.0
+0.0
+2.0
+3.0
+4.0
+5.0
+6.0
+9.0","-9.0
+-8.0
+-6.0
+-5.0
+-4.0
+-3.0
+0.0
+2.0
+3.0
+4.0
+5.0
+6.0
+9.0"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.round,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.round.txt,True,0,0,"ROUND([int2], 2)",expression,,None,None,295.0,"
+      SELECT ROUND(`calcs`.`int2`,2) AS `temp_test__1240237577__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-9.0
+-8.0
+-6.0
+-5.0
+-4.0
+-3.0
+0.0
+2.0
+3.0
+4.0
+5.0
+6.0
+9.0","-9.0
+-8.0
+-6.0
+-5.0
+-4.0
+-3.0
+0.0
+2.0
+3.0
+4.0
+5.0
+6.0
+9.0"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.round,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.round.txt,True,0,0,round(num0),expression,,None,None,304.0,"
+      SELECT ROUND(`calcs`.`num0`) AS `temp_test__3892529067__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-16.0
+-12.0
+-4.0
+0.0
+4.0
+10.0
+12.0
+16.0","%null%
+-16.0
+-12.0
+-4.0
+0.0
+4.0
+10.0
+12.0
+16.0"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.round,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.round.txt,True,0,0,"round(num4,1)",expression,,None,None,363.0,"
+      SELECT ROUND(`calcs`.`num4`,1) AS `temp_test__2722044748__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-14.2
+-13.5
+-10.2
+-6.1
+3.4
+3.8
+4.8
+6.8
+8.3
+10.7
+10.9
+19.4","%null%
+-14.2
+-13.5
+-10.2
+-6.1
+3.4
+3.8
+4.8
+6.8
+8.3
+10.7
+10.9
+19.4"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.sign,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.sign.txt,True,0,0,SIGN([int2]),expression,,None,None,324.0,"
+      SELECT SIGN(`calcs`.`int2`) AS `temp_test__3509671532__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-1
+0
+1","-1
+0
+1"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.sign,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.sign.txt,True,0,0,sign(num0),expression,,None,None,324.0,"
+      SELECT SIGN(`calcs`.`num0`) AS `temp_test__4247289834__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-1
+0
+1","%null%
+-1
+0
+1"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.sin,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.sin.txt,True,0,0,SIN([int2]),expression,,None,None,335.0,"
+      SELECT SIN(`calcs`.`int2`) AS `temp_test__527156183__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-0.98935825
+-0.95892427
+-0.7568025
+-0.41211849
+-0.2794155
+-0.14112001
+0.0
+0.14112001
+0.2794155
+0.41211849
+0.7568025
+0.90929743
+0.95892427","-0.98935825
+-0.95892427
+-0.7568025
+-0.41211849
+-0.2794155
+-0.14112001
+0.0
+0.14112001
+0.2794155
+0.41211849
+0.7568025
+0.90929743
+0.95892427"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.sin,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.sin.txt,True,0,0,sin(num0),expression,,None,None,324.0,"
+      SELECT SIN(`calcs`.`num0`) AS `temp_test__1184030290__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-0.54402111
+-0.35078323
+-0.26323179
+-0.0079631838
+0.0
+0.0079631838
+0.26323179
+0.35078323","%null%
+-0.54402111
+-0.35078323
+-0.26323179
+-0.0079631838
+0.0
+0.0079631838
+0.26323179
+0.35078323"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.sqrt,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.sqrt.txt,True,0,0,SQRT([int2]),expression,,None,None,318.0,"
+      SELECT (CASE WHEN `calcs`.`int2` < 0 THEN CAST(NULL AS DOUBLE) ELSE SQRT(`calcs`.`int2`) END) AS `temp_test__2398974448__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0.0
+1.4142136
+1.7320508
+2.0
+2.236068
+2.4494897
+3.0","%null%
+0.0
+1.4142136
+1.7320508
+2.0
+2.236068
+2.4494897
+3.0"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.sqrt,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.sqrt.txt,True,0,0,sqrt(num0),expression,,None,None,429.0,"
+      SELECT (CASE WHEN `calcs`.`num0` < 0 THEN CAST(NULL AS DOUBLE) ELSE SQRT(`calcs`.`num0`) END) AS `temp_test__634651992__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0.0
+1.8708287
+3.1622777
+3.5071356
+3.9623226","%null%
+0.0
+1.8708287
+3.1622777
+3.5071356
+3.9623226"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.square,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.square.txt,True,1,0,SQUARE([int2]),expression,,None,None,319.0,"
+      SELECT POW(`calcs`.`int2`,2) AS `temp_test__3898674109__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","0.0
+4.0
+9.0
+16.0
+25.0
+36.0
+64.0
+81.0","0.0
+4.0
+9.0
+16.0
+25.0
+36.0
+64.0
+81.0"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.square,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.square.txt,True,1,0,square(num0),expression,,None,None,314.0,"
+      SELECT POW(`calcs`.`num0`,2) AS `temp_test__1119897860__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0.0
+12.25
+100.0
+151.29
+246.49","%null%
+0.0
+12.25
+100.0
+151.29
+246.49"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.tan,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.tan.txt,True,0,0,TAN([int2]),expression,,None,None,329.0,"
+      SELECT (SIN(`calcs`.`int2`)/COS(`calcs`.`int2`)) AS `temp_test__1227693937__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-3.380515
+-2.1850399
+-1.1578213
+-0.45231566
+-0.29100619
+-0.14254654
+0.0
+0.14254654
+0.29100619
+0.45231566
+1.1578213
+3.380515
+6.7997115","-3.380515
+-2.1850399
+-1.1578213
+-0.45231566
+-0.29100619
+-0.14254654
+0.0
+0.14254654
+0.29100619
+0.45231566
+1.1578213
+3.380515
+6.7997115"
+databricks,expression.standard.databricks,cast_calcs.databricks,math.zn,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.math.zn.txt,True,0,0,ZN([int1]),expression,,None,None,332.0,"
+      SELECT COALESCE(CAST(`calcs`.`int1` AS BIGINT), CAST(0 AS BIGINT)) AS `temp_test__3976315675__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","-9
+-8
+-6
+-4
+-3
+0
+2
+3","-9
+-8
+-6
+-4
+-3
+0
+2
+3"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.bool.txt,True,0,0,not bool0,expression,,None,None,318.0,"
+      SELECT (NOT `calcs`.`bool0`) AS `temp_test__1413132553__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.bool.txt,True,0,0,NULL,expression,,None,None,382.0,"
+      SELECT CAST(NULL AS INT) AS `temp_test__496893948__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.bool.txt,True,0,0,TRUE,expression,,None,None,365.0,"
+      SELECT true AS `temp_test__1507734681__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.bool.txt,True,0,0,FALSE,expression,,None,None,312.0,"
+      SELECT false AS `temp_test__1303362598__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",false,false
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.bool.txt,True,0,0,bool0 AND bool1,expression,,None,None,311.0,"
+      SELECT (`calcs`.`bool0` AND `calcs`.`bool1`) AS `temp_test__3618731173__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.bool.txt,True,0,0,bool0 == bool1,expression,,None,None,337.0,"
+      SELECT (`calcs`.`bool0` AND `calcs`.`bool1` OR NOT `calcs`.`bool0` AND NOT `calcs`.`bool1`) AS `temp_test__830571724__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.bool.txt,True,0,0,bool0 != bool1,expression,,None,None,316.0,"
+      SELECT (`calcs`.`bool0` AND NOT `calcs`.`bool1` OR NOT `calcs`.`bool0` AND `calcs`.`bool1`) AS `temp_test__3090944671__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.bool,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.bool.txt,True,0,0,bool0 or bool1,expression,,None,None,304.0,"
+      SELECT (`calcs`.`bool0` OR `calcs`.`bool1`) AS `temp_test__4182992858__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.date.txt,True,0,0,date0 == #7/4/1972#,expression,,None,None,344.0,"
+      SELECT (`calcs`.`date0` = CAST('1972-07-04' AS DATE)) AS `temp_test__397499995__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.date.txt,True,0,0,date0 >= #11/12/1975#,expression,,None,None,310.0,"
+      SELECT (`calcs`.`date0` >= CAST('1975-11-12' AS DATE)) AS `temp_test__1366787273__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.date.txt,True,0,0,date0 > #11/12/1975#,expression,,None,None,314.0,"
+      SELECT (`calcs`.`date0` > CAST('1975-11-12' AS DATE)) AS `temp_test__3193322782__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.date.txt,True,0,0,date0 <= #11/12/1975#,expression,,None,None,310.0,"
+      SELECT (`calcs`.`date0` <= CAST('1975-11-12' AS DATE)) AS `temp_test__822657216__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.date.txt,True,0,0,date0 < #11/12/1975#,expression,,None,None,307.0,"
+      SELECT (`calcs`.`date0` < CAST('1975-11-12' AS DATE)) AS `temp_test__3764753091__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.date.txt,True,0,0,date0 - datetime0,expression,,None,None,385.0,"
+      SELECT (UNIX_TIMESTAMP(`calcs`.`date0`) - UNIX_TIMESTAMP(`calcs`.`datetime0`)) / 86400.0 AS `temp_test__937166222__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-11710.521
+-10491.333
+-85.428877
+-39.979421
+-31.55162","%null%
+-11710.521
+-10491.333
+-85.428877
+-39.979421
+-31.55162"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.date.txt,True,0,0,datetime0 - #1/1/2004#,expression,,None,None,362.0,"
+      SELECT (UNIX_TIMESTAMP(`calcs`.`datetime0`) - UNIX_TIMESTAMP(CAST('2004-01-01' AS DATE))) / 86400.0 AS `temp_test__100938644__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","185.95102
+186.55162
+190.42888
+193.72935
+195.32153
+195.34495
+198.58468
+200.93161
+203.0211
+204.88446
+206.64058
+207.52123
+209.28808
+209.52394
+209.97942
+212.49852
+214.33291","185.95102
+186.55162
+190.42888
+193.72935
+195.32153
+195.34495
+198.58468
+200.93161
+203.0211
+204.88446
+206.64058
+207.52123
+209.28808
+209.52394
+209.97942
+212.49852
+214.33291"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.date.txt,True,0,0,date0 - num4,expression,,None,None,351.0,"
+      SELECT CAST(FROM_UNIXTIME(CAST(CAST(`calcs`.`date0` AS TIMESTAMP) AS BIGINT) - CAST((`calcs`.`num4`) * 86400 AS INT)) AS TIMESTAMP) AS `temp_test__2923065813__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1972-06-23 03:36:00#
+#1975-11-25 11:16:48#
+#2004-06-10 01:12:00#
+#2004-06-10 16:19:12#","%null%
+#1972-06-23 03:36:00#
+#1975-11-25 11:16:48#
+#2004-06-10 01:12:00#
+#2004-06-10 16:19:12#"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.date.txt,True,0,0,date0 != #11/12/1975#,expression,,None,None,316.0,"
+      SELECT (`calcs`.`date0` <> CAST('1975-11-12' AS DATE)) AS `temp_test__798936259__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.date,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.date.txt,True,0,0,date0 + num4,expression,,None,None,368.0,"
+      SELECT CAST(FROM_UNIXTIME(CAST(CAST(CAST(`calcs`.`date0` AS TIMESTAMP) AS BIGINT) + (`calcs`.`num4` * 86400) AS BIGINT)) AS TIMESTAMP) AS `temp_test__2067341949__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+#1972-07-14 20:24:00#
+#1975-10-29 12:43:12#
+#2004-05-28 22:48:00#
+#2004-06-27 07:40:48#","%null%
+#1972-07-14 20:24:00#
+#1975-10-29 12:43:12#
+#2004-05-28 22:48:00#
+#2004-06-27 07:40:48#"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.int,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.int.txt,True,0,0,int0 % int1,expression,,None,None,349.0,"
+      SELECT PMOD(`calcs`.`int0`, `calcs`.`int1`) AS `temp_test__1307456344__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+1
+2
+8","%null%
+1
+2
+8"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.int,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.int.txt,True,0,0,int0 / int1,expression,,None,None,336.0,"
+      SELECT (CASE WHEN `calcs`.`int1` = 0 THEN NULL ELSE CAST(`calcs`.`int0` AS DOUBLE) / `calcs`.`int1` END) AS `temp_test__2402101080__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-1.25
+-0.88888889
+-0.33333333
+2.6666667","%null%
+-1.25
+-0.88888889
+-0.33333333
+2.6666667"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.int,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.int.txt,True,0,0,int3 / int2,expression,,None,None,364.0,"
+      SELECT (CASE WHEN `calcs`.`int2` = 0 THEN NULL ELSE CAST(`calcs`.`int3` AS DOUBLE) / `calcs`.`int2` END) AS `temp_test__3559262472__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-3.6666667
+-3.25
+-2.8333333
+-2.25
+-1.2222222
+-1.0
+-0.5
+-0.22222222
+0.0
+0.4
+1.6
+2.0
+3.0
+3.5
+4.5","%null%
+-3.6666667
+-3.25
+-2.8333333
+-2.25
+-1.2222222
+-1.0
+-0.5
+-0.22222222
+0.0
+0.4
+1.6
+2.0
+3.0
+3.5
+4.5"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.int,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.int.txt,True,0,0,int0 ^ num1,expression,,None,None,356.0,"
+      SELECT (CASE WHEN `calcs`.`int0` < 0 AND FLOOR(`calcs`.`num1`) <> `calcs`.`num1` THEN NULL ELSE POW(`calcs`.`int0`,`calcs`.`num1`) END) AS `temp_test__4265403921__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+1.0
+295.12092
+29881.154
+1634026.6
+1751306.3
+2691539.2
+24767836.0
+44477182.0
+1.3201657e+10
+1.578759e+11
+6.7412058e+14","%null%
+1.0
+295.12092
+29881.154
+1634026.6
+1751306.3
+2691539.2
+24767836.0
+44477182.0
+1.3201657e+10
+1.578759e+11
+6.7412058e+14"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,abs(num0),expression,,None,None,6.0,"
+      SELECT ABS(`calcs`.`num0`) AS `temp_test__3816473022__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0.0
+3.5
+10.0
+12.3
+15.7","%null%
+0.0
+3.5
+10.0
+12.3
+15.7"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,[num0],expression,,None,None,314.0,"
+      SELECT `calcs`.`num0` AS `temp_test__965512284__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-15.7
+-12.3
+-3.5
+0.0
+3.5
+10.0
+12.3
+15.7","%null%
+-15.7
+-12.3
+-3.5
+0.0
+3.5
+10.0
+12.3
+15.7"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,[num1],expression,,None,None,319.0,"
+      SELECT `calcs`.`num1` AS `temp_test__1826927073__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","2.47
+6.71
+7.1
+7.12
+7.43
+8.42
+9.05
+9.38
+9.47
+9.78
+10.32
+10.37
+11.38
+12.05
+12.4
+16.42
+16.81","2.47
+6.71
+7.1
+7.12
+7.43
+8.42
+9.05
+9.38
+9.47
+9.78
+10.32
+10.37
+11.38
+12.05
+12.4
+16.42
+16.81"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,-num0,expression,,None,None,327.0,"
+      SELECT (-`calcs`.`num0`) AS `temp_test__4188722171__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-15.7
+-12.3
+-10.0
+-3.5
+0.0
+3.5
+12.3
+15.7","%null%
+-15.7
+-12.3
+-10.0
+-3.5
+0.0
+3.5
+12.3
+15.7"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,num0 / num1,expression,,None,None,331.0,"
+      SELECT (CASE WHEN `calcs`.`num1` = 0 THEN NULL ELSE `calcs`.`num0` / `calcs`.`num1` END) AS `temp_test__272703322__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-2.1130552
+-1.8330849
+-0.37313433
+0.0
+0.38674033
+1.0559662
+1.4608076
+1.605317","%null%
+-2.1130552
+-1.8330849
+-0.37313433
+0.0
+0.38674033
+1.0559662
+1.4608076
+1.605317"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,num0=abs(num0),expression,,None,None,314.0,"
+      SELECT (`calcs`.`num0` = ABS(`calcs`.`num0`)) AS `temp_test__3360366790__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,num0==abs(num0),expression,,None,None,311.0,"
+      SELECT (`calcs`.`num0` = ABS(`calcs`.`num0`)) AS `temp_test__2564078271__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,num0 >= num1,expression,,None,None,305.0,"
+      SELECT (`calcs`.`num0` >= `calcs`.`num1`) AS `temp_test__1366300770__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,num0 > num1,expression,,None,None,333.0,"
+      SELECT (`calcs`.`num0` > `calcs`.`num1`) AS `temp_test__4123004830__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,num0 <= num1,expression,,None,None,325.0,"
+      SELECT (`calcs`.`num0` <= `calcs`.`num1`) AS `temp_test__1224631717__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,num0 < num1,expression,,None,None,311.0,"
+      SELECT (`calcs`.`num0` < `calcs`.`num1`) AS `temp_test__1731699042__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,num0 - num1,expression,,None,None,359.0,"
+      SELECT (`calcs`.`num0` - `calcs`.`num1`) AS `temp_test__3781247900__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-23.13
+-19.01
+-16.42
+-12.88
+-5.55
+0.53
+3.88
+5.92","%null%
+-23.13
+-19.01
+-16.42
+-12.88
+-5.55
+0.53
+3.88
+5.92"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,num0 <> abs(num0),expression,,None,None,323.0,"
+      SELECT (`calcs`.`num0` <> ABS(`calcs`.`num0`)) AS `temp_test__4047276454__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,num0 != abs(num0),expression,,None,None,299.0,"
+      SELECT (`calcs`.`num0` <> ABS(`calcs`.`num0`)) AS `temp_test__3492695719__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,num0 + num1,expression,,None,None,336.0,"
+      SELECT (`calcs`.`num0` + `calcs`.`num1`) AS `temp_test__977554451__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-8.27
+-5.59
+5.88
+12.55
+16.42
+19.47
+20.72
+25.48","%null%
+-8.27
+-5.59
+5.88
+12.55
+16.42
+19.47
+20.72
+25.48"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,num0 ^ num1,expression,,None,None,363.0,"
+      SELECT (CASE WHEN `calcs`.`num0` < 0 AND FLOOR(`calcs`.`num1`) <> `calcs`.`num1` THEN NULL ELSE POW(`calcs`.`num0`,`calcs`.`num1`) END) AS `temp_test__637953353__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0.0
+83910.402
+1.5031456e+09
+2.9512092e+09
+4.9647639e+11","%null%
+0.0
+83910.402
+1.5031456e+09
+2.9512092e+09
+4.9647639e+11"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.num,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.num.txt,True,0,0,num0 * num1,expression,,None,None,437.0,"
+      SELECT (`calcs`.`num0` * `calcs`.`num1`) AS `temp_test__1861245368__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+-116.651
+-82.533
+-32.83
+0.0
+31.675
+94.7
+103.566
+153.546","%null%
+-116.651
+-82.533
+-32.83
+0.0
+31.675
+94.7
+103.566
+153.546"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.str.txt,True,1,0,"str2 == iif(num3>0,str2,str3)",expression,,None,None,394.0,"
+      SELECT (`calcs`.`str2` = (CASE WHEN (`calcs`.`num3` > 0) THEN `calcs`.`str2` WHEN NOT (`calcs`.`num3` > 0) THEN `calcs`.`str3` ELSE NULL END)) AS `temp_test__1635792874__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.str.txt,True,1,0,"str2 >= iif(num3>0,lower(str0),str3)",expression,,None,None,330.0,"
+      SELECT (`calcs`.`str2` >= (CASE WHEN (`calcs`.`num3` > 0) THEN LOWER(`calcs`.`str0`) WHEN NOT (`calcs`.`num3` > 0) THEN `calcs`.`str3` ELSE NULL END)) AS `temp_test__1555382477__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.str.txt,True,1,0,"str2 > iif(num3>0,str0,str3)",expression,,None,None,318.0,"
+      SELECT (`calcs`.`str2` > (CASE WHEN (`calcs`.`num3` > 0) THEN `calcs`.`str0` WHEN NOT (`calcs`.`num3` > 0) THEN `calcs`.`str3` ELSE NULL END)) AS `temp_test__3821822049__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+true","%null%
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.str.txt,True,1,0,"str2 <= iif(num3>0,lower(str0),str3)",expression,,None,None,335.0,"
+      SELECT (`calcs`.`str2` <= (CASE WHEN (`calcs`.`num3` > 0) THEN LOWER(`calcs`.`str0`) WHEN NOT (`calcs`.`num3` > 0) THEN `calcs`.`str3` ELSE NULL END)) AS `temp_test__2776534421__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.str.txt,True,1,0,"str2 < iif(num3>0,lower(str0),str3)",expression,,None,None,337.0,"
+      SELECT (`calcs`.`str2` < (CASE WHEN (`calcs`.`num3` > 0) THEN LOWER(`calcs`.`str0`) WHEN NOT (`calcs`.`num3` > 0) THEN `calcs`.`str3` ELSE NULL END)) AS `temp_test__398649381__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.str.txt,True,1,0,"str2 != iif(num3>0,str2,str3)",expression,,None,None,334.0,"
+      SELECT (`calcs`.`str2` <> (CASE WHEN (`calcs`.`num3` > 0) THEN `calcs`.`str2` WHEN NOT (`calcs`.`num3` > 0) THEN `calcs`.`str3` ELSE NULL END)) AS `temp_test__119026413__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.str.txt,True,1,0,str2 + str3,expression,,None,None,357.0,"
+      SELECT CONCAT(`calcs`.`str2`,`calcs`.`str3`) AS `temp_test__724155660__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""eighte""
+""elevene""
+""fifteene""
+""onee""
+""sixteene""
+""tene""
+""threee""
+""twoe""","%null%
+""eighte""
+""elevene""
+""fifteene""
+""onee""
+""sixteene""
+""tene""
+""threee""
+""twoe"""
+databricks,expression.standard.databricks,cast_calcs.databricks,operator.str,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.operator.str.txt,True,1,0,"""Pat O'Hanrahan & <Matthew Eldridge]'""",expression,,None,None,328.0,"
+      SELECT 'Pat O\'Hanrahan & <Matthew Eldridge]\'' AS `temp_test__627207302__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ","""Pat O'Hanrahan & <Matthew Eldridge]'""","""Pat O'Hanrahan & <Matthew Eldridge]'"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.B21622,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.B21622.txt,True,0,0,str(int([num4])),expression,,None,None,322.0,"
+      SELECT CAST(CAST(`calcs`.`num4` AS BIGINT) AS STRING) AS `temp_test__1425036653__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""-10""
+""-13""
+""-14""
+""-6""
+""10""
+""19""
+""3""
+""4""
+""6""
+""8""","%null%
+""-10""
+""-13""
+""-14""
+""-6""
+""10""
+""19""
+""3""
+""4""
+""6""
+""8"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.ascii,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.ascii.txt,True,0,0,"ASCII(""a"")",expression,,None,None,339.0,"
+      SELECT ASCII('a') AS `temp_test__415603459__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",97,97
+databricks,expression.standard.databricks,cast_calcs.databricks,string.ascii,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.ascii.txt,True,0,0,ascii(str2),expression,,None,None,328.0,"
+      SELECT ASCII(`calcs`.`str2`) AS `temp_test__526259814__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+101
+102
+110
+111
+115
+116","%null%
+101
+102
+110
+111
+115
+116"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.ascii,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.ascii.txt,True,0,0,ascii(str1),expression,,None,None,301.0,"
+      SELECT ASCII(`calcs`.`str1`) AS `temp_test__4258651616__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","65
+66
+67
+68
+69","65
+66
+67
+68
+69"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.char,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.char.txt,True,0,0,CHAR(65),expression,,None,None,315.0,"
+      SELECT CHAR(65) AS `temp_test__3578809945__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ","""A""","""A"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.constants,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.constants.txt,True,0,0,'      ' + str2 + '      ',expression,,None,None,361.0,"
+      SELECT CONCAT(CONCAT('      ',`calcs`.`str2`),'      ') AS `temp_test__2313738384__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""      eight      ""
+""      eleven      ""
+""      fifteen      ""
+""      five      ""
+""      fourteen      ""
+""      nine      ""
+""      one      ""
+""      six      ""
+""      sixteen      ""
+""      ten      ""
+""      three      ""
+""      twelve      ""
+""      two      ""","%null%
+""      eight      ""
+""      eleven      ""
+""      fifteen      ""
+""      five      ""
+""      fourteen      ""
+""      nine      ""
+""      one      ""
+""      six      ""
+""      sixteen      ""
+""      ten      ""
+""      three      ""
+""      twelve      ""
+""      two      """
+databricks,expression.standard.databricks,cast_calcs.databricks,string.constants,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.constants.txt,True,0,0,'CONST',expression,,None,None,299.0,"
+      SELECT 'CONST' AS `temp_test__3972932107__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ","""CONST""","""CONST"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.contains.empty,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.contains.empty.txt,True,0,0,"CONTAINS(str2, LEFT(str2, 0))",expression,,None,None,323.0,"
+      SELECT `calcs`.`str2` RLIKE CONCAT('.*', CASE WHEN 0 >= 0 THEN SUBSTRING(`calcs`.`str2`,1,CAST(0 AS INT)) ELSE NULL END, '.*') AS `temp_test__3977299552__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+true","%null%
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.contains.regex,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.contains.regex.txt,True,0,0,"CONTAINS(str2, ""A("")",expression,,None,None,320.0,"
+      SELECT `calcs`.`str2` RLIKE CONCAT('.*', 'A\\(', '.*') AS `temp_test__2383066519__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false","%null%
+false"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.contains.regex,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.contains.regex.txt,True,0,0,"CONTAINS(str2, ""A\("")",expression,,None,None,301.0,"
+      SELECT `calcs`.`str2` RLIKE CONCAT('.*', 'A\\\\\\(', '.*') AS `temp_test__540594765__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false","%null%
+false"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.contains,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.contains.txt,True,0,0,"CONTAINS(str2, ""e"")",expression,,None,None,328.0,"
+      SELECT `calcs`.`str2` RLIKE CONCAT('.*', 'e', '.*') AS `temp_test__1364536471__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.contains,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.contains.txt,True,0,0,"CONTAINS(str1, ""IND"")",expression,,None,None,321.0,"
+      SELECT `calcs`.`str1` RLIKE CONCAT('.*', 'IND', '.*') AS `temp_test__1380546255__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","false
+true","false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.endswith,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.endswith.txt,True,0,0,"ENDSWITH(str1, ""s"")",expression,,None,None,364.0,"
+      SELECT 
+(CASE WHEN ((CASE WHEN (LENGTH(`calcs`.`str1`) - LENGTH('s')) < 0 THEN 1
+      ELSE LENGTH(`calcs`.`str1`) - LENGTH('s') + 1 END)
+ IS NULL) OR (LENGTH('s') IS NULL) THEN NULL
+      WHEN LENGTH('s') < 1 THEN ''
+      WHEN (CASE WHEN (LENGTH(`calcs`.`str1`) - LENGTH('s')) < 0 THEN 1
+      ELSE LENGTH(`calcs`.`str1`) - LENGTH('s') + 1 END)
+ < 1 THEN SUBSTRING(RTRIM(`calcs`.`str1`),CAST(1 AS INT),CAST(LENGTH('s') AS INT))
+      ELSE SUBSTRING(RTRIM(`calcs`.`str1`),CAST((CASE WHEN (LENGTH(`calcs`.`str1`) - LENGTH('s')) < 0 THEN 1
+      ELSE LENGTH(`calcs`.`str1`) - LENGTH('s') + 1 END)
+ AS INT),CAST(LENGTH('s') AS INT)) END) = 's' AS `temp_test__1759936097__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",false,false
+databricks,expression.standard.databricks,cast_calcs.databricks,string.endswith,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.endswith.txt,True,0,0,"ENDSWITH(str2, ""een"")",expression,,None,None,378.0,"
+      SELECT 
+(CASE WHEN ((CASE WHEN (LENGTH(`calcs`.`str2`) - LENGTH('een')) < 0 THEN 1
+      ELSE LENGTH(`calcs`.`str2`) - LENGTH('een') + 1 END)
+ IS NULL) OR (LENGTH('een') IS NULL) THEN NULL
+      WHEN LENGTH('een') < 1 THEN ''
+      WHEN (CASE WHEN (LENGTH(`calcs`.`str2`) - LENGTH('een')) < 0 THEN 1
+      ELSE LENGTH(`calcs`.`str2`) - LENGTH('een') + 1 END)
+ < 1 THEN SUBSTRING(RTRIM(`calcs`.`str2`),CAST(1 AS INT),CAST(LENGTH('een') AS INT))
+      ELSE SUBSTRING(RTRIM(`calcs`.`str2`),CAST((CASE WHEN (LENGTH(`calcs`.`str2`) - LENGTH('een')) < 0 THEN 1
+      ELSE LENGTH(`calcs`.`str2`) - LENGTH('een') + 1 END)
+ AS INT),CAST(LENGTH('een') AS INT)) END) = 'een' AS `temp_test__3179156403__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false
+true","%null%
+false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.find,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.find.txt,True,0,0,"FIND(str2, ""ee"")",expression,,None,None,346.0,"
+      SELECT INSTR( `calcs`.`str2`, 'ee' ) AS `temp_test__3981629397__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0
+4
+5
+6","%null%
+0
+4
+5
+6"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.find,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.find.txt,True,0,0,"find(str1,'E')",expression,,None,None,298.0,"
+      SELECT INSTR( `calcs`.`str1`, 'E' ) AS `temp_test__257220821__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","0
+1
+5
+6
+7
+11
+15
+17","0
+1
+5
+6
+7
+11
+15
+17"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.find,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.find.txt,True,0,0,"find(str1,'E',6)",expression,,None,None,356.0,"
+      SELECT (CASE
+	WHEN (6 IS NULL) THEN NULL
+	WHEN 6 < 1 THEN INSTR( `calcs`.`str1`, 'E' )
+	WHEN 0 = INSTR( SUBSTRING(`calcs`.`str1`,CAST(6 AS INT),CAST(LENGTH(`calcs`.`str1`) - (6) + 1 AS INT)), 'E' ) THEN 0
+	ELSE INSTR( SUBSTRING(`calcs`.`str1`,CAST(6 AS INT),CAST(LENGTH(`calcs`.`str1`) - (6) + 1 AS INT)), 'E' ) + 6 - 1
+	END) AS `temp_test__282093116__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","0
+6
+7
+9
+11
+15
+17","0
+6
+7
+9
+11
+15
+17"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.find,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.find.txt,True,0,0,"find(str2,str3)",expression,,None,None,328.0,"
+      SELECT INSTR( `calcs`.`str2`, `calcs`.`str3` ) AS `temp_test__3096760581__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0
+1
+2
+3
+4
+5","%null%
+0
+1
+2
+3
+4
+5"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.find,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.find.txt,True,0,0,"find(str2,str3,num4*.2)",expression,,None,None,388.0,"
+      SELECT (CASE
+	WHEN ((`calcs`.`num4` * 0.20000000000000001) IS NULL) THEN NULL
+	WHEN (`calcs`.`num4` * 0.20000000000000001) < 1 THEN INSTR( `calcs`.`str2`, `calcs`.`str3` )
+	WHEN 0 = INSTR( SUBSTRING(`calcs`.`str2`,CAST((`calcs`.`num4` * 0.20000000000000001) AS INT),CAST(LENGTH(`calcs`.`str2`) - ((`calcs`.`num4` * 0.20000000000000001)) + 1 AS INT)), `calcs`.`str3` ) THEN 0
+	ELSE INSTR( SUBSTRING(`calcs`.`str2`,CAST((`calcs`.`num4` * 0.20000000000000001) AS INT),CAST(LENGTH(`calcs`.`str2`) - ((`calcs`.`num4` * 0.20000000000000001)) + 1 AS INT)), `calcs`.`str3` ) + CAST((`calcs`.`num4` * 0.20000000000000001) AS BIGINT) - 1
+	END) AS `temp_test__2787932066__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+0
+1
+3
+4
+5","%null%
+0
+1
+3
+4
+5"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.isdate,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.isdate.txt,True,0,0,"ISDATE(""2015-01-01"")",expression,,None,None,306.0,"
+      SELECT (CAST('2015-01-01' AS DATE) IS NOT NULL) AS `temp_test__3095770696__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,string.isdate,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.isdate.txt,True,0,0,"ISDATE(""data"")",expression,,None,None,298.0,"
+      SELECT (CAST('data' AS DATE) IS NOT NULL) AS `temp_test__334867691__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",false,false
+databricks,expression.standard.databricks,cast_calcs.databricks,string.left.negative,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.left.negative.txt,True,0,0,"LEFT([str0],-2)",expression,,None,None,325.0,"
+      SELECT CASE WHEN -2 >= 0 THEN SUBSTRING(`calcs`.`str0`,1,CAST(-2 AS INT)) ELSE NULL END AS `temp_test__765040119__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ",%null%,%null%
+databricks,expression.standard.databricks,cast_calcs.databricks,string.left.real,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.left.real.txt,True,0,0,"left(str0,num4)",expression,,None,None,333.0,"
+      SELECT CASE WHEN `calcs`.`num4` >= 0 THEN SUBSTRING(`calcs`.`str0`,1,CAST(CAST(`calcs`.`num4` AS BIGINT) AS INT)) ELSE NULL END AS `temp_test__1907571572__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""FURNITURE""
+""OFFICE S""
+""OFFICE SUP""
+""TEC""
+""TECH""
+""TECHNO""
+""TECHNOLOGY""","%null%
+""FURNITURE""
+""OFFICE S""
+""OFFICE SUP""
+""TEC""
+""TECH""
+""TECHNO""
+""TECHNOLOGY"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.left,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.left.txt,True,0,0,"LEFT(str1, 2)",expression,,None,None,318.0,"
+      SELECT CASE WHEN 2 >= 0 THEN SUBSTRING(`calcs`.`str1`,1,CAST(2 AS INT)) ELSE NULL END AS `temp_test__2443162804__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""AI""
+""AN""
+""BI""
+""BU""
+""CD""
+""CL""
+""CO""
+""DO""
+""DV""
+""ER""","""AI""
+""AN""
+""BI""
+""BU""
+""CD""
+""CL""
+""CO""
+""DO""
+""DV""
+""ER"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.left,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.left.txt,True,0,0,"left(str2,3)",expression,,None,None,331.0,"
+      SELECT CASE WHEN 3 >= 0 THEN SUBSTRING(`calcs`.`str2`,1,CAST(3 AS INT)) ELSE NULL END AS `temp_test__1954670685__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""eig""
+""ele""
+""fif""
+""fiv""
+""fou""
+""nin""
+""one""
+""six""
+""ten""
+""thr""
+""twe""
+""two""","%null%
+""eig""
+""ele""
+""fif""
+""fiv""
+""fou""
+""nin""
+""one""
+""six""
+""ten""
+""thr""
+""twe""
+""two"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.left,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.left.txt,True,0,0,"left(str2,int0)",expression,,None,None,335.0,"
+      SELECT CASE WHEN `calcs`.`int0` >= 0 THEN SUBSTRING(`calcs`.`str2`,1,CAST(`calcs`.`int0` AS INT)) ELSE NULL END AS `temp_test__3664185027__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""elev""
+""fifteen""
+""five""
+""four""
+""o""
+""six""
+""sixt""
+""ten""
+""twelve""","%null%
+""elev""
+""fifteen""
+""five""
+""four""
+""o""
+""six""
+""sixt""
+""ten""
+""twelve"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.len,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.len.txt,True,0,0,"LEN(""data"")",expression,,None,None,323.0,"
+      SELECT LENGTH('data') AS `temp_test__5037157__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",4,4
+databricks,expression.standard.databricks,cast_calcs.databricks,string.len,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.len.txt,True,0,0,len(str2),expression,,None,None,331.0,"
+      SELECT LENGTH(`calcs`.`str2`) AS `temp_test__382448263__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+3
+4
+5
+6
+7
+8","%null%
+3
+4
+5
+6
+7
+8"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.lower,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.lower.txt,True,0,0,LOWER(str2),expression,,None,None,342.0,"
+      SELECT LOWER(`calcs`.`str2`) AS `temp_test__1011144549__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two""","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.lower,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.lower.txt,True,0,0,lower(str1),expression,,None,None,299.0,"
+      SELECT LOWER(`calcs`.`str1`) AS `temp_test__2419238545__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""air purifiers""
+""answering machines""
+""binder accessories""
+""binder clips""
+""binding machines""
+""binding supplies""
+""business copiers""
+""business envelopes""
+""cd-r media""
+""clamp on lamps""
+""clocks""
+""conference phones""
+""corded keyboards""
+""cordless keyboards""
+""dot matrix printers""
+""dvd""
+""ericsson""","""air purifiers""
+""answering machines""
+""binder accessories""
+""binder clips""
+""binding machines""
+""binding supplies""
+""business copiers""
+""business envelopes""
+""cd-r media""
+""clamp on lamps""
+""clocks""
+""conference phones""
+""corded keyboards""
+""cordless keyboards""
+""dot matrix printers""
+""dvd""
+""ericsson"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.ltrim,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.ltrim.txt,True,0,0,"LTRIM("" "" + str2 + "" "")",expression,,None,None,327.0,"
+      SELECT LTRIM(CONCAT(CONCAT(' ',`calcs`.`str2`),' ')) AS `temp_test__1106979036__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""eight ""
+""eleven ""
+""fifteen ""
+""five ""
+""fourteen ""
+""nine ""
+""one ""
+""six ""
+""sixteen ""
+""ten ""
+""three ""
+""twelve ""
+""two ""","%null%
+""eight ""
+""eleven ""
+""fifteen ""
+""five ""
+""fourteen ""
+""nine ""
+""one ""
+""six ""
+""sixteen ""
+""ten ""
+""three ""
+""twelve ""
+""two """
+databricks,expression.standard.databricks,cast_calcs.databricks,string.max,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.max.txt,True,0,0,"MAX(str1, str2)",expression,,None,None,380.0,"
+      SELECT (CASE
+	WHEN (`calcs`.`str1` IS NULL) OR (`calcs`.`str2` IS NULL) THEN NULL
+	WHEN `calcs`.`str1` > `calcs`.`str2` THEN `calcs`.`str1`
+	ELSE `calcs`.`str2` END) AS `temp_test__3052188625__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two""","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.max,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.max.txt,True,0,0,"MAX(str3, str2)",expression,,None,None,328.0,"
+      SELECT (CASE
+	WHEN (`calcs`.`str3` IS NULL) OR (`calcs`.`str2` IS NULL) THEN NULL
+	WHEN `calcs`.`str3` > `calcs`.`str2` THEN `calcs`.`str3`
+	ELSE `calcs`.`str2` END) AS `temp_test__2280873463__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""eight""
+""eleven""
+""fifteen""
+""one""
+""sixteen""
+""ten""
+""three""
+""two""","%null%
+""eight""
+""eleven""
+""fifteen""
+""one""
+""sixteen""
+""ten""
+""three""
+""two"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.mid.calc,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.mid.calc.txt,True,0,0,"mid(str2,(num0+5)*.3,num1)",expression,,None,None,346.0,"
+      SELECT 
+(CASE WHEN (((`calcs`.`num0` + 5) * 0.29999999999999999) IS NULL) OR (`calcs`.`num1` IS NULL) THEN NULL
+      WHEN `calcs`.`num1` < 1 THEN ''
+      WHEN ((`calcs`.`num0` + 5) * 0.29999999999999999) < 1 THEN SUBSTRING(`calcs`.`str2`,CAST(1 AS INT),CAST(CAST(`calcs`.`num1` AS BIGINT) AS INT))
+      ELSE SUBSTRING(`calcs`.`str2`,CAST(CAST(((`calcs`.`num0` + 5) * 0.29999999999999999) AS BIGINT) AS INT),CAST(CAST(`calcs`.`num1` AS BIGINT) AS INT)) END) AS `temp_test__1934432200__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""""
+""e""
+""ive""
+""six""
+""two""","%null%
+""""
+""e""
+""ive""
+""six""
+""two"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.mid,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.mid.txt,True,2,0,"mid(str1,6)",expression,,None,None,511.0,"
+      SELECT 
+(CASE WHEN (6 IS NULL) OR 6 < 1 THEN NULL
+      ELSE SUBSTRING(`calcs`.`str1`,CAST(6 AS INT),CAST(LENGTH(`calcs`.`str1`) - (6) + 1 AS INT)) END) AS `temp_test__98307893__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""""
+"" ON LAMPS""
+""ATRIX PRINTERS""
+""D KEYBOARDS""
+""ESS COPIERS""
+""ESS ENVELOPES""
+""ESS KEYBOARDS""
+""MEDIA""
+""NG MACHINES""
+""NG SUPPLIES""
+""R ACCESSORIES""
+""R CLIPS""
+""RENCE PHONES""
+""RING MACHINES""
+""S""
+""SON""
+""URIFIERS""","""""
+"" ON LAMPS""
+""ATRIX PRINTERS""
+""D KEYBOARDS""
+""ESS COPIERS""
+""ESS ENVELOPES""
+""ESS KEYBOARDS""
+""MEDIA""
+""NG MACHINES""
+""NG SUPPLIES""
+""R ACCESSORIES""
+""R CLIPS""
+""RENCE PHONES""
+""RING MACHINES""
+""S""
+""SON""
+""URIFIERS"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.mid,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.mid.txt,True,2,0,"mid(str1,2, 4)",expression,,None,None,344.0,"
+      SELECT 
+(CASE WHEN (2 IS NULL) OR (4 IS NULL) THEN NULL
+      WHEN 4 < 1 THEN ''
+      WHEN 2 < 1 THEN SUBSTRING(`calcs`.`str1`,CAST(1 AS INT),CAST(4 AS INT))
+      ELSE SUBSTRING(`calcs`.`str1`,CAST(2 AS INT),CAST(4 AS INT)) END) AS `temp_test__3472698691__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","""D-R ""
+""INDE""
+""INDI""
+""IR P""
+""LAMP""
+""LOCK""
+""NSWE""
+""ONFE""
+""ORDE""
+""ORDL""
+""OT M""
+""RICS""
+""USIN""
+""VD""","""D-R ""
+""INDE""
+""INDI""
+""IR P""
+""LAMP""
+""LOCK""
+""NSWE""
+""ONFE""
+""ORDE""
+""ORDL""
+""OT M""
+""RICS""
+""USIN""
+""VD"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.min,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.min.txt,True,0,0,"MIN(""Data"", ""Tableau"")",expression,,None,None,335.0,"
+      SELECT (CASE
+	WHEN ('Data' IS NULL) OR ('Tableau' IS NULL) THEN NULL
+	WHEN 'Data' < 'Tableau' THEN 'Data'
+	ELSE 'Tableau' END) AS `temp_test__535453017__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ","""Data""","""Data"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.min,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.min.txt,True,0,0,"MIN(str1, str2)",expression,,None,None,334.0,"
+      SELECT (CASE
+	WHEN (`calcs`.`str1` IS NULL) OR (`calcs`.`str2` IS NULL) THEN NULL
+	WHEN `calcs`.`str1` < `calcs`.`str2` THEN `calcs`.`str1`
+	ELSE `calcs`.`str2` END) AS `temp_test__497224717__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""AIR PURIFIERS""
+""ANSWERING MACHINES""
+""BINDER CLIPS""
+""BINDING MACHINES""
+""BUSINESS COPIERS""
+""BUSINESS ENVELOPES""
+""CD-R MEDIA""
+""CLAMP ON LAMPS""
+""CLOCKS""
+""CONFERENCE PHONES""
+""CORDLESS KEYBOARDS""
+""DOT MATRIX PRINTERS""
+""DVD""","%null%
+""AIR PURIFIERS""
+""ANSWERING MACHINES""
+""BINDER CLIPS""
+""BINDING MACHINES""
+""BUSINESS COPIERS""
+""BUSINESS ENVELOPES""
+""CD-R MEDIA""
+""CLAMP ON LAMPS""
+""CLOCKS""
+""CONFERENCE PHONES""
+""CORDLESS KEYBOARDS""
+""DOT MATRIX PRINTERS""
+""DVD"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.min,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.min.txt,True,0,0,"MIN(str2, str3)",expression,,None,None,303.0,"
+      SELECT (CASE
+	WHEN (`calcs`.`str2` IS NULL) OR (`calcs`.`str3` IS NULL) THEN NULL
+	WHEN `calcs`.`str2` < `calcs`.`str3` THEN `calcs`.`str2`
+	ELSE `calcs`.`str3` END) AS `temp_test__1239505702__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""e""","%null%
+""e"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.replace,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.replace.txt,True,0,0,"REPLACE(""cat"", ""c"", ""b"") //cat->bat",expression,,None,None,524.0,"
+      SELECT REGEXP_REPLACE('cat','c','b') AS `temp_test__3161246105__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ","""bat""","""bat"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.replace,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.replace.txt,True,0,0,"REPLACE(str2, ""e"", ""o"")",expression,,None,None,340.0,"
+      SELECT REGEXP_REPLACE(`calcs`.`str2`,'e','o') AS `temp_test__2953834147__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""fiftoon""
+""fivo""
+""fourtoon""
+""nino""
+""oight""
+""olovon""
+""ono""
+""six""
+""sixtoon""
+""throo""
+""ton""
+""two""
+""twolvo""","%null%
+""fiftoon""
+""fivo""
+""fourtoon""
+""nino""
+""oight""
+""olovon""
+""ono""
+""six""
+""sixtoon""
+""throo""
+""ton""
+""two""
+""twolvo"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.right.real,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.right.real.txt,True,0,0,"right(str0,num4)",expression,,None,None,344.0,"
+      SELECT (CASE WHEN `calcs`.`num4` >= 0 THEN IF(LENGTH(`calcs`.`str0`) < `calcs`.`num4` + 1, `calcs`.`str0`, SUBSTRING(`calcs`.`str0`, LENGTH(`calcs`.`str0`) - CAST(`calcs`.`num4` AS INT) + 1)) ELSE NULL END) AS `temp_test__3619367444__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""E SUPPLIES""
+""FURNITURE""
+""LOGY""
+""NOLOGY""
+""OGY""
+""SUPPLIES""
+""TECHNOLOGY""","%null%
+""E SUPPLIES""
+""FURNITURE""
+""LOGY""
+""NOLOGY""
+""OGY""
+""SUPPLIES""
+""TECHNOLOGY"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.right,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.right.txt,True,0,0,"RIGHT(""Data"", 2)",expression,,None,None,366.0,"
+      SELECT (CASE WHEN 2 >= 0 THEN IF(LENGTH('Data') < 2 + 1, 'Data', SUBSTRING('Data', LENGTH('Data') - CAST(2 AS INT) + 1)) ELSE NULL END) AS `temp_test__2843244905__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ","""ta""","""ta"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.right,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.right.txt,True,0,0,"right(str2,3)",expression,,None,None,335.0,"
+      SELECT (CASE WHEN 3 >= 0 THEN IF(LENGTH(`calcs`.`str2`) < 3 + 1, `calcs`.`str2`, SUBSTRING(`calcs`.`str2`, LENGTH(`calcs`.`str2`) - CAST(3 AS INT) + 1)) ELSE NULL END) AS `temp_test__868342576__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""een""
+""ght""
+""ine""
+""ive""
+""lve""
+""one""
+""ree""
+""six""
+""ten""
+""two""
+""ven""","%null%
+""een""
+""ght""
+""ine""
+""ive""
+""lve""
+""one""
+""ree""
+""six""
+""ten""
+""two""
+""ven"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.right,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.right.txt,True,0,0,"right(str2,int0)",expression,,None,None,332.0,"
+      SELECT (CASE WHEN `calcs`.`int0` >= 0 THEN IF(LENGTH(`calcs`.`str2`) < `calcs`.`int0` + 1, `calcs`.`str2`, SUBSTRING(`calcs`.`str2`, LENGTH(`calcs`.`str2`) - CAST(`calcs`.`int0` AS INT) + 1)) ELSE NULL END) AS `temp_test__427841631__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""e""
+""even""
+""fifteen""
+""five""
+""six""
+""teen""
+""ten""
+""twelve""","%null%
+""e""
+""even""
+""fifteen""
+""five""
+""six""
+""teen""
+""ten""
+""twelve"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.rtrim,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.rtrim.txt,True,0,0,"RTRIM("" "" + str2 + "" "")",expression,,None,None,352.0,"
+      SELECT RTRIM(CONCAT(CONCAT(' ',`calcs`.`str2`),' ')) AS `temp_test__2277366246__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+"" eight""
+"" eleven""
+"" fifteen""
+"" five""
+"" fourteen""
+"" nine""
+"" one""
+"" six""
+"" sixteen""
+"" ten""
+"" three""
+"" twelve""
+"" two""","%null%
+"" eight""
+"" eleven""
+"" fifteen""
+"" five""
+"" fourteen""
+"" nine""
+"" one""
+"" six""
+"" sixteen""
+"" ten""
+"" three""
+"" twelve""
+"" two"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.space.int.constant,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.space.int.constant.txt,True,0,0,SPACE(int(2)),expression,,None,None,330.0,"
+      SELECT (CASE WHEN CAST(2 AS BIGINT) >= 0 THEN SPACE(CAST(CAST(2 AS BIGINT) AS INT)) ELSE CAST(NULL AS STRING) END) AS `temp_test__1595235754__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ","""  ""","""  """
+databricks,expression.standard.databricks,cast_calcs.databricks,string.space.int.var,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.space.int.var.txt,True,0,0,SPACE(int2),expression,,None,None,316.0,"
+      SELECT (CASE WHEN `calcs`.`int2` >= 0 THEN SPACE(CAST(`calcs`.`int2` AS INT)) ELSE CAST(NULL AS STRING) END) AS `temp_test__3089742405__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""""
+""  ""
+""   ""
+""    ""
+""     ""
+""      ""
+""         ""","%null%
+""""
+""  ""
+""   ""
+""    ""
+""     ""
+""      ""
+""         """
+databricks,expression.standard.databricks,cast_calcs.databricks,string.space,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.space.txt,True,0,0,'>'+SPACE(2)+'<',expression,,None,None,334.0,"
+      SELECT CONCAT(CONCAT('>',(CASE WHEN 2 >= 0 THEN SPACE(CAST(2 AS INT)) ELSE CAST(NULL AS STRING) END)),'<') AS `temp_test__3167158121__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",""">  <""",""">  <"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.split.right,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.split.right.txt,True,0,0,"SPLIT(""a-b-c"", ""-"", -2) //b",expression,,None,None,341.0,"
+      SELECT 
+            CASE WHEN ('a-b-c' IS NULL) THEN CAST(NULL AS STRING) WHEN NOT (-2 IS NULL) THEN COALESCE((CASE WHEN -2 > 0 THEN SPLIT('a-b-c', '-')[-2-1] ELSE SPLIT(REVERSE('a-b-c'), REVERSE('-'))[ABS(-2)-1] END), '') ELSE NULL END
+         AS `temp_test__281150402__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ","""b""","""b"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.split,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.split.txt,True,0,0,"SPLIT(""a-b-c"", ""-"", 2) //b",expression,,None,None,301.0,"
+      SELECT 
+            CASE WHEN ('a-b-c' IS NULL) THEN CAST(NULL AS STRING) WHEN NOT (2 IS NULL) THEN COALESCE((CASE WHEN 2 > 0 THEN SPLIT('a-b-c', '-')[2-1] ELSE SPLIT(REVERSE('a-b-c'), REVERSE('-'))[ABS(2)-1] END), '') ELSE NULL END
+         AS `temp_test__1221977364__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ","""b""","""b"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.startswith,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.startswith.txt,True,0,0,"STARTSWITH(""Data"", ""D"")",expression,,None,None,341.0,"
+      SELECT 
+(CASE WHEN (1 IS NULL) OR (LENGTH('D') IS NULL) THEN NULL
+      WHEN LENGTH('D') < 1 THEN ''
+      WHEN 1 < 1 THEN SUBSTRING('Data',CAST(1 AS INT),CAST(LENGTH('D') AS INT))
+      ELSE SUBSTRING('Data',CAST(1 AS INT),CAST(LENGTH('D') AS INT)) END) = 'D' AS `temp_test__3252316215__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",true,true
+databricks,expression.standard.databricks,cast_calcs.databricks,string.startswith,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.startswith.txt,True,0,0,"STARTSWITH([str1], ""BI"" )",expression,,None,None,390.0,"
+      SELECT 
+(CASE WHEN (1 IS NULL) OR (LENGTH('BI') IS NULL) THEN NULL
+      WHEN LENGTH('BI') < 1 THEN ''
+      WHEN 1 < 1 THEN SUBSTRING(`calcs`.`str1`,CAST(1 AS INT),CAST(LENGTH('BI') AS INT))
+      ELSE SUBSTRING(`calcs`.`str1`,CAST(1 AS INT),CAST(LENGTH('BI') AS INT)) END) = 'BI' AS `temp_test__535799381__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","false
+true","false
+true"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.startswith,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.startswith.txt,True,0,0,"STARTSWITH([str1], [str2])",expression,,None,None,343.0,"
+      SELECT 
+(CASE WHEN (1 IS NULL) OR (LENGTH(`calcs`.`str2`) IS NULL) THEN NULL
+      WHEN LENGTH(`calcs`.`str2`) < 1 THEN ''
+      WHEN 1 < 1 THEN SUBSTRING(`calcs`.`str1`,CAST(1 AS INT),CAST(LENGTH(`calcs`.`str2`) AS INT))
+      ELSE SUBSTRING(`calcs`.`str1`,CAST(1 AS INT),CAST(LENGTH(`calcs`.`str2`) AS INT)) END) = `calcs`.`str2` AS `temp_test__2377293421__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+false","%null%
+false"
+databricks,expression.standard.databricks,cast_calcs.databricks,string.trim,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.trim.txt,True,0,0,"TRIM("" "" + str2 + "" "")",expression,,None,None,341.0,"
+      SELECT TRIM(CONCAT(CONCAT(' ',`calcs`.`str2`),' ')) AS `temp_test__1903992131__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two""","%null%
+""eight""
+""eleven""
+""fifteen""
+""five""
+""fourteen""
+""nine""
+""one""
+""six""
+""sixteen""
+""ten""
+""three""
+""twelve""
+""two"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.upper,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.upper.txt,True,0,0,"UPPER(""data"")",expression,,None,None,346.0,"
+      SELECT UPPER('data') AS `temp_test__2967749075__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ","""DATA""","""DATA"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.upper,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.upper.txt,True,0,0,upper(str2),expression,,None,None,332.0,"
+      SELECT UPPER(`calcs`.`str2`) AS `temp_test__3516395767__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1
+    ","%null%
+""EIGHT""
+""ELEVEN""
+""FIFTEEN""
+""FIVE""
+""FOURTEEN""
+""NINE""
+""ONE""
+""SIX""
+""SIXTEEN""
+""TEN""
+""THREE""
+""TWELVE""
+""TWO""","%null%
+""EIGHT""
+""ELEVEN""
+""FIFTEEN""
+""FIVE""
+""FOURTEEN""
+""NINE""
+""ONE""
+""SIX""
+""SIXTEEN""
+""TEN""
+""THREE""
+""TWELVE""
+""TWO"""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.utf8,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.utf8.txt,True,0,0,"REPLACE(""This is ® replace test."", ""®"", ""RegisterSymbol"")",expression,,None,None,308.0,"
+      SELECT REGEXP_REPLACE('This is ® replace test.','®','RegisterSymbol') AS `temp_test__4256708872__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ","""This is RegisterSymbol replace test.""","""This is RegisterSymbol replace test."""
+databricks,expression.standard.databricks,cast_calcs.databricks,string.utf8,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/standard\setup.string.utf8.txt,True,0,0,"FIND(""This is ™ find test."", ""™"")",expression,,None,None,339.0,"
+      SELECT INSTR( 'This is ™ find test.', '™' ) AS `temp_test__1040567396__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",9,9
+databricks,expression.lod.databricks,cast_calcs.databricks,lod.calcs,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/lodcalcs\setup.lod.calcs.txt,True,0,0,{fixed [str1] : SUM([num1])},expression,,None,None,1362.0,"
+      SELECT `t0`.`temp_test__2300115098__0_` AS `temp_test__2300115098__0_`
+FROM (
+  SELECT SUM(`calcs`.`num1`) AS `temp_test__2300115098__0_`
+  FROM `tableau_tdvt`.`calcs` `calcs`
+  GROUP BY `calcs`.`str1`
+) `t0`
+GROUP BY 1
+    ","2.47
+6.71
+7.1
+7.12
+7.43
+8.42
+9.05
+9.38
+9.47
+9.78
+10.32
+10.37
+11.38
+12.05
+12.4
+16.42
+16.81","2.47
+6.71
+7.1
+7.12
+7.43
+8.42
+9.05
+9.38
+9.47
+9.78
+10.32
+10.37
+11.38
+12.05
+12.4
+16.42
+16.81"
+databricks,expression.lod.databricks,cast_calcs.databricks,lod.calcs,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/lodcalcs\setup.lod.calcs.txt,True,0,0,{exclude [str1] : SUM([num1])},expression,,None,None,1215.0,"
+      SELECT SUM(`calcs`.`num1`) AS `temp_test__4279721284__0_`
+FROM `tableau_tdvt`.`calcs` `calcs`
+GROUP BY 1.1000000000000001
+    ",166.68,166.68
+databricks,expression.lod.databricks,cast_calcs.databricks,lod.calcs,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/lodcalcs\setup.lod.calcs.txt,True,0,0,{include [str1] : SUM([num1])},expression,,None,None,1954.0,"
+      SELECT `t0`.`temp_test__3262646021__0_` AS `temp_test__3262646021__0_`
+FROM (
+  SELECT SUM(`calcs`.`num1`) AS `temp_test__3262646021__0_`
+  FROM `tableau_tdvt`.`calcs` `calcs`
+  GROUP BY `calcs`.`str1`
+) `t0`
+GROUP BY 1
+    ","2.47
+6.71
+7.1
+7.12
+7.43
+8.42
+9.05
+9.38
+9.47
+9.78
+10.32
+10.37
+11.38
+12.05
+12.4
+16.42
+16.81","2.47
+6.71
+7.1
+7.12
+7.43
+8.42
+9.05
+9.38
+9.47
+9.78
+10.32
+10.37
+11.38
+12.05
+12.4
+16.42
+16.81"
+databricks,expression.lod.databricks,cast_calcs.databricks,lod.calcs,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/lodcalcs\setup.lod.calcs.txt,True,0,0,SUM([num1]) / AVG({fixed [str1] : SUM([num1])}),expression,,None,None,3598.0,"
+      SELECT (CASE WHEN `t2`.`x_measure__1` = 0 THEN NULL ELSE `t0`.`x_measure__0` / `t2`.`x_measure__1` END) AS `temp_test__3502400386__0_`
+FROM (
+  SELECT SUM(`calcs`.`num1`) AS `x_measure__0`
+  FROM `tableau_tdvt`.`calcs` `calcs`
+  GROUP BY 1.1000000000000001
+) `t0`
+  JOIN (
+  SELECT AVG(`t1`.`x_measure__0`) AS `x_measure__1`
+  FROM (
+    SELECT SUM(`calcs`.`num1`) AS `x_measure__0`
+    FROM `tableau_tdvt`.`calcs` `calcs`
+    GROUP BY `calcs`.`str1`
+  ) `t1`
+  GROUP BY 1.1000000000000001
+) `t2`
+    ",17.0,17.0
+databricks,expression.lod.databricks,cast_calcs.databricks,lod.calcs,c:\users\administrator\documents\connector-plugin-sdk\tdvt\tdvt\exprtests/lodcalcs\setup.lod.calcs.txt,True,0,0,{fixed [str1] : AVG({include [str2] : SUM([num1])})},expression,,None,None,3508.0,"
+      SELECT `t1`.`temp_test__1869227114__0_` AS `temp_test__1869227114__0_`
+FROM (
+  SELECT AVG(`t0`.`x_measure__1`) AS `temp_test__1869227114__0_`
+  FROM (
+    SELECT `calcs`.`str1` AS `str1`,
+      SUM(`calcs`.`num1`) AS `x_measure__1`
+    FROM `tableau_tdvt`.`calcs` `calcs`
+    GROUP BY 1,
+      `calcs`.`str2`
+  ) `t0`
+  GROUP BY `t0`.`str1`
+) `t1`
+GROUP BY 1
+    ","2.47
+6.71
+7.1
+7.12
+7.43
+8.42
+9.05
+9.38
+9.47
+9.78
+10.32
+10.37
+11.38
+12.05
+12.4
+16.42
+16.81","2.47
+6.71
+7.1
+7.12
+7.43
+8.42
+9.05
+9.38
+9.47
+9.78
+10.32
+10.37
+11.38
+12.05
+12.4
+16.42
+16.81"


### PR DESCRIPTION
The results are consistent with the 2020.2 results. There is one failure, namely the results for the test case `calcs_data.time1`. This is expected, as Databricks Runtime doesn't support this datatype.