### PR TITLE
Use SQL INSTR() for CONTAINS expressions

### DIFF
--- a/tableau-databricks/dialect.tdd
+++ b/tableau-databricks/dialect.tdd
@@ -72,12 +72,6 @@ limitations under the License.
         <argument type='date' />
     </function>
 
-    <function group='string' name='CONTAINS' return-type='bool'>
-        <formula>(INSTR(%1,%2) &gt; 0)</formula>
-        <argument type='str' />
-        <argument type='str' />
-    </function>
-
     <function name='FLOAT' group='cast' return-type='real'>
         <formula>DATEDIFF(CAST(%1 AS DATE), CAST('1900-01-01' AS DATE))</formula>
         <argument type='date' />
@@ -155,6 +149,13 @@ limitations under the License.
         <argument type='localstr' />
         <argument type='date' />
     </date-function>
+
+    <function group='string' name='CONTAINS' return-type='bool'>
+        <formula>(INSTR(%1,%2) &gt; 0)</formula>
+        <argument type='str' />
+        <argument type='str' />
+    </function>
+
 </function-map>
 
 <sql-format>

--- a/tableau-databricks/dialect.tdd
+++ b/tableau-databricks/dialect.tdd
@@ -72,6 +72,12 @@ limitations under the License.
         <argument type='date' />
     </function>
 
+    <function group='string' name='CONTAINS' return-type='bool'>
+        <formula>(INSTR(%1,%2) &gt; 0)</formula>
+        <argument type='str' />
+        <argument type='str' />
+    </function>
+
     <function name='FLOAT' group='cast' return-type='real'>
         <formula>DATEDIFF(CAST(%1 AS DATE), CAST('1900-01-01' AS DATE))</formula>
         <argument type='date' />


### PR DESCRIPTION
Implement the Tableau CONTAINS expression as INSTR() instead of the
current use of RLIKE(*.*). The INSTR SQL expression is implemented more
efficiently than RLIKE().