### PR TITLE
add auto infer instanceUrl

### DIFF
--- a/tableau-databricks/connection-fields.xml
+++ b/tableau-databricks/connection-fields.xml
@@ -34,17 +34,6 @@ limitations under the License. -->
         </selection-group>
     </field>
 
-    <field name="instanceurl" label="@string/authentication_oauth_endpoint_prompt/" category="authentication" value-type="string">
-        <conditions>
-          <condition field="authentication" value="oauth" />
-        </conditions>
-        <!-- limit to well-known domains:
-          https://*.microsoftonline.(com|us|de|cn) (public, govcloud, germany, china),
-          https://*.chinacloudapi.cn (China)
-          https://*/oidc (Databricks redirector) -->
-        <validation-rule reg-exp="^https:\/\/([a-zA-Z0-9-]+\.)+((microsoftonline\.(com|us|cn|de))|chinacloudapi\.cn|[a-zA-Z]+\/oidc)" />
-    </field>
-
     <field name="username" label="@string/username_prompt/" category="authentication" value-type="string">
         <conditions>
             <condition field="authentication" value="auth-user-pass" />

--- a/tableau-databricks/oauth-config.xml
+++ b/tableau-databricks/oauth-config.xml
@@ -11,6 +11,7 @@
 
     <authUri>/oauth2/v2.0/authorize</authUri>
     <tokenUri>/oauth2/v2.0/token</tokenUri>
+    <instanceUrlSuffix>/oidc</instanceUrlSuffix>
     <instanceUrlValidationRegex>^https:\/\/([a-zA-Z0-9-]+\.)+((microsoftonline\.(com|us|cn|de))|chinacloudapi\.cn|[a-zA-Z]+\/oidc).*</instanceUrlValidationRegex>
 
     <scopes>openid</scopes>
@@ -56,7 +57,11 @@
             <key>OAUTH_CAP_SUPPORTS_GET_USERINFO_FROM_ID_TOKEN</key>
             <value>true</value>
         </entry>
-   </capabilities>
+	    <entry>
+            <key>OAUTH_CAP_INFER_INSTANCE_URL_FROM_SERVER</key>
+            <value>true</value>
+        </entry>
+    </capabilities>
     <accessTokenResponseMaps>
         <entry>
             <key>ACCESSTOKEN</key>


### PR DESCRIPTION
Adding the auto infer oauth instanceUrl capability to Databricks.
The new UI will look like this:(ignore the databricks2 by Company Name part)
<img width="547" alt="image" src="https://github.com/databricks/tableau-connector/assets/115501094/2244ec17-d573-4ef3-bb18-5c8a6518f99a">
Old UI looks like this:
<img width="576" alt="image" src="https://github.com/databricks/tableau-connector/assets/115501094/b2c7ecc4-ba38-4773-9ef3-f20837f2dcae">

Testing:
Locally test with Tableau Desktop. Open old Workbook with this new connector works, open new workbook with old connector works.
Tableau Server has not released 2023.2 so cannot test there yet.
