### PR TITLE
[PECO-1754]remove basic auth from Tableau connector

### DIFF
--- a/tableau-databricks/connection-fields.xml
+++ b/tableau-databricks/connection-fields.xml
@@ -34,16 +34,9 @@ limitations under the License. -->
         </selection-group>
     </field>
 
-    <field name="username" label="@string/username_prompt/" category="authentication" value-type="string">
-        <conditions>
-            <condition field="authentication" value="auth-user-pass" />
-        </conditions>
-    </field>
-
     <field name="password" label="@string/password_prompt/" category="authentication" value-type="string" secure="true">
      <conditions>
          <condition field="authentication" value="auth-pass" />
-         <condition field="authentication" value="auth-user-pass" />
       </conditions>
     </field>
 


### PR DESCRIPTION
Remove the basic auth mode from Tableau connector
<img width="540" alt="image" src="https://github.com/databricks/tableau-connector/assets/115501094/651ec09d-9d56-418d-85d0-57920aa3e3ff">
