### PR TITLE
Rename 'v-http-path' -> 'dbname' for backwards compatibility

### DIFF
--- a/tableau-databricks/connection-builder.js
+++ b/tableau-databricks/connection-builder.js
@@ -16,16 +16,12 @@ limitations under the License.
 */
 
 (function dsbuilder(attr) {
-	var vendorDefined = {
-		attributeHttpPath: "v-http-path"
-	}
-
 	var params = {};
 
 	// The Databricks cluster ODBC endpoint
 	params["HOST"] = attr[connectionHelper.attributeServer];
 	params["PORT"] = "443";
-	params["HTTPPATH"] = attr[vendorDefined.attributeHttpPath];
+	params["HTTPPATH"] = attr[connectionHelper.attributeDatabase];
 	params["THRIFTTRANSPORT"] = "2";
 	params["SPARKSERVERTYPE"] = "3";
 	params["SSL"] = "1";

--- a/tableau-databricks/connection-fields.xml
+++ b/tableau-databricks/connection-fields.xml
@@ -21,9 +21,6 @@ limitations under the License. -->
     <field name="server" label="@string/server_prompt/" category="endpoint" value-type="string">
         <validation-rule reg-exp="^([0-9A-Za-z-]+\.)+([0-9A-Za-z-]+\.?)$" />
     </field>
-    <field name="v-http-path" label="@string/http_path_prompt/" category="endpoint" value-type="string">
-        <validation-rule reg-exp="^[0-9A-Za-z-_/]*$" />
-    </field>
     <!-- /Endpoint -->
 
     <!-- Authentication -->

--- a/tableau-databricks/connection-metadata.xml
+++ b/tableau-databricks/connection-metadata.xml
@@ -16,7 +16,9 @@ See the License for the specific language governing permissions and
 limitations under the License. -->
 
 <connection-metadata>
-    <database enabled='false' label="None" />
+    <database enabled='true' label="@string/http_path_prompt/" >
+        <field optional='false' />
+    </database>
     <schema enabled='true' label="@string/metadata_database_prompt/" />
     <table enabled='true' label="@string/metadata_table_prompt/" />
 </connection-metadata>

--- a/tableau-databricks/connection-resolver.tdr
+++ b/tableau-databricks/connection-resolver.tdr
@@ -27,7 +27,7 @@ limitations under the License.
                 <attribute-list>
                     <attr>class</attr>
                     <attr>server</attr>
-                    <attr>v-http-path</attr>
+                    <attr>dbname</attr>
                     <attr>one-time-sql</attr>
                     <attr>authentication</attr>
                     <attr>username</attr>

--- a/tableau-databricks/manifest.xml
+++ b/tableau-databricks/manifest.xml
@@ -17,10 +17,6 @@ limitations under the License.
 -->
 
 <connector-plugin class='databricks' superclass='spark' plugin-version='1.0' name='@string/databricks/' version='18.1'>
-<vendor-information>
-    <company name="Test Company"/>
-    <support-link url = "http://example.com"/>
-</vendor-information>
 <connection-customization class="databricks" enabled="true" version="1.0">
     <vendor name="databricks"/>
     <driver name="databricks"/>

--- a/tableau-databricks/manifest.xml
+++ b/tableau-databricks/manifest.xml
@@ -17,6 +17,10 @@ limitations under the License.
 -->
 
 <connector-plugin class='databricks' superclass='spark' plugin-version='1.0' name='@string/databricks/' version='18.1'>
+<vendor-information>
+    <company name="Test Company"/>
+    <support-link url = "http://example.com"/>
+</vendor-information>
 <connection-customization class="databricks" enabled="true" version="1.0">
     <vendor name="databricks"/>
     <driver name="databricks"/>


### PR DESCRIPTION
Rename the http path field back to 'dbname' for compatibility with the old connector. Using the database field results in the same UX as using the custom field.

Validated through manual testing that an old .tds remains valid.