### PR TITLE
Improve OAuth labels and fields

### DIFF
--- a/tableau-databricks/connection-fields.xml
+++ b/tableau-databricks/connection-fields.xml
@@ -19,7 +19,7 @@ limitations under the License. -->
 
     <!-- Endpoint -->
     <field name="server" label="@string/server_prompt/" category="endpoint" value-type="string">
-        <validation-rule reg-exp="^([0-9A-Za-z-]+\.)+([0-9A-Za-z-]+\.?)$" />
+        <validation-rule reg-exp="^([0-9A-Za-z-]+\.)+([0-9A-Za-z-]+)$" />
     </field>
     <!-- /Endpoint -->
 
@@ -34,10 +34,11 @@ limitations under the License. -->
         </selection-group>
     </field>
 
-    <field name="instanceurl" label="@string/authentication_oauth_endpoint_prompt/" category="authentication" value-type="string" default-value="https://login.microsoftonline.com/common/oauth2/v2.0">
+    <field name="instanceurl" label="@string/authentication_oauth_endpoint_prompt/" category="authentication" value-type="string" default-value="Enter address e.g. https://[Server Hostname]/oidc">
         <conditions>
           <condition field="authentication" value="oauth" />
         </conditions>
+        <validation-rule reg-exp="^https:\/\/([0-9A-Za-z-]+\.)+([0-9A-Za-z-]+)\/oidc$" />
     </field>
 
     <field name="username" label="@string/username_prompt/" category="authentication" value-type="string">

--- a/tableau-databricks/resources-de_DE.xml
+++ b/tableau-databricks/resources-de_DE.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth Directory</string>
+  <string name="authentication_label_oauth">OAuth / Azure AD</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-en_GB.xml
+++ b/tableau-databricks/resources-en_GB.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth Directory</string>
+  <string name="authentication_label_oauth">OAuth / Azure AD</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-en_US.xml
+++ b/tableau-databricks/resources-en_US.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth</string>
+  <string name="authentication_label_oauth">OAuth / Azure AD</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
   
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-es_ES.xml
+++ b/tableau-databricks/resources-es_ES.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth Directory</string>
+  <string name="authentication_label_oauth">OAuth / Azure AD</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-fr_FR.xml
+++ b/tableau-databricks/resources-fr_FR.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth Directory</string>
+  <string name="authentication_label_oauth">OAuth / Azure AD</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-it_IT.xml
+++ b/tableau-databricks/resources-it_IT.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth Directory</string>
+  <string name="authentication_label_oauth">OAuth / Azure AD</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-ja_JP.xml
+++ b/tableau-databricks/resources-ja_JP.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth Directory</string>
+  <string name="authentication_label_oauth">OAuth / Azure AD</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-ko_KR.xml
+++ b/tableau-databricks/resources-ko_KR.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth Directory</string>
+  <string name="authentication_label_oauth">OAuth / Azure AD</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-pt_BR.xml
+++ b/tableau-databricks/resources-pt_BR.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth Directory</string>
+  <string name="authentication_label_oauth">OAuth / Azure AD</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-zh_CN.xml
+++ b/tableau-databricks/resources-zh_CN.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth Directory</string>
+  <string name="authentication_label_oauth">OAuth / Azure AD</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-zh_TW.xml
+++ b/tableau-databricks/resources-zh_TW.xml
@@ -20,11 +20,11 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth Directory</string>
+  <string name="authentication_label_oauth">OAuth / Azure AD</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>


### PR DESCRIPTION
- Change default OAuth endpoint to "Enter address e.g. https://[Server Hostname]/oidc"
- Change OAuth label in dropdown to "OAuth / Azure AD"
- Change OAuth field header to "OAuth Endpoint"
- Add validator for OAuth Endpoint to restrict to "https://[hostname]/oidc"