### PR TITLE
Add Simba SSP configurations

### DIFF
--- a/tableau-databricks/connection-builder.js
+++ b/tableau-databricks/connection-builder.js
@@ -67,10 +67,10 @@ limitations under the License.
 	// Tell the ODBC driver that it is Tableau connecting.
 	params["UserAgentEntry"] = "Tableau";
 
-  // Prevent the driver from turning server-side properties to lower-case
+	// Prevent the driver from turning server-side properties to lower-case
 	params["LCaseSspKeyName"] = "0";
 	
-  // Prevent the driver to set properties by executing statements
+	// Prevent the driver to set properties by executing statements
 	params["ApplySSPWithQueries"] = "0";
 
 	// Load ODBC connection string extras

--- a/tableau-databricks/connection-builder.js
+++ b/tableau-databricks/connection-builder.js
@@ -67,6 +67,12 @@ limitations under the License.
 	// Tell the ODBC driver that it is Tableau connecting.
 	params["UserAgentEntry"] = "Tableau";
 
+  // Prevent the driver from turning server-side properties to lower-case
+	params["LCaseSspKeyName"] = "0";
+	
+  // Prevent the driver to set properties by executing statements
+	params["ApplySSPWithQueries"] = "0";
+
 	// Load ODBC connection string extras
 	var odbcConnectStringExtrasMap = {};
 	const attributeODBCConnectStringExtras = connectionHelper.attributeODBCConnectStringExtras;


### PR DESCRIPTION
This patch adds two Simba configuration that prevent the driver from 
1) turning server-side properties to lower-case
2) setting the properties by executing statements
