### PR TITLE
Updating OAuth config to allow generic IDP providers

### DIFF
--- a/tableau-databricks/connection-fields.xml
+++ b/tableau-databricks/connection-fields.xml
@@ -26,20 +26,16 @@ limitations under the License. -->
     <!-- Authentication -->
     <field name="authentication" label="@string/authentication_prompt/" category="authentication" value-type="selection" default-value="oauth">
         <selection-group>
-            <option label="@string/authentication_label_azure_ad/" value="oauth"/>
+            <option label="@string/authentication_label_oauth/" value="oauth"/>
             <option label="@string/authentication_label_token/" value="auth-pass"/>
             <option label="@string/authentication_label_user_pass/" value="auth-user-pass" />
         </selection-group>
     </field>
 
-    <field name="instanceurl" label="@string/authentication_aad_endpoint_prompt/" category="authentication" value-type="string" default-value="https://login.microsoftonline.com/common">
+    <field name="instanceurl" label="@string/authentication_oauth_endpoint_prompt/" category="authentication" value-type="string" default-value="https://login.microsoftonline.com/common/oauth2/v2.0">
         <conditions>
           <condition field="authentication" value="oauth" />
         </conditions>
-           <!-- limit to well-known domains:
-                 https://*.microsoftonline.(com|us|de|cn)/ (public, govcloud, germany, china),
-                 https://*.chinacloudapi.cn/ (China) -->
-           <validation-rule reg-exp="^https:\/\/([a-zA-Z0-9-.]+\.)?((microsoftonline\.(com|us|cn|de))|chinacloudapi\.cn)/"/>
     </field>
 
     <field name="username" label="@string/username_prompt/" category="authentication" value-type="string">

--- a/tableau-databricks/oauth-config.xml
+++ b/tableau-databricks/oauth-config.xml
@@ -9,8 +9,8 @@
     <redirectUrisDesktop>http://localhost:55558/Callback</redirectUrisDesktop>
     <redirectUrisDesktop>http://localhost:55559/Callback</redirectUrisDesktop>
 
-    <authUri>/oauth2/v2.0/authorize</authUri>
-    <tokenUri>/oauth2/v2.0/token</tokenUri>
+    <authUri>/authorize</authUri>
+    <tokenUri>/token</tokenUri>
 
     <scopes>openid</scopes>
     <scopes>email</scopes>
@@ -19,6 +19,10 @@
     <scopes>2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/user_impersonation</scopes>
 
     <capabilities>
+	<entry>
+	   <key>OAUTH_CAP_SUPPORTS_STATE</key>
+	   <value>true</value>
+	</entry>
         <entry>
             <key>OAUTH_CAP_SUPPORTS_CUSTOM_DOMAIN</key>
             <value>true</value>
@@ -47,7 +51,7 @@
             <key>OAUTH_CAP_SUPPORTS_GET_USERINFO_FROM_ID_TOKEN</key>
             <value>true</value>
         </entry>
-    </capabilities>
+   </capabilities>
     <accessTokenResponseMaps>
         <entry>
             <key>ACCESSTOKEN</key>

--- a/tableau-databricks/resources-de_DE.xml
+++ b/tableau-databricks/resources-de_DE.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_azure_ad">Azure Active Directory</string>
+  <string name="authentication_label_oauth">OAuth Directory</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
-  <string name="authentication_aad_advanced_options_prompt">Advanced configuration for Azure AD</string>
-  <string name="authentication_aad_endpoint_prompt">Azure AD endpoint</string>
+  <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-en_GB.xml
+++ b/tableau-databricks/resources-en_GB.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_azure_ad">Azure Active Directory</string>
+  <string name="authentication_label_oauth">OAuth Directory</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
-  <string name="authentication_aad_advanced_options_prompt">Advanced configuration for Azure AD</string>
-  <string name="authentication_aad_endpoint_prompt">Azure AD endpoint</string>
+  <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-en_US.xml
+++ b/tableau-databricks/resources-en_US.xml
@@ -20,12 +20,12 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_azure_ad">Azure Active Directory</string>
+  <string name="authentication_label_oauth">OAuth</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
-  <string name="authentication_aad_advanced_options_prompt">Advanced configuration for Azure AD</string>
-  <string name="authentication_aad_endpoint_prompt">Azure AD endpoint</string>
-
+  <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
+  
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>
 

