### PR TITLE
Remove trailing slash from instanceUrlValidationRegex

### DIFF
--- a/tableau-databricks/oauth-config.xml
+++ b/tableau-databricks/oauth-config.xml
@@ -11,7 +11,7 @@
 
     <authUri>/oauth2/v2.0/authorize</authUri>
     <tokenUri>/oauth2/v2.0/token</tokenUri>
-    <instanceUrlValidationRegex>^https:\/\/([a-zA-Z0-9-]+\.)+((microsoftonline\.(com|us|cn|de))|chinacloudapi\.cn|[a-zA-Z]+\/oidc)\/(.*)</instanceUrlValidationRegex>
+    <instanceUrlValidationRegex>^https:\/\/([a-zA-Z0-9-]+\.)+((microsoftonline\.(com|us|cn|de))|chinacloudapi\.cn|[a-zA-Z]+\/oidc).*</instanceUrlValidationRegex>
 
     <scopes>openid</scopes>
     <scopes>email</scopes>


### PR DESCRIPTION
This is to make it consistent with the regex from the connection
dialog. Otherwise, certain URLs e.g. https://servername/oidc pass in
the connection dialog but fail when attempting to connect.