### PR TITLE
Enable the CAP_QUERY_TOP_0_METADATA capability for custom SQL queries

### DIFF
--- a/tableau-databricks/manifest.xml
+++ b/tableau-databricks/manifest.xml
@@ -147,7 +147,7 @@ limitations under the License.
         <customization name='CAP_ODBC_METADATA_SUPPRESS_SQLCOLUMNS_API' value='no' />
         <customization name='CAP_ODBC_METADATA_SUPPRESS_SELECT_STAR' value='yes' />
         <customization name='CAP_ODBC_SUPPRESS_CATALOG_NAME' value='no'/>
-        <customization name='CAP_QUERY_TOP_0_METADATA' value='no' />
+        <customization name='CAP_QUERY_TOP_0_METADATA' value='yes' />
         <customization name='CAP_QUERY_WHERE_FALSE_METADATA' value='no' />
         <customization name='CAP_SUPPRESS_ENUMERATE_TABLES_VIA_SQL' value='yes' />
         <customization name='CAP_SUPPRESS_ENUMERATE_SCHEMAS_VIA_SQL' value='yes' />


### PR DESCRIPTION
From Tableau: `The fact that you have both CAP_ODBC_METADATA_SUPPRESS_PREPARED_QUERY and CAP_ODBC_METADATA_SUPPRESS_EXECUTED_QUERY set to yes means that CAP_QUERY_TOP_0_METADATA will only be used during Custom SQL.`
The purpose of this change is for a custom sql query it currently use select * limit 1 to get metadata, but it can take a long time if the custom query is complex. We can use limit 0 to expedite the get metadata operation.
This should not affect metadata fetching for a regular table, those will still use the built in odbc functions to retrieve metadata.
**Test Matrix:**
Spark Versions: 9.1, 10.4. 11.3, 12.2, 13.3, 14.1
Unity Catalog: True, False
**Test Step:** 
Create Tableau connection
Create a new Custom Sql query: Select * from `schema`.`table`
Verify metadata renders successful
Verify sql query in tableau logs is 
```
SELECT *
FROM (
    SELECT *
    FROM `hive_metastore`.`simba_pkfk_schema`.`departments`
) AS `custom_sql_query`
LIMIT 0;
```
Run tableau correctness test with the custom connector on tableau server, verify for non-custom sql queries the metadata query does not change, documented steps here:
https://databricks.atlassian.net/wiki/spaces/UN/pages/3328771221/Tableau+E2E+wiki
