### PR TITLE
Change OAuth field header and allow AAD endpoints

### DIFF
--- a/tableau-databricks/connection-fields.xml
+++ b/tableau-databricks/connection-fields.xml
@@ -34,11 +34,15 @@ limitations under the License. -->
         </selection-group>
     </field>
 
-    <field name="instanceurl" label="@string/authentication_oauth_endpoint_prompt/" category="authentication" value-type="string" default-value="Enter address e.g. https://[Server Hostname]/oidc">
+    <field name="instanceurl" label="@string/authentication_oauth_endpoint_prompt/" category="authentication" value-type="string">
         <conditions>
           <condition field="authentication" value="oauth" />
         </conditions>
-        <validation-rule reg-exp="^https:\/\/([0-9A-Za-z-]+\.)+([0-9A-Za-z-]+)\/oidc$" />
+        <!-- limit to well-known domains:
+          https://*.microsoftonline.(com|us|de|cn) (public, govcloud, germany, china),
+          https://*.chinacloudapi.cn (China)
+          https://*/oidc (Databricks redirector) -->
+        <validation-rule reg-exp="^https:\/\/([a-zA-Z0-9-]+\.)+((microsoftonline\.(com|us|cn|de))|chinacloudapi\.cn|[a-zA-Z]+\/oidc)" />
     </field>
 
     <field name="username" label="@string/username_prompt/" category="authentication" value-type="string">

--- a/tableau-databricks/resources-de_DE.xml
+++ b/tableau-databricks/resources-de_DE.xml
@@ -24,7 +24,7 @@ limitations under the License. -->
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-en_GB.xml
+++ b/tableau-databricks/resources-en_GB.xml
@@ -24,7 +24,7 @@ limitations under the License. -->
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-en_US.xml
+++ b/tableau-databricks/resources-en_US.xml
@@ -24,7 +24,7 @@ limitations under the License. -->
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
   
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-es_ES.xml
+++ b/tableau-databricks/resources-es_ES.xml
@@ -24,7 +24,7 @@ limitations under the License. -->
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-fr_FR.xml
+++ b/tableau-databricks/resources-fr_FR.xml
@@ -24,7 +24,7 @@ limitations under the License. -->
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-it_IT.xml
+++ b/tableau-databricks/resources-it_IT.xml
@@ -24,7 +24,7 @@ limitations under the License. -->
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-ja_JP.xml
+++ b/tableau-databricks/resources-ja_JP.xml
@@ -24,7 +24,7 @@ limitations under the License. -->
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-ko_KR.xml
+++ b/tableau-databricks/resources-ko_KR.xml
@@ -24,7 +24,7 @@ limitations under the License. -->
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-pt_BR.xml
+++ b/tableau-databricks/resources-pt_BR.xml
@@ -24,7 +24,7 @@ limitations under the License. -->
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-zh_CN.xml
+++ b/tableau-databricks/resources-zh_CN.xml
@@ -24,7 +24,7 @@ limitations under the License. -->
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>

--- a/tableau-databricks/resources-zh_TW.xml
+++ b/tableau-databricks/resources-zh_TW.xml
@@ -24,7 +24,7 @@ limitations under the License. -->
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
-  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint</string>
+  <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 
   <string name="username_prompt">Username</string>
   <string name="password_prompt">Password</string>


### PR DESCRIPTION
- Remove the default value from the OAuth endpoint field, since it's invalid anyway.
- Change to OAuth field header to "OAuth Endpoint e.g. https://[Server Hostname]/oidc"
- Allow the entry of Databricks redirector URLs as well as AAD endpoints.