### PR TITLE
Remove  passing through `SSP_databricks.catalog` to ODBC

### DIFF
--- a/tableau-databricks/connection-builder.js
+++ b/tableau-databricks/connection-builder.js
@@ -34,7 +34,6 @@ limitations under the License.
 	if (attr[connectionHelper.attributeDatabase] &&
 	    attr[connectionHelper.attributeDatabase] !== "SPARK") {
 		params["Catalog"] = attr[connectionHelper.attributeDatabase];
-		params["SSP_databricks.catalog"] = attr[connectionHelper.attributeDatabase];
 	}
 
 	var authenticationMode = attr[connectionHelper.attributeAuthentication];


### PR DESCRIPTION
This patch removes setting the `SSP_databricks.catalog` configuration as a backwards compatible fix for integrations that use ODBC drivers without multi-catalog support.