### PR TITLE
filter information schema

### DIFF
--- a/tableau-databricks/manifest.xml
+++ b/tableau-databricks/manifest.xml
@@ -152,6 +152,7 @@ limitations under the License.
         <customization name='CAP_SUPPRESS_ENUMERATE_TABLES_VIA_SQL' value='yes' />
         <customization name='CAP_SUPPRESS_ENUMERATE_SCHEMAS_VIA_SQL' value='yes' />
         <customization name='CAP_ODBC_SUPPRESS_ENUMERATE_SCHEMA_WITHOUT_CATALOG' value='yes' />
+	<customization name='CAP_ODBC_SUPPRESS_INFO_SCHEMA_TABLES' value='yes' />
     </customizations>
 </connection-customization>
 <connection-fields file='connection-fields.xml'/>


### PR DESCRIPTION
adds `CAP_ODBC_SUPPRESS_INFO_SCHEMA_TABLES` per https://databricks.atlassian.net/browse/PECO-8

the new behaviour after adding `CAP_ODBC_SUPPRESS_INFO_SCHEMA_TABLES`:

Tableau UI allows selecting `information_schema` as database. However it doesn't allow selecting any of the tables in `information_schema` database. see screenshot
<img width="275" alt="Screen Shot 2022-05-26 at 6 04 36 AM" src="https://user-images.githubusercontent.com/22279672/170498703-87c89e7d-8ac9-4536-981e-2d52d75fc690.png">

It is possible to write a custom SQL query to query tables in `information_schema` see screenshot
<img width="866" alt="Screen Shot 2022-05-26 at 6 04 06 AM" src="https://user-images.githubusercontent.com/22279672/170498874-89f11887-9538-491b-bf82-0a66c2a8ba88.png">


