### PR TITLE
enable cross database join in single connection

### DIFF
--- a/tableau-databricks/manifest.xml
+++ b/tableau-databricks/manifest.xml
@@ -152,7 +152,9 @@ limitations under the License.
         <customization name='CAP_SUPPRESS_ENUMERATE_TABLES_VIA_SQL' value='yes' />
         <customization name='CAP_SUPPRESS_ENUMERATE_SCHEMAS_VIA_SQL' value='yes' />
         <customization name='CAP_ODBC_SUPPRESS_ENUMERATE_SCHEMA_WITHOUT_CATALOG' value='yes' />
-	<customization name='CAP_ODBC_SUPPRESS_INFO_SCHEMA_SCHEMAS' value='yes' />
+        <customization name='CAP_ODBC_SUPPRESS_INFO_SCHEMA_SCHEMAS' value='yes' />
+        <!--enable cross-catalog join within same connection-->
+        <customization name=' CAP_ODBC_INCLUDE_CATALOG_NAME' value='yes' />
     </customizations>
 </connection-customization>
 <connection-fields file='connection-fields.xml'/>


### PR DESCRIPTION
Verified locally that cross database join works with the capability set, see steps here: https://docs.google.com/document/d/1axL5YE1_vZsejvK9QksjOGxiUjnZpe0k33PPeU3WLFQ/edit?usp=sharing.
1. run tdvt tests, results same as before
2. Test backward compatibility, new connector can open old joined workbook, old connector can open new joined workbook so both way works fine.