### PR TITLE
Add CAP_SUPPRESS_ENUMERATE_TABLES_VIA_SQL to suppress SHOW queries

### DIFF
--- a/tableau-databricks/manifest.xml
+++ b/tableau-databricks/manifest.xml
@@ -148,6 +148,7 @@ limitations under the License.
         <customization name='CAP_ODBC_METADATA_SUPPRESS_SELECT_STAR' value='no' />
         <customization name='CAP_QUERY_TOP_0_METADATA' value='no' />
         <customization name='CAP_QUERY_WHERE_FALSE_METADATA' value='no' />
+        <customization name='CAP_SUPPRESS_ENUMERATE_TABLES_VIA_SQL' value='yes' />
     </customizations>
 </connection-customization>
 <connection-fields file='connection-fields.xml'/>


### PR DESCRIPTION
The base spark connector issues SHOW VIEWS and SHOW TABLES queries which can be slow. Setting CAP_SUPPRESS_ENUMERATE_TABLES_VIA_SQL suppresses these queries. 

We won't be able to test this until the 2021.1 beta. 