### PR TITLE
recommend oauth

### DIFF
--- a/tableau-databricks/resources-de_DE.xml
+++ b/tableau-databricks/resources-de_DE.xml
@@ -20,9 +20,9 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth / Azure AD</string>
-  <string name="authentication_label_token">Personal Access Token</string>
-  <string name="authentication_label_user_pass">Username / Password</string>
+  <string name="authentication_label_oauth">Databricks login (recommended)</string>
+  <string name="authentication_label_token">Personal access token</string>
+  <string name="authentication_label_user_pass">Basic auth (legacy)</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
   <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 

--- a/tableau-databricks/resources-en_GB.xml
+++ b/tableau-databricks/resources-en_GB.xml
@@ -20,9 +20,9 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth / Azure AD</string>
-  <string name="authentication_label_token">Personal Access Token</string>
-  <string name="authentication_label_user_pass">Username / Password</string>
+  <string name="authentication_label_oauth">Databricks login (recommended)</string>
+  <string name="authentication_label_token">Personal access token</string>
+  <string name="authentication_label_user_pass">Basic auth (legacy)</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
   <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 

--- a/tableau-databricks/resources-en_US.xml
+++ b/tableau-databricks/resources-en_US.xml
@@ -20,7 +20,7 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth / Azure AD</string>
+  <string name="authentication_label_oauth">OAuth / Azure AD (Recommended)</string>
   <string name="authentication_label_token">Personal Access Token</string>
   <string name="authentication_label_user_pass">Username / Password</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>

--- a/tableau-databricks/resources-en_US.xml
+++ b/tableau-databricks/resources-en_US.xml
@@ -20,9 +20,9 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth / Azure AD (Recommended)</string>
+  <string name="authentication_label_oauth">Databricks login (recommendded)</string>
   <string name="authentication_label_token">Personal Access Token</string>
-  <string name="authentication_label_user_pass">Username / Password</string>
+  <string name="authentication_label_user_pass">Basic auth (deprecated)</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
   <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
   

--- a/tableau-databricks/resources-en_US.xml
+++ b/tableau-databricks/resources-en_US.xml
@@ -20,9 +20,9 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">Databricks login (recommendded)</string>
-  <string name="authentication_label_token">Personal Access Token</string>
-  <string name="authentication_label_user_pass">Basic auth (deprecated)</string>
+  <string name="authentication_label_oauth">Databricks login (recommended)</string>
+  <string name="authentication_label_token">Personal access token</string>
+  <string name="authentication_label_user_pass">Basic auth (legacy)</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
   <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
   

--- a/tableau-databricks/resources-es_ES.xml
+++ b/tableau-databricks/resources-es_ES.xml
@@ -20,9 +20,9 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth / Azure AD</string>
-  <string name="authentication_label_token">Personal Access Token</string>
-  <string name="authentication_label_user_pass">Username / Password</string>
+  <string name="authentication_label_oauth">Databricks login (recommended)</string>
+  <string name="authentication_label_token">Personal access token</string>
+  <string name="authentication_label_user_pass">Basic auth (legacy)</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
   <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 

--- a/tableau-databricks/resources-fr_FR.xml
+++ b/tableau-databricks/resources-fr_FR.xml
@@ -20,9 +20,9 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth / Azure AD</string>
-  <string name="authentication_label_token">Personal Access Token</string>
-  <string name="authentication_label_user_pass">Username / Password</string>
+  <string name="authentication_label_oauth">Databricks login (recommended)</string>
+  <string name="authentication_label_token">Personal access token</string>
+  <string name="authentication_label_user_pass">Basic auth (legacy)</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
   <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 

--- a/tableau-databricks/resources-it_IT.xml
+++ b/tableau-databricks/resources-it_IT.xml
@@ -20,9 +20,9 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth / Azure AD</string>
-  <string name="authentication_label_token">Personal Access Token</string>
-  <string name="authentication_label_user_pass">Username / Password</string>
+  <string name="authentication_label_oauth">Databricks login (recommended)</string>
+  <string name="authentication_label_token">Personal access token</string>
+  <string name="authentication_label_user_pass">Basic auth (legacy)</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
   <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 

--- a/tableau-databricks/resources-ja_JP.xml
+++ b/tableau-databricks/resources-ja_JP.xml
@@ -20,9 +20,9 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth / Azure AD</string>
-  <string name="authentication_label_token">Personal Access Token</string>
-  <string name="authentication_label_user_pass">Username / Password</string>
+  <string name="authentication_label_oauth">Databricks login (recommended)</string>
+  <string name="authentication_label_token">Personal access token</string>
+  <string name="authentication_label_user_pass">Basic auth (legacy)</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
   <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 

--- a/tableau-databricks/resources-ko_KR.xml
+++ b/tableau-databricks/resources-ko_KR.xml
@@ -20,9 +20,9 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth / Azure AD</string>
-  <string name="authentication_label_token">Personal Access Token</string>
-  <string name="authentication_label_user_pass">Username / Password</string>
+  <string name="authentication_label_oauth">Databricks login (recommended)</string>
+  <string name="authentication_label_token">Personal access token</string>
+  <string name="authentication_label_user_pass">Basic auth (legacy)</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
   <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 

--- a/tableau-databricks/resources-pt_BR.xml
+++ b/tableau-databricks/resources-pt_BR.xml
@@ -20,9 +20,9 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth / Azure AD</string>
-  <string name="authentication_label_token">Personal Access Token</string>
-  <string name="authentication_label_user_pass">Username / Password</string>
+  <string name="authentication_label_oauth">Databricks login (recommended)</string>
+  <string name="authentication_label_token">Personal access token</string>
+  <string name="authentication_label_user_pass">Basic auth (legacy)</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
   <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 

--- a/tableau-databricks/resources-zh_CN.xml
+++ b/tableau-databricks/resources-zh_CN.xml
@@ -20,9 +20,9 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth / Azure AD</string>
-  <string name="authentication_label_token">Personal Access Token</string>
-  <string name="authentication_label_user_pass">Username / Password</string>
+  <string name="authentication_label_oauth">Databricks login (recommended)</string>
+  <string name="authentication_label_token">Personal access token</string>
+  <string name="authentication_label_user_pass">Basic auth (legacy)</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
   <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 

--- a/tableau-databricks/resources-zh_TW.xml
+++ b/tableau-databricks/resources-zh_TW.xml
@@ -20,9 +20,9 @@ limitations under the License. -->
   <string name="http_path_prompt">HTTP Path</string>
 
   <string name="authentication_prompt">Authentication</string>
-  <string name="authentication_label_oauth">OAuth / Azure AD</string>
-  <string name="authentication_label_token">Personal Access Token</string>
-  <string name="authentication_label_user_pass">Username / Password</string>
+  <string name="authentication_label_oauth">Databricks login (recommended)</string>
+  <string name="authentication_label_token">Personal access token</string>
+  <string name="authentication_label_user_pass">Basic auth (legacy)</string>
   <string name="authentication_oauth_advanced_options_prompt">Advanced configuration for OAuth</string>
   <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
 


### PR DESCRIPTION
As part of effort to promote OAuth usage we want to slowly deprecate other auth modes in Tableau. 
As a first step we are changing the auth mode text to denote what is recommend/deprecated.
Databricks login (recommended) is the OAuth login.
Basic auth (deprecated) is the username-password.
The risk is minimal since it only changes the label shown to customer.

<img width="499" alt="image" src="https://github.com/databricks/tableau-connector/assets/115501094/2008d6fe-3d1a-47a6-b5df-ae84ac75be3d">

Get approval from Slack from: @sbhaiatdb and @ken wong

