### PR TITLE
Restore authentication-type attribute

### DIFF
--- a/tableau-databricks/connection-resolver.tdr
+++ b/tableau-databricks/connection-resolver.tdr
@@ -32,6 +32,7 @@ limitations under the License.
                     <attr>authentication</attr>
                     <attr>username</attr>
                     <attr>password</attr>
+                    <attr>authentication-type</attr>
                     <attr>instanceurl</attr>
                     <attr>odbc-connect-string-extras</attr>
                     <attr>ACCESSTOKEN</attr>


### PR DESCRIPTION
Restore the authentication-type attribute as discussed in tableau/connector-plugin-sdk#646