### PR TITLE
Change "Password" Label to "Token"

### DIFF
--- a/tableau-databricks/resources-en_US.xml
+++ b/tableau-databricks/resources-en_US.xml
@@ -27,7 +27,7 @@ limitations under the License. -->
   <string name="authentication_oauth_endpoint_prompt">OAuth Endpoint e.g. https://[Server Hostname]/oidc</string>
   
   <string name="username_prompt">Username</string>
-  <string name="password_prompt">Password</string>
+  <string name="password_prompt">Token</string>
 
   <string name="odbc_extra_config_prompt">Extra ODBC options ('key=value;key2=value2;...')</string>
 


### PR DESCRIPTION
Now that we are removing the username/password auth mode, there is no need to keep labeling the password field as password. We can call it token, because people will be pasting their token in.

If this change is accepted, will make the change on our side as a follow-up to the change that removes username/password auth.