### PR TITLE
Switch to production OAuth clientId

### DIFF
--- a/tableau-databricks/oauth-config.xml
+++ b/tableau-databricks/oauth-config.xml
@@ -2,7 +2,7 @@
 <pluginOAuthConfig>
     <dbclass>databricks</dbclass>
 
-    <clientIdDesktop>602b9111-dbbc-469f-bd20-7e2db0f7f956</clientIdDesktop>
+    <clientIdDesktop>0464ea90-c12f-42a7-b347-c2311ca4413c</clientIdDesktop>
     <redirectUrisDesktop>http://localhost:55555/Callback</redirectUrisDesktop>
     <redirectUrisDesktop>http://localhost:55556/Callback</redirectUrisDesktop>
     <redirectUrisDesktop>http://localhost:55557/Callback</redirectUrisDesktop>


### PR DESCRIPTION
The OAuth clientId used in the prepackaged Tableau connector is different from the one in our repo currently. This PR makes repo connector consistent with the production connector.