### PR TITLE
Remove leading whitespace

### DIFF
--- a/tableau-databricks/manifest.xml
+++ b/tableau-databricks/manifest.xml
@@ -154,7 +154,7 @@ limitations under the License.
         <customization name='CAP_ODBC_SUPPRESS_ENUMERATE_SCHEMA_WITHOUT_CATALOG' value='yes' />
         <customization name='CAP_ODBC_SUPPRESS_INFO_SCHEMA_SCHEMAS' value='yes' />
         <!--enable cross-catalog join within same connection-->
-        <customization name=' CAP_ODBC_INCLUDE_CATALOG_NAME' value='yes' />
+        <customization name='CAP_ODBC_INCLUDE_CATALOG_NAME' value='yes' />
     </customizations>
 </connection-customization>
 <connection-fields file='connection-fields.xml'/>


### PR DESCRIPTION
There's a leading whitespace in  name=' CAP_ODBC_INCLUDE_CATALOG_NAME' which should not be there.