### PR TITLE
Updating capability key values in OAuth configuration

### DIFF
--- a/tableau-databricks/oauth-config.xml
+++ b/tableau-databricks/oauth-config.xml
@@ -20,31 +20,31 @@
 
     <capabilities>
         <entry>
-            <key>CAP_SUPPORTS_CUSTOM_DOMAIN</key>
+            <key>OAUTH_CAP_SUPPORTS_CUSTOM_DOMAIN</key>
             <value>true</value>
         </entry>
         <entry>
-            <key>CAP_PKCE_REQUIRES_CODE_CHALLENGE_METHOD</key>
+            <key>OAUTH_CAP_PKCE_REQUIRES_CODE_CHALLENGE_METHOD</key>
             <value>true</value>
         </entry>
         <entry>
-            <key>CAP_REQUIRE_PKCE</key>
+            <key>OAUTH_CAP_REQUIRE_PKCE</key>
             <value>true</value>
         </entry>
         <entry>
-            <key>CAP_FIXED_PORT_IN_CALLBACK_URL</key>
+            <key>OAUTH_CAP_FIXED_PORT_IN_CALLBACK_URL</key>
             <value>true</value>
         </entry>
         <entry>
-            <key>CAP_PKCE_REQUIRES_CODE_CHALLENGE_METHOD</key>
+            <key>OAUTH_CAP_PKCE_REQUIRES_CODE_CHALLENGE_METHOD</key>
             <value>true</value>
         </entry>
         <entry>
-            <key>CAP_CLIENT_SECRET_IN_URL_QUERY_PARAM</key>
+            <key>OAUTH_CAP_CLIENT_SECRET_IN_URL_QUERY_PARAM</key>
             <value>true</value>
         </entry>
         <entry>
-            <key>CAP_SUPPORTS_GET_USERINFO_FROM_ID_TOKEN</key>
+            <key>OAUTH_CAP_SUPPORTS_GET_USERINFO_FROM_ID_TOKEN</key>
             <value>true</value>
         </entry>
     </capabilities>


### PR DESCRIPTION
Our connector was ignoring the instanceurl in the latest release of Tableau's Desktop client 2021.1.0 (20211.21.0320.1853). The symptom was that it would try to form a URL with only a path, e.g. "/authorize".

Tableau seems to have changed the names of these fields in their documentation:
https://tableau.github.io/connector-plugin-sdk/docs/oauth

The cause is that without "OAUTH_CAP_SUPPORTS_CUSTOM_DOMAIN" being set, it will try to use the authUri and tokenUri fields directly.