--- a/tableau-databricks/resources-es_ES.xml
+++ b/tableau-databricks/resources-es_ES.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_azure_ad">Azure Active Directory</string>
+  <string name="authentication_label_oauth">OAuth Directory</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
-  <string name="authentication_aad_advanced_options_prompt">Advanced configuration for Azure AD</string>
-  <string name="authentication_aad_endpoint_prompt">Azure AD endpoint</string>
+  <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-fr_FR.xml
+++ b/tableau-databricks/resources-fr_FR.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_azure_ad">Azure Active Directory</string>
+  <string name="authentication_label_oauth">OAuth Directory</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
-  <string name="authentication_aad_advanced_options_prompt">Advanced configuration for Azure AD</string>
-  <string name="authentication_aad_endpoint_prompt">Azure AD endpoint</string>
+  <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-it_IT.xml
+++ b/tableau-databricks/resources-it_IT.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_azure_ad">Azure Active Directory</string>
+  <string name="authentication_label_oauth">OAuth Directory</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
-  <string name="authentication_aad_advanced_options_prompt">Advanced configuration for Azure AD</string>
-  <string name="authentication_aad_endpoint_prompt">Azure AD endpoint</string>
+  <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-ja_JP.xml
+++ b/tableau-databricks/resources-ja_JP.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_azure_ad">Azure Active Directory</string>
+  <string name="authentication_label_oauth">OAuth Directory</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
-  <string name="authentication_aad_advanced_options_prompt">Advanced configuration for Azure AD</string>
-  <string name="authentication_aad_endpoint_prompt">Azure AD endpoint</string>
+  <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-ko_KR.xml
+++ b/tableau-databricks/resources-ko_KR.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_azure_ad">Azure Active Directory</string>
+  <string name="authentication_label_oauth">OAuth Directory</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
-  <string name="authentication_aad_advanced_options_prompt">Advanced configuration for Azure AD</string>
-  <string name="authentication_aad_endpoint_prompt">Azure AD endpoint</string>
+  <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-pt_BR.xml
+++ b/tableau-databricks/resources-pt_BR.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_azure_ad">Azure Active Directory</string>
+  <string name="authentication_label_oauth">OAuth Directory</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
-  <string name="authentication_aad_advanced_options_prompt">Advanced configuration for Azure AD</string>
-  <string name="authentication_aad_endpoint_prompt">Azure AD endpoint</string>
+  <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-zh_CN.xml
+++ b/tableau-databricks/resources-zh_CN.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_azure_ad">Azure Active Directory</string>
+  <string name="authentication_label_oauth">OAuth Directory</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
-  <string name="authentication_aad_advanced_options_prompt">Advanced configuration for Azure AD</string>
-  <string name="authentication_aad_endpoint_prompt">Azure AD endpoint</string>
+  <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-zh_TW.xml
+++ b/tableau-databricks/resources-zh_TW.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_azure_ad">Azure Active Directory</string>
+  <string name="authentication_label_oauth">OAuth Directory</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
-  <string name="authentication_aad_advanced_options_prompt">Advanced configuration for Azure AD</string>
-  <string name="authentication_aad_endpoint_prompt">Azure AD endpoint</string>
+  <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>


### PR DESCRIPTION
This changes some Microsoft-specific configurations in oauth-config.xml that let us more easily use other IDP providers.

Specifically, it changes the default paths to be more neutral. The tradeoff is that users will need to enter:
https://login.microsoftonline.com/common/oauth2/v2.0

Instead of:
https://login.microsoftonline.com/